### PR TITLE
feat: support disabling baseline rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,6 +70,8 @@ The Agent is built from several components, each owning a different boundary. Be
 
 A single Job may carry one scope or both. Each scope owns its own rules, evaluation state, and outputs, and the two are isolated: neither operator can read or override the other's rules, and their outputs are emitted separately. This is the security boundary of the agent — see `docs/developer-guide/agent.md` for the conceptual model and `docs/developer-guide/agent-ownership-boundaries.md` for the implementation ownership rules. For the kernel-side model, see `docs/developer-guide/ebpf-runtime.md`.
 
+Host scope and project scope are internal Agent implementation boundaries. User-facing docs should describe the user-visible deployment path and configuration owner instead: installed runner, GitHub Action, project-local config, or manager config. GitHub Action can run with `manager-url`, so do not imply that Action configuration and manager configuration are mutually exclusive. Do not expose host/project scope mechanics in user docs unless the page is specifically explaining Agent architecture or a log field that uses scope to distinguish emitted records.
+
 ## Commits
 
 - Conventional Commits. English. One-line title.

--- a/cmd/cicd-sensor-manager/main.go
+++ b/cmd/cicd-sensor-manager/main.go
@@ -228,6 +228,7 @@ func buildServedConfig(startup manager.StartupConfig, outputSettings *managerv1b
 	return &manager.ServedConfig{
 		ConfigRevision:          startup.Revision,
 		DefaultMaxAlertsPerRule: startup.DefaultMaxAlertsPerRule,
+		DisableBaselineRules:    startup.DisableBaselineRules,
 		OutputSettings:          outputSettings,
 	}
 }

--- a/cmd/cicd-sensor-manager/main_test.go
+++ b/cmd/cicd-sensor-manager/main_test.go
@@ -275,6 +275,7 @@ func TestBuildServedConfig(t *testing.T) {
 	startup := manager.StartupConfig{
 		Revision:                "sha256:config",
 		DefaultMaxAlertsPerRule: 7,
+		DisableBaselineRules:    true,
 	}
 	settings := &managerv1beta1.OutputSettings{
 		Detection: &managerv1beta1.OutputSetting{
@@ -296,6 +297,9 @@ func TestBuildServedConfig(t *testing.T) {
 	}
 	if served.DefaultMaxAlertsPerRule != 7 {
 		t.Fatalf("DefaultMaxAlertsPerRule: got %d, want 7", served.DefaultMaxAlertsPerRule)
+	}
+	if !served.DisableBaselineRules {
+		t.Fatalf("DisableBaselineRules: got false, want true")
 	}
 	if !served.OutputSettings.GetDetection().GetEnabled() {
 		t.Fatalf("detection settings: got false, want true")

--- a/cmd/cicd-sensor/project.go
+++ b/cmd/cicd-sensor/project.go
@@ -257,6 +257,9 @@ func buildProjectStartRequest(identity jobIdentityFlags, metadata jobMetadataFla
 		if projectConfig.DefaultMaxAlertsPerRule != nil && *projectConfig.DefaultMaxAlertsPerRule != 0 {
 			req["default_max_alerts_per_rule"] = *projectConfig.DefaultMaxAlertsPerRule
 		}
+		if projectConfig.DisableBaselineRules {
+			req["disable_baseline_rules"] = true
+		}
 	}
 
 	if rulesFile != "" {

--- a/cmd/cicd-sensor/project_test.go
+++ b/cmd/cicd-sensor/project_test.go
@@ -109,6 +109,21 @@ func TestBuildProjectStartRequest_LoadsProjectConfig(t *testing.T) {
 	}
 }
 
+func TestBuildProjectStartRequest_ConfigDisablesBaselineRules(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "project.yaml")
+	if err := os.WriteFile(configPath, []byte("disable_baseline_rules: true\n"), 0o644); err != nil {
+		t.Fatalf("write project config: %v", err)
+	}
+
+	got, err := buildProjectStartRequest(githubIdentity(), jobMetadataFlags{}, configPath, "", managerConnectionConfig{}, false)
+	if err != nil {
+		t.Fatalf("buildProjectStartRequest: %v", err)
+	}
+	if got["disable_baseline_rules"] != true {
+		t.Fatalf("disable_baseline_rules: got %#v, want true", got["disable_baseline_rules"])
+	}
+}
+
 func TestBuildProjectStartRequest_EmptyProjectConfigOmitsDefaultMaxAlerts(t *testing.T) {
 	configPath := filepath.Join(t.TempDir(), "project.yaml")
 	if err := os.WriteFile(configPath, []byte("{}\n"), 0o644); err != nil {

--- a/docs/developer-guide/manager.md
+++ b/docs/developer-guide/manager.md
@@ -54,6 +54,8 @@ The Manager exposes two endpoints to Agents.
 
 Agents fetch config and rules with `ConfigService.FetchConfig`.
 In manager mode, repository-local `.cicd-sensor/config.yaml` and `.cicd-sensor/rules/` are not used.
+The manager config owns manager-backed baseline policy, default alert caps, and output policy.
+For the user-facing `manager.yaml` setting reference, see [Manager](../user-guide/manager.md#manageryaml).
 
 Startup config is read once at process start.
 Rules are checked on each `FetchConfig` request: if the rule bundle file's modification time or size has changed, it is re-parsed; otherwise the cached parse is reused.
@@ -66,7 +68,8 @@ The Manager process accepts file locations through either CLI flags or environme
 | Startup config | `--config-file` | `CICD_SENSOR_MANAGER_CONFIG_FILE` | Read at process start |
 | Rule bundle | `--rules-file` | `CICD_SENSOR_MANAGER_RULES_FILE` | Rechecked on each `FetchConfig` request |
 
-Only file locations are part of this startup interface.
+Only file locations are accepted through this CLI / environment interface.
+The settings themselves live in `manager.yaml`; custom rules live in the rule bundle file.
 
 Rule sources returned by the Manager are merged and compiled by the Agent.
 The Manager holds the rule bundle, but it does not evaluate runtime events.

--- a/docs/user-guide/baseline-rules.md
+++ b/docs/user-guide/baseline-rules.md
@@ -6,12 +6,16 @@ They are maintained with current CI/CD supply-chain attack patterns in mind and 
 The operating model is baseline first, customization second.
 Most users should start with the baseline rule set, then add custom RuleSets or RuleModifiers only where their environment needs additional coverage or tuning.
 
-## Always-on baseline
+## Default-on baseline
 
-Baseline Rules are designed to be applied in every supported deployment mode.
+Baseline Rules are applied by default in every supported deployment mode.
 Whether you run cicd-sensor on GitHub-hosted runners, self-hosted runners, or through Manager, each monitored runtime should start from the latest cicd-sensor baseline.
 
 That keeps baseline detection coverage updated without requiring every repository to copy or maintain the rule set by hand.
+
+Disable the baseline only when you want to opt out of standard detections.
+In GitHub-hosted standalone mode, set `disable_baseline_rules: true` in `.cicd-sensor/config.yaml`.
+In manager mode, set `disable_baseline_rules: true` in `manager.yaml`; project-side action or `project start` settings cannot override the manager's baseline policy.
 
 ## How to customize
 

--- a/docs/user-guide/github-hosted.md
+++ b/docs/user-guide/github-hosted.md
@@ -64,7 +64,7 @@ repo/
       b.yaml
 ```
 
-Even when project-local rules are not present, [Baseline Rules](baseline-rules.md) still apply.
+Even when project-local rules are not present, [Baseline Rules](baseline-rules.md) still apply by default.
 Use project-local files only for repository-specific tuning or additional detections.
 
 ### config.yaml
@@ -73,11 +73,13 @@ Use project-local files only for repository-specific tuning or additional detect
 
 ```yaml
 default_max_alerts_per_rule: 20
+disable_baseline_rules: false
 ```
 
 | Field | Meaning |
 | --- | --- |
 | `default_max_alerts_per_rule` | Default Detection Log limit for rules that do not set `max_alerts`. Allowed values are 1-100. |
+| `disable_baseline_rules` | Disable cicd-sensor baseline rules for standalone project-local mode. Defaults to `false`. |
 
 See [RuleSet max_alerts](rule-set.md#max_alerts) for per-rule limits.
 
@@ -117,6 +119,7 @@ In this mode, the cicd-sensor Agent can still generate the HTML report and attes
 Important: when `manager-url` is set, repository-local `.cicd-sensor/config.yaml` and `.cicd-sensor/rules/` are not used.
 Config and rules are fetched from the manager.
 Repository-local rules and manager rules are not merged together.
+Baseline policy is also owned by the manager, not by repository-local config.
 
 ```yaml
 jobs:

--- a/docs/user-guide/manager.md
+++ b/docs/user-guide/manager.md
@@ -58,7 +58,7 @@ Design HTTPS / TLS, authentication boundaries, and private network exposure with
 
 ## Network requirements
 
-Allow outbound HTTPS from the manager to the following hosts.
+Allow outbound HTTPS from the manager to the following hosts when baseline rules are enabled.
 
 | Host | Purpose |
 | --- | --- |
@@ -68,7 +68,7 @@ Allow outbound HTTPS from the manager to the following hosts.
 | `tuf-repo-cdn.sigstore.dev` | Fetch the Sigstore root certificates used for baseline rule signature verification |
 
 When using Manager, Agents do not connect to these hosts directly.
-Agents connect to the Manager, and the Manager fetches and verifies baseline rules.
+Agents connect to the Manager, and the Manager fetches and verifies baseline rules unless `disable_baseline_rules` is set.
 
 ## Startup files
 
@@ -136,6 +136,7 @@ bind:
   port: 8080
 
 default_max_alerts_per_rule: 10
+disable_baseline_rules: false
 
 sinks:
   s3-out:
@@ -152,19 +153,23 @@ logs:
     sink: s3-out
 ```
 
-`bind` is optional. Omitted or empty values fall back to `address: "0.0.0.0"` (listen on all interfaces) and `port: 8080`. `port` must be in 0–65535.
-`default_max_alerts_per_rule` is optional and uses the same meaning as project config: it sets the default Detection Log limit for rules that do not set `max_alerts`.
+The manager reads `manager.yaml` once at process start. Changing these
+settings requires a manager restart.
 
 For richer routing (per-log-kind destinations, multiple sinks), see
 [Log routing](#log-routing).
 
-| Setting | Purpose |
-| --- | --- |
-| `bind.address` | Listen address. Defaults to `0.0.0.0`. |
-| `bind.port` | Listen port. Defaults to `8080`. |
-| `default_max_alerts_per_rule` | Default per-rule Detection Log limit. Use 1-100 to set a value; omit it or set 0 to use the system default. |
-| `sinks` | Physical log destinations. |
-| `logs` | Mapping from log `log_type` to one sink. |
+| Setting | Purpose | Default | Reload behavior |
+| --- | --- | --- | --- |
+| `bind` | Manager listen address and port. `bind.port` must be in 0-65535. | `address: "0.0.0.0"`, `port: 8080` | Manager restart |
+| `default_max_alerts_per_rule` | Default per-rule Detection Log limit for rules that do not set `max_alerts`. Use 1-100 to set a value; omit it or set 0 to use the system default. | `10` | Manager restart |
+| `disable_baseline_rules` | Disable cicd-sensor baseline rule fetch/prepend when using the manager. Custom rule bundles from `--rules-file` are still served. | `false` | Manager restart |
+| `sinks` | Physical cloud output destinations, such as S3, GCS, or Pub/Sub. | none | Manager restart |
+| `logs` | Mapping from each manager-ingested `log_type` to one configured sink. | none | Manager restart |
+
+The custom rule bundle is configured separately with `--rules-file` or
+`CICD_SENSOR_MANAGER_RULES_FILE`. The manager rechecks that file on each
+`FetchConfig` request, so rule bundle changes do not require a restart.
 
 ## Log routing
 

--- a/docs/user-guide/rule-set.md
+++ b/docs/user-guide/rule-set.md
@@ -72,7 +72,7 @@ See [Correlation](rule-correlation.md) for details.
 | `condition` | yes | CEL expression that returns bool |
 | `action` | yes | `detect`, `collect`, or `terminate` |
 | `tags` | no | Metadata such as severity or category |
-| `target` | no | Repository / project scope where the rule applies |
+| `target` | no | Repository / project where the rule applies |
 | `max_alerts` | no | Maximum entries emitted to the Detection Log per job / rule |
 
 ## Actions

--- a/internal/agent/jobregistry/finalize_test.go
+++ b/internal/agent/jobregistry/finalize_test.go
@@ -37,7 +37,10 @@ func TestJobRegistry_FinalizeAll_RemovesJobs(t *testing.T) {
 
 	jr := newTestJobRegistry()
 	for _, jobID := range []string{"a", "b"} {
-		if _, err := jr.ApplyGitHubProjectStart(testCtx, jobcontext.GitLabJobIdentity("gitlab.com", "group/project", jobID), jobcontext.JobMetadata{}, "machine", 0, 0, nil, managerclient.Connection{}, nil, false); err != nil {
+		if _, err := jr.ApplyGitHubProjectStart(testCtx, GitHubProjectStartConfig{
+			Identity:   jobcontext.GitLabJobIdentity("gitlab.com", "group/project", jobID),
+			RunnerType: "machine",
+		}); err != nil {
 			t.Fatalf("start %s: %v", jobID, err)
 		}
 	}
@@ -53,7 +56,10 @@ func TestJobRegistry_FinalizeExpiredJobs_RemovesJob(t *testing.T) {
 	t.Parallel()
 
 	jr := newTestJobRegistry()
-	j, err := jr.ApplyGitHubProjectStart(testCtx, jobcontext.GitHubJobIdentity("github.com", "acme/example", "123", "build", "1", "runner-1"), jobcontext.JobMetadata{}, "machine", 0, 0, nil, managerclient.Connection{}, nil, false)
+	j, err := jr.ApplyGitHubProjectStart(testCtx, GitHubProjectStartConfig{
+		Identity:   jobcontext.GitHubJobIdentity("github.com", "acme/example", "123", "build", "1", "runner-1"),
+		RunnerType: "machine",
+	})
 	if err != nil {
 		t.Fatalf("start: %v", err)
 	}
@@ -103,7 +109,10 @@ func TestJobRegistry_RequestGitHubHostEnd_ProjectOnlyJobReturnsError(t *testing.
 
 	jr := newTestJobRegistry()
 	id := jobcontext.GitHubJobIdentity("github.com", "acme/example", "123", "build", "1", "runner-1")
-	if _, err := jr.ApplyGitHubProjectStart(testCtx, id, jobcontext.JobMetadata{}, "machine", 0, 0, nil, managerclient.Connection{}, nil, false); err != nil {
+	if _, err := jr.ApplyGitHubProjectStart(testCtx, GitHubProjectStartConfig{
+		Identity:   id,
+		RunnerType: "machine",
+	}); err != nil {
 		t.Fatalf("project start: %v", err)
 	}
 
@@ -145,7 +154,10 @@ func TestJobRegistry_GetGitHubJobHealth(t *testing.T) {
 	}
 
 	projectOnlyID := jobcontext.GitHubJobIdentity("github.com", "acme/example", "124", "build", "1", "runner-2")
-	if _, err := jr.ApplyGitHubProjectStart(testCtx, projectOnlyID, jobcontext.JobMetadata{}, "machine", 0, 0, nil, managerclient.Connection{}, nil, false); err != nil {
+	if _, err := jr.ApplyGitHubProjectStart(testCtx, GitHubProjectStartConfig{
+		Identity:   projectOnlyID,
+		RunnerType: "machine",
+	}); err != nil {
 		t.Fatalf("project start: %v", err)
 	}
 	projectHealth, err := jr.GetGitHubJobHealth(testCtx, projectOnlyID, 1)

--- a/internal/agent/jobregistry/host_start_test.go
+++ b/internal/agent/jobregistry/host_start_test.go
@@ -254,22 +254,28 @@ func TestJobRegistry_ManagerConfigDoesNotApplyToProjectScope(t *testing.T) {
 		t.Fatalf("apply host start: %v", err)
 	}
 	collect := rule.RuleActionCollect
-	job, err := jr.ApplyGitHubProjectStart(testCtx, id, meta, "machine", 0, 7, []rulesource.LoadedRules{{
-		RuleSets: []rule.RuleSet{{
-			RulesetID: "project",
-			Rules: []rule.Rule{{
-				RuleID:    "project-only",
-				EventType: jobevent.ProcessExec,
-				Condition: `process_name == "go"`,
-				Action:    rule.RuleActionDetect,
+	job, err := jr.ApplyGitHubProjectStart(testCtx, jobregistry.GitHubProjectStartConfig{
+		Identity:                id,
+		Metadata:                meta,
+		RunnerType:              "machine",
+		DefaultMaxAlertsPerRule: 7,
+		RuleSources: []rulesource.LoadedRules{{
+			RuleSets: []rule.RuleSet{{
+				RulesetID: "project",
+				Rules: []rule.Rule{{
+					RuleID:    "project-only",
+					EventType: jobevent.ProcessExec,
+					Condition: `process_name == "go"`,
+					Action:    rule.RuleActionDetect,
+				}},
+			}},
+			RuleModifiers: []rule.RuleModifier{{
+				ModifierID:     "project-mod",
+				Targets:        []rule.RuleModifierTarget{{RulesetID: "project", RuleID: "project-only"}},
+				OverrideAction: &collect,
 			}},
 		}},
-		RuleModifiers: []rule.RuleModifier{{
-			ModifierID:     "project-mod",
-			Targets:        []rule.RuleModifierTarget{{RulesetID: "project", RuleID: "project-only"}},
-			OverrideAction: &collect,
-		}},
-	}}, managerclient.Connection{}, nil, false)
+	})
 	if err != nil {
 		t.Fatalf("apply project start: %v", err)
 	}
@@ -343,7 +349,11 @@ func TestJobRegistry_ApplyGitHubHostStart_RejectsAfterProjectOnly(t *testing.T) 
 	id := jobcontext.GitHubJobIdentity("github.com", "acme/example", "123", "build", "1", "runner-1")
 	meta := jobcontext.JobMetadata{}
 
-	projectJob, err := jr.ApplyGitHubProjectStart(testCtx, id, meta, "machine", 0, 0, nil, managerclient.Connection{}, nil, false)
+	projectJob, err := jr.ApplyGitHubProjectStart(testCtx, jobregistry.GitHubProjectStartConfig{
+		Identity:   id,
+		Metadata:   meta,
+		RunnerType: "machine",
+	})
 	if err != nil {
 		t.Fatalf("apply project start: %v", err)
 	}

--- a/internal/agent/jobregistry/kerneltracker_job_tracking_linux_test.go
+++ b/internal/agent/jobregistry/kerneltracker_job_tracking_linux_test.go
@@ -59,7 +59,12 @@ func TestJobRegistry_PeerPIDAuthorization(t *testing.T) {
 		if _, err := jr.ApplyGitHubHostStart(ctx, id, meta, "machine", selfPID, managerclient.Connection{}, staticManagerFetcher{}); err != nil {
 			t.Fatalf("ApplyGitHubHostStart: %v", err)
 		}
-		if _, err := jr.ApplyGitHubProjectStart(ctx, id, meta, "machine", selfPID, 0, nil, managerclient.Connection{}, nil, false); err != nil {
+		if _, err := jr.ApplyGitHubProjectStart(ctx, GitHubProjectStartConfig{
+			Identity:   id,
+			Metadata:   meta,
+			RunnerType: "machine",
+			PeerPID:    selfPID,
+		}); err != nil {
 			t.Fatalf("ApplyGitHubProjectStart same-cgroup peer: %v", err)
 		}
 		if _, err := jr.RequestGitHubProjectResult(ctx, id, selfPID); err != nil {
@@ -74,7 +79,12 @@ func TestJobRegistry_PeerPIDAuthorization(t *testing.T) {
 			t.Fatalf("ApplyGitHubHostStart: %v", err)
 		}
 		// PID 1 lives in a different cgroup than the test process.
-		_, err := jr.ApplyGitHubProjectStart(ctx, id, meta, "machine", 1, 0, nil, managerclient.Connection{}, nil, false)
+		_, err := jr.ApplyGitHubProjectStart(ctx, GitHubProjectStartConfig{
+			Identity:   id,
+			Metadata:   meta,
+			RunnerType: "machine",
+			PeerPID:    1,
+		})
 		if !errors.Is(err, ErrPeerNotInJob) {
 			t.Fatalf("ApplyGitHubProjectStart foreign peer: got %v, want ErrPeerNotInJob", err)
 		}
@@ -88,7 +98,12 @@ func TestJobRegistry_PeerPIDAuthorization(t *testing.T) {
 		jr, ctx := startPeerPIDAuthRegistry(t)
 		id := jobcontext.GitHubJobIdentity("github.com", "acme/example", "3", "build", "1", "r1")
 		// No ApplyGitHubHostStart: project_start creates a hosted-only Job.
-		if _, err := jr.ApplyGitHubProjectStart(ctx, id, meta, "machine", selfPID, 0, nil, managerclient.Connection{}, nil, false); err != nil {
+		if _, err := jr.ApplyGitHubProjectStart(ctx, GitHubProjectStartConfig{
+			Identity:   id,
+			Metadata:   meta,
+			RunnerType: "machine",
+			PeerPID:    selfPID,
+		}); err != nil {
 			t.Fatalf("ApplyGitHubProjectStart hosted: %v", err)
 		}
 		if _, err := jr.RequestGitHubProjectResult(ctx, id, selfPID); err != nil {

--- a/internal/agent/jobregistry/project_result_test.go
+++ b/internal/agent/jobregistry/project_result_test.go
@@ -25,7 +25,11 @@ func TestJobRegistry_RequestGitHubProjectResult_ExistingJob(t *testing.T) {
 	id := jobcontext.GitHubJobIdentity("github.com", "acme/example", "123", "build", "1", "runner-1")
 	meta := jobcontext.JobMetadata{}
 
-	if _, err := jr.ApplyGitHubProjectStart(testCtx, id, meta, "machine", 0, 0, nil, managerclient.Connection{}, nil, false); err != nil {
+	if _, err := jr.ApplyGitHubProjectStart(testCtx, jobregistry.GitHubProjectStartConfig{
+		Identity:   id,
+		Metadata:   meta,
+		RunnerType: "machine",
+	}); err != nil {
 		t.Fatalf("apply project start: %v", err)
 	}
 
@@ -53,7 +57,11 @@ func TestJobRegistry_RequestGitHubProjectResult_ClosesDebugOutputBeforeReturn(t 
 	id := jobcontext.GitHubJobIdentity("github.com", "acme/example", "123", "build", "1", "runner-1")
 	meta := jobcontext.JobMetadata{}
 
-	if _, err := jr.ApplyGitHubProjectStart(testCtx, id, meta, "machine", 0, 0, nil, managerclient.Connection{}, nil, false); err != nil {
+	if _, err := jr.ApplyGitHubProjectStart(testCtx, jobregistry.GitHubProjectStartConfig{
+		Identity:   id,
+		Metadata:   meta,
+		RunnerType: "machine",
+	}); err != nil {
 		t.Fatalf("apply project start: %v", err)
 	}
 	job := registeredJob(jr, id)

--- a/internal/agent/jobregistry/project_start.go
+++ b/internal/agent/jobregistry/project_start.go
@@ -11,66 +11,61 @@ import (
 	"github.com/cicd-sensor/cicd-sensor/internal/rulesource"
 )
 
+// GitHubProjectStartConfig carries the inputs for a GitHub project/start request.
+type GitHubProjectStartConfig struct {
+	Identity                jobcontext.JobIdentity
+	Metadata                jobcontext.JobMetadata
+	RunnerType              string
+	PeerPID                 int32
+	DefaultMaxAlertsPerRule int
+	DisableBaselineRules    bool
+	RuleSources             []rulesource.LoadedRules
+	ManagerConnection       managerclient.Connection
+	ManagerClient           ManagerConfigFetcher
+	DebugEnabled            bool
+}
+
 // ApplyGitHubProjectStart registers the GitHub project scope. Hosted jobs can
 // start here; self-hosted jobs attach to an existing GitHub host scope.
-func (jr *JobRegistry) ApplyGitHubProjectStart(
-	ctx context.Context,
-	identity jobcontext.JobIdentity,
-	metadata jobcontext.JobMetadata,
-	runnerType string,
-	peerPID int32,
-	projectDefaultMaxAlertsPerRule int,
-	projectRuleSources []rulesource.LoadedRules,
-	projectManagerConnection managerclient.Connection,
-	projectManagerClient ManagerConfigFetcher,
-	debugEnabled bool,
-) (*job.Job, error) {
+func (jr *JobRegistry) ApplyGitHubProjectStart(ctx context.Context, cfg GitHubProjectStartConfig) (*job.Job, error) {
 	// Project/start peer authorization lives here because existing-host and
 	// hosted project-only flows use different Job/BPF state.
-	reservation := jr.reserveJobStart(identity)
+	reservation := jr.reserveJobStart(cfg.Identity)
 	if reservation.existing != nil {
-		return jr.attachGitHubProjectScopeToExistingJob(ctx, reservation.existing, identity, metadata, runnerType, peerPID, projectDefaultMaxAlertsPerRule, projectRuleSources, projectManagerConnection, projectManagerClient, debugEnabled)
+		return jr.attachGitHubProjectScopeToExistingJob(ctx, reservation.existing, cfg)
 	}
 	if reservation.inFlight() {
 		return nil, ErrJobAlreadyRegistered
 	}
 	defer reservation.done()
 
-	return jr.startGitHubProjectOnlyJob(ctx, identity, metadata, runnerType, peerPID, projectDefaultMaxAlertsPerRule, projectRuleSources, projectManagerConnection, projectManagerClient, debugEnabled)
+	return jr.startGitHubProjectOnlyJob(ctx, cfg)
 }
 
 func (jr *JobRegistry) attachGitHubProjectScopeToExistingJob(
 	ctx context.Context,
 	existing *job.Job,
-	identity jobcontext.JobIdentity,
-	metadata jobcontext.JobMetadata,
-	runnerType string,
-	peerPID int32,
-	projectDefaultMaxAlertsPerRule int,
-	projectRuleSources []rulesource.LoadedRules,
-	projectManagerConnection managerclient.Connection,
-	projectManagerClient ManagerConfigFetcher,
-	debugEnabled bool,
+	cfg GitHubProjectStartConfig,
 ) (*job.Job, error) {
 	if existing.ProjectScope() != nil {
 		return nil, job.ErrProjectScopeAlreadySet
 	}
-	if err := jr.verifyPeerPIDBelongsToJob(ctx, peerPID, identity); err != nil {
+	if err := jr.verifyPeerPIDBelongsToJob(ctx, cfg.PeerPID, cfg.Identity); err != nil {
 		return nil, err
 	}
 
 	// Self-hosted GitHub builds project scope, then attaches it to the host-created Job.
 	var projectScope *jobscope.JobScopeState
 	var err error
-	if projectManagerClient != nil {
-		projectScope, err = jr.buildProjectScopeFromManagerConfig(ctx, identity, metadata, runnerType, projectManagerConnection, projectManagerClient)
+	if cfg.ManagerClient != nil {
+		projectScope, err = jr.buildProjectScopeFromManagerConfig(ctx, cfg.Identity, cfg.Metadata, cfg.RunnerType, cfg.ManagerConnection, cfg.ManagerClient)
 	} else {
-		projectScope, err = jr.buildProjectScopeFromLocalConfig(ctx, identity, projectDefaultMaxAlertsPerRule, projectRuleSources)
+		projectScope, err = jr.buildProjectScopeFromLocalConfig(ctx, cfg.Identity, cfg.DefaultMaxAlertsPerRule, cfg.DisableBaselineRules, cfg.RuleSources)
 	}
 	if err != nil {
 		return nil, err
 	}
-	jr.attachDebugOutput(ctx, projectScope, debugEnabled)
+	jr.attachDebugOutput(ctx, projectScope, cfg.DebugEnabled)
 	// SetProjectScope swaps in the host+project evaluation bundle atomically.
 	if err := existing.SetProjectScope(ctx, projectScope); err != nil {
 		return nil, err
@@ -80,30 +75,22 @@ func (jr *JobRegistry) attachGitHubProjectScopeToExistingJob(
 
 func (jr *JobRegistry) startGitHubProjectOnlyJob(
 	ctx context.Context,
-	identity jobcontext.JobIdentity,
-	metadata jobcontext.JobMetadata,
-	runnerType string,
-	peerPID int32,
-	projectDefaultMaxAlertsPerRule int,
-	projectRuleSources []rulesource.LoadedRules,
-	projectManagerConnection managerclient.Connection,
-	projectManagerClient ManagerConfigFetcher,
-	debugEnabled bool,
+	cfg GitHubProjectStartConfig,
 ) (*job.Job, error) {
 	var projectScope *jobscope.JobScopeState
 	var err error
-	if projectManagerClient != nil {
-		projectScope, err = jr.buildProjectScopeFromManagerConfig(ctx, identity, metadata, runnerType, projectManagerConnection, projectManagerClient)
+	if cfg.ManagerClient != nil {
+		projectScope, err = jr.buildProjectScopeFromManagerConfig(ctx, cfg.Identity, cfg.Metadata, cfg.RunnerType, cfg.ManagerConnection, cfg.ManagerClient)
 	} else {
-		projectScope, err = jr.buildProjectScopeFromLocalConfig(ctx, identity, projectDefaultMaxAlertsPerRule, projectRuleSources)
+		projectScope, err = jr.buildProjectScopeFromLocalConfig(ctx, cfg.Identity, cfg.DefaultMaxAlertsPerRule, cfg.DisableBaselineRules, cfg.RuleSources)
 	}
 	if err != nil {
 		return nil, err
 	}
-	jr.attachDebugOutput(ctx, projectScope, debugEnabled)
+	jr.attachDebugOutput(ctx, projectScope, cfg.DebugEnabled)
 
 	// Hosted Actions without host/start create the Job runtime here.
-	job, err := jr.registerJobRuntime(ctx, identity, metadata, runnerType)
+	job, err := jr.registerJobRuntime(ctx, cfg.Identity, cfg.Metadata, cfg.RunnerType)
 	if err != nil {
 		return nil, err
 	}
@@ -114,7 +101,7 @@ func (jr *JobRegistry) startGitHubProjectOnlyJob(
 	}
 	if jr.kernelTracker != nil {
 		// project_start peer is the root cgroup for hosted project-only jobs.
-		if err := jr.bindStartProcessCgroupToJob(ctx, identity, peerPID, "github_project_start"); err != nil {
+		if err := jr.bindStartProcessCgroupToJob(ctx, cfg.Identity, cfg.PeerPID, "github_project_start"); err != nil {
 			return nil, err
 		}
 	}
@@ -152,14 +139,16 @@ func (jr *JobRegistry) buildProjectScopeFromManagerConfig(ctx context.Context, i
 }
 
 // buildProjectScopeFromLocalConfig builds a resolved project scope from project-local config.
-func (jr *JobRegistry) buildProjectScopeFromLocalConfig(ctx context.Context, identity jobcontext.JobIdentity, projectDefaultMaxAlertsPerRule int, projectRuleSources []rulesource.LoadedRules) (*jobscope.JobScopeState, error) {
+func (jr *JobRegistry) buildProjectScopeFromLocalConfig(ctx context.Context, identity jobcontext.JobIdentity, projectDefaultMaxAlertsPerRule int, disableBaselineRules bool, projectRuleSources []rulesource.LoadedRules) (*jobscope.JobScopeState, error) {
 	projectScope := jobscope.NewProject()
-	baselineSource, err := jr.loadBaselineRules(ctx, identity)
-	if err != nil {
-		return nil, err
-	}
-	if err := projectScope.ApplyBaselineRules(baselineSource); err != nil {
-		return nil, err
+	if !disableBaselineRules {
+		baselineSource, err := jr.loadBaselineRules(ctx, identity)
+		if err != nil {
+			return nil, err
+		}
+		if err := projectScope.ApplyBaselineRules(baselineSource); err != nil {
+			return nil, err
+		}
 	}
 	if err := projectScope.ApplyProjectLocalConfig(jobscope.ProjectLocalConfig{
 		RuleSources:             projectRuleSources,

--- a/internal/agent/jobregistry/project_start_internal_test.go
+++ b/internal/agent/jobregistry/project_start_internal_test.go
@@ -27,7 +27,7 @@ func TestBuildProjectScopeFromLocalConfigCanAddBaselineFallback(t *testing.T) {
 		}}}, nil
 	})
 
-	scope, err := jr.buildProjectScopeFromLocalConfig(testCtx, id, 7, []rulesource.LoadedRules{{
+	scope, err := jr.buildProjectScopeFromLocalConfig(testCtx, id, 7, false, []rulesource.LoadedRules{{
 		RuleSets: []rule.RuleSet{{
 			RulesetID: "project",
 			Rules: []rule.Rule{{
@@ -67,7 +67,7 @@ func TestBuildProjectScopeFromLocalConfigKeepsBaselineFirst(t *testing.T) {
 		}}}, nil
 	})
 
-	scope, err := jr.buildProjectScopeFromLocalConfig(testCtx, id, 0, []rulesource.LoadedRules{{
+	scope, err := jr.buildProjectScopeFromLocalConfig(testCtx, id, 0, false, []rulesource.LoadedRules{{
 		RuleSets: []rule.RuleSet{{
 			RulesetID: "shared",
 			Rules: []rule.Rule{{
@@ -87,6 +87,42 @@ func TestBuildProjectScopeFromLocalConfigKeepsBaselineFirst(t *testing.T) {
 	}
 	if got.Rule.Condition != `process_name == "baseline"` {
 		t.Fatalf("condition: got %q, want baseline rule", got.Rule.Condition)
+	}
+}
+
+func TestBuildProjectScopeFromLocalConfigCanDisableBaseline(t *testing.T) {
+	jr := newTestJobRegistry()
+	id := jobcontext.GitHubJobIdentity("github.com", "acme/example", "1", "build", "1", "runner-1")
+	jr.SetBaselineLoadForTesting(func(context.Context, *slog.Logger, string) (rulesource.LoadedRules, error) {
+		t.Fatal("baseline loader should not be called when baseline rules are disabled")
+		return rulesource.LoadedRules{}, nil
+	})
+
+	scope, err := jr.buildProjectScopeFromLocalConfig(testCtx, id, 7, true, []rulesource.LoadedRules{{
+		RuleSets: []rule.RuleSet{{
+			RulesetID: "project",
+			Rules: []rule.Rule{{
+				RuleID:    "project_exec",
+				EventType: jobevent.ProcessExec,
+				Condition: `process_name == "go"`,
+				Action:    rule.RuleActionDetect,
+			}},
+		}},
+	}})
+	if err != nil {
+		t.Fatalf("buildProjectScopeFromLocalConfig: %v", err)
+	}
+	if got := len(scope.RuleSets); got != 1 {
+		t.Fatalf("rule_sets: got %d, want 1", got)
+	}
+	if got := scope.RuleSets[0].RulesetID; got != "project" {
+		t.Fatalf("ruleset: got %q, want project", got)
+	}
+	if got := scope.DefaultMaxAlertsPerRule; got != 7 {
+		t.Fatalf("default_max_alerts_per_rule: got %d, want 7", got)
+	}
+	if got := len(scope.ResolvedRules.Rules); got != 1 {
+		t.Fatalf("resolved rules: got %d, want 1", got)
 	}
 }
 

--- a/internal/agent/jobregistry/project_start_test.go
+++ b/internal/agent/jobregistry/project_start_test.go
@@ -23,7 +23,12 @@ func TestJobRegistry_ApplyGitHubProjectStart_SeedsProjectDefaultMaxAlerts(t *tes
 	id := jobcontext.GitHubJobIdentity("github.com", "acme/example", "123", "build", "1", "runner-1")
 	meta := jobcontext.JobMetadata{}
 
-	job, err := jr.ApplyGitHubProjectStart(testCtx, id, meta, "machine", 0, 12, nil, managerclient.Connection{}, nil, false)
+	job, err := jr.ApplyGitHubProjectStart(testCtx, jobregistry.GitHubProjectStartConfig{
+		Identity:                id,
+		Metadata:                meta,
+		RunnerType:              "machine",
+		DefaultMaxAlertsPerRule: 12,
+	})
 	if err != nil {
 		t.Fatalf("apply project start: %v", err)
 	}
@@ -41,22 +46,27 @@ func TestJobRegistry_ApplyGitHubProjectStart_AppliesProjectRules(t *testing.T) {
 	meta := jobcontext.JobMetadata{}
 
 	collect := rule.RuleActionCollect
-	job, err := jr.ApplyGitHubProjectStart(testCtx, id, meta, "machine", 0, 0, []rulesource.LoadedRules{{
-		RuleSets: []rule.RuleSet{{
-			RulesetID: "project",
-			Rules: []rule.Rule{{
-				RuleID:    "project_exec",
-				EventType: jobevent.ProcessExec,
-				Condition: `process_name == "bash"`,
-				Action:    rule.RuleActionDetect,
+	job, err := jr.ApplyGitHubProjectStart(testCtx, jobregistry.GitHubProjectStartConfig{
+		Identity:   id,
+		Metadata:   meta,
+		RunnerType: "machine",
+		RuleSources: []rulesource.LoadedRules{{
+			RuleSets: []rule.RuleSet{{
+				RulesetID: "project",
+				Rules: []rule.Rule{{
+					RuleID:    "project_exec",
+					EventType: jobevent.ProcessExec,
+					Condition: `process_name == "bash"`,
+					Action:    rule.RuleActionDetect,
+				}},
+			}},
+			RuleModifiers: []rule.RuleModifier{{
+				ModifierID:     "project-collect",
+				Targets:        []rule.RuleModifierTarget{{RulesetID: "project", RuleID: "project_exec"}},
+				OverrideAction: &collect,
 			}},
 		}},
-		RuleModifiers: []rule.RuleModifier{{
-			ModifierID:     "project-collect",
-			Targets:        []rule.RuleModifierTarget{{RulesetID: "project", RuleID: "project_exec"}},
-			OverrideAction: &collect,
-		}},
-	}}, managerclient.Connection{}, nil, false)
+	})
 	if err != nil {
 		t.Fatalf("apply project start: %v", err)
 	}
@@ -116,10 +126,18 @@ func TestJobRegistry_ApplyGitHubProjectStart_ManagerConfigIgnoresLocalProjectInp
 		}},
 	}}
 
-	job, err := jr.ApplyGitHubProjectStart(testCtx, id, meta, "machine", 0, 12, localSources, managerclient.Connection{
-		BaseURL: server.URL,
-		Token:   testManagerToken,
-	}, client, false)
+	job, err := jr.ApplyGitHubProjectStart(testCtx, jobregistry.GitHubProjectStartConfig{
+		Identity:                id,
+		Metadata:                meta,
+		RunnerType:              "machine",
+		DefaultMaxAlertsPerRule: 12,
+		RuleSources:             localSources,
+		ManagerConnection: managerclient.Connection{
+			BaseURL: server.URL,
+			Token:   testManagerToken,
+		},
+		ManagerClient: client,
+	})
 	if err != nil {
 		t.Fatalf("apply project start: %v", err)
 	}
@@ -147,7 +165,11 @@ func TestJobRegistry_ApplyGitHubProjectStart_SetsProjectScopeOnNewJob(t *testing
 	id := jobcontext.GitHubJobIdentity("github.com", "acme/example", "123", "build", "1", "runner-1")
 	meta := jobcontext.JobMetadata{}
 
-	job, err := jr.ApplyGitHubProjectStart(testCtx, id, meta, "machine", 0, 0, nil, managerclient.Connection{}, nil, false)
+	job, err := jr.ApplyGitHubProjectStart(testCtx, jobregistry.GitHubProjectStartConfig{
+		Identity:   id,
+		Metadata:   meta,
+		RunnerType: "machine",
+	})
 	if err != nil {
 		t.Fatalf("apply project start: %v", err)
 	}
@@ -166,7 +188,11 @@ func TestJobRegistry_ApplyGitHubProjectStart_UpdatesExistingJob(t *testing.T) {
 	if err != nil {
 		t.Fatalf("apply host start: %v", err)
 	}
-	got, err := jr.ApplyGitHubProjectStart(testCtx, id, projectMeta, "machine", 0, 0, nil, managerclient.Connection{}, nil, false)
+	got, err := jr.ApplyGitHubProjectStart(testCtx, jobregistry.GitHubProjectStartConfig{
+		Identity:   id,
+		Metadata:   projectMeta,
+		RunnerType: "machine",
+	})
 	if err != nil {
 		t.Fatalf("apply project start: %v", err)
 	}
@@ -186,10 +212,18 @@ func TestJobRegistry_ApplyGitHubProjectStart_DuplicateReturnsError(t *testing.T)
 	id := jobcontext.GitHubJobIdentity("github.com", "acme/example", "123", "build", "1", "runner-1")
 	meta := jobcontext.JobMetadata{}
 
-	if _, err := jr.ApplyGitHubProjectStart(testCtx, id, meta, "machine", 0, 0, nil, managerclient.Connection{}, nil, false); err != nil {
+	if _, err := jr.ApplyGitHubProjectStart(testCtx, jobregistry.GitHubProjectStartConfig{
+		Identity:   id,
+		Metadata:   meta,
+		RunnerType: "machine",
+	}); err != nil {
 		t.Fatalf("first project start: %v", err)
 	}
-	if _, err := jr.ApplyGitHubProjectStart(testCtx, id, meta, "machine", 0, 0, nil, managerclient.Connection{}, nil, false); !errors.Is(err, jobpkg.ErrProjectScopeAlreadySet) {
+	if _, err := jr.ApplyGitHubProjectStart(testCtx, jobregistry.GitHubProjectStartConfig{
+		Identity:   id,
+		Metadata:   meta,
+		RunnerType: "machine",
+	}); !errors.Is(err, jobpkg.ErrProjectScopeAlreadySet) {
 		t.Fatalf("second project start error: got %v, want %v", err, jobpkg.ErrProjectScopeAlreadySet)
 	}
 }
@@ -205,7 +239,12 @@ func TestJobRegistry_ApplyGitHubProjectStart_PendingDuplicateReturnsError(t *tes
 
 	startDone := make(chan error, 1)
 	go func() {
-		_, err := jr.ApplyGitHubProjectStart(testCtx, id, meta, "machine", 0, 0, nil, managerclient.Connection{}, fetcher, false)
+		_, err := jr.ApplyGitHubProjectStart(testCtx, jobregistry.GitHubProjectStartConfig{
+			Identity:      id,
+			Metadata:      meta,
+			RunnerType:    "machine",
+			ManagerClient: fetcher,
+		})
 		startDone <- err
 	}()
 
@@ -215,7 +254,11 @@ func TestJobRegistry_ApplyGitHubProjectStart_PendingDuplicateReturnsError(t *tes
 		t.Fatal("ApplyGitHubProjectStart did not reach manager fetch within timeout")
 	}
 
-	_, err := jr.ApplyGitHubProjectStart(testCtx, id, meta, "machine", 0, 0, nil, managerclient.Connection{}, nil, false)
+	_, err := jr.ApplyGitHubProjectStart(testCtx, jobregistry.GitHubProjectStartConfig{
+		Identity:   id,
+		Metadata:   meta,
+		RunnerType: "machine",
+	})
 	if !errors.Is(err, jobregistry.ErrJobAlreadyRegistered) {
 		t.Fatalf("in-flight duplicate project start: got %v, want %v", err, jobregistry.ErrJobAlreadyRegistered)
 	}

--- a/internal/agent/listener/github.go
+++ b/internal/agent/listener/github.go
@@ -89,18 +89,18 @@ func (l *Listener) handleGitHubProjectStart(w http.ResponseWriter, r *http.Reque
 		}
 	}
 
-	_, err = l.jobRegistry.ApplyGitHubProjectStart(
-		r.Context(),
-		identity,
-		metadata,
-		l.runnerType,
-		peerPID,
-		req.DefaultMaxAlertsPerRule,
-		req.RuleSources,
-		managerConnection,
-		projectManagerClient,
-		req.DebugEnabled,
-	)
+	_, err = l.jobRegistry.ApplyGitHubProjectStart(r.Context(), jobregistry.GitHubProjectStartConfig{
+		Identity:                identity,
+		Metadata:                metadata,
+		RunnerType:              l.runnerType,
+		PeerPID:                 peerPID,
+		DefaultMaxAlertsPerRule: req.DefaultMaxAlertsPerRule,
+		DisableBaselineRules:    req.DisableBaselineRules,
+		RuleSources:             req.RuleSources,
+		ManagerConnection:       managerConnection,
+		ManagerClient:           projectManagerClient,
+		DebugEnabled:            req.DebugEnabled,
+	})
 	if err != nil {
 		if errors.Is(err, jobregistry.ErrPeerNotInJob) {
 			l.writeError(w, r, http.StatusForbidden, "peer not in job tracking set")

--- a/internal/agent/listener/github_test.go
+++ b/internal/agent/listener/github_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"io"
+	"log/slog"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -716,6 +717,55 @@ func TestListener_ProjectStart_AcceptsProjectRules(t *testing.T) {
 	}
 }
 
+func TestListener_ProjectStart_DisableBaselineRulesKeepsProjectRules(t *testing.T) {
+	client, jobRegistry, cleanup := setupListenerWithRegistry(t)
+	defer cleanup()
+	jobRegistry.SetBaselineLoadForTesting(func(context.Context, *slog.Logger, string) (rulesource.LoadedRules, error) {
+		t.Fatal("baseline loader should not be called when project start disables baseline rules")
+		return rulesource.LoadedRules{}, nil
+	})
+
+	body, _ := json.Marshal(map[string]any{
+		"provider":                  "github",
+		"provider_host":             "github.com",
+		"project_path":              "acme/example",
+		"github_run_id":             "123456789",
+		"github_job":                "build",
+		"github_run_attempt":        "1",
+		"github_runner_tracking_id": "github_tracking_disable_baseline",
+		"disable_baseline_rules":    true,
+		"rule_sources": []rulesource.LoadedRules{{
+			RuleSets: []rule.RuleSet{{
+				RulesetID: "project",
+				Rules: []rule.Rule{{
+					RuleID:    "project_exec",
+					EventType: jobevent.ProcessExec,
+					Condition: `process_name == "bash"`,
+					Action:    rule.RuleActionDetect,
+				}},
+			}},
+		}},
+	})
+	resp, err := client.Post("http://cicd-sensor/v1/github/project/start", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status: got %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+
+	id := jobcontext.GitHubJobIdentity("github.com", "acme/example", "123456789", "build", "1", "github_tracking_disable_baseline")
+	job := listenerRegisteredJob(jobRegistry, id)
+	if job == nil || job.ProjectScope() == nil {
+		t.Fatal("expected project scope to be created")
+	}
+	if got := len(job.ProjectScope().RuleSets); got != 1 {
+		t.Fatalf("project scope rule_sets: got %d, want 1", got)
+	}
+}
+
 func TestListener_ProjectStart_AppliesProjectManagerConfig(t *testing.T) {
 	managerBearerToken := managerauth.TokenPrefix + strings.Repeat("a", 64)
 	svc := &fakeConfigService{
@@ -831,6 +881,43 @@ func TestListener_ProjectStart_ManagerModeIgnoresLocalDefaultMaxAlerts(t *testin
 	}
 	if got := job.ProjectScope().DefaultMaxAlertsPerRule; got != 31 {
 		t.Fatalf("project default_max_alerts_per_rule: got %d, want 31", got)
+	}
+}
+
+func TestListener_ProjectStart_RejectsProjectManagerWithDisableBaselineRules(t *testing.T) {
+	client, cleanup := setupListener(t)
+	defer cleanup()
+
+	body, _ := json.Marshal(map[string]any{
+		"provider":                  "github",
+		"provider_host":             "github.com",
+		"project_path":              "acme/example",
+		"github_run_id":             "123456789",
+		"github_job":                "build",
+		"github_run_attempt":        "1",
+		"github_runner_tracking_id": "github_tracking_manager_disable_baseline",
+		"manager_url":               "https://project-manager.example.com",
+		"manager_token":             managerauth.TokenPrefix + strings.Repeat("a", 64),
+		"disable_baseline_rules":    true,
+	})
+	resp, err := client.Post("http://cicd-sensor/v1/github/project/start", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status: got %d, want %d", resp.StatusCode, http.StatusBadRequest)
+	}
+
+	var result struct {
+		Error string `json:"error"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if result.Error != "disable_baseline_rules cannot be combined with manager_url" {
+		t.Fatalf("error: got %q, want %q", result.Error, "disable_baseline_rules cannot be combined with manager_url")
 	}
 }
 

--- a/internal/agent/listener/requests.go
+++ b/internal/agent/listener/requests.go
@@ -23,6 +23,7 @@ type githubProjectStartRequest struct {
 	jobcontext.JobIdentity
 	Metadata                jobcontext.JobMetadata   `json:"metadata,omitempty"`
 	DefaultMaxAlertsPerRule int                      `json:"default_max_alerts_per_rule,omitempty"`
+	DisableBaselineRules    bool                     `json:"disable_baseline_rules,omitempty"`
 	RuleSources             []rulesource.LoadedRules `json:"rule_sources,omitempty"`
 	ManagerURL              string                   `json:"manager_url,omitempty"`
 	ManagerToken            string                   `json:"manager_token,omitempty"`
@@ -38,6 +39,9 @@ func (r *githubProjectStartRequest) Validate() error {
 		errs = append(errs, errors.New("manager_url requires manager_token"))
 	case r.ManagerURL != "" && !managerauth.IsValidToken(r.ManagerToken):
 		errs = append(errs, errors.New(managerauth.ValidTokenDescription()))
+	}
+	if r.ManagerURL != "" && r.DisableBaselineRules {
+		errs = append(errs, errors.New("disable_baseline_rules cannot be combined with manager_url"))
 	}
 	if r.ManagerURL == "" {
 		cfg := projectconfig.ProjectConfig{DefaultMaxAlertsPerRule: &r.DefaultMaxAlertsPerRule}

--- a/internal/agent/projectconfig/projectconfig.go
+++ b/internal/agent/projectconfig/projectconfig.go
@@ -18,6 +18,7 @@ import (
 // ProjectConfig contains project-owned inputs accepted by project start.
 type ProjectConfig struct {
 	DefaultMaxAlertsPerRule *int `yaml:"default_max_alerts_per_rule,omitempty"`
+	DisableBaselineRules    bool `yaml:"disable_baseline_rules,omitempty"`
 }
 
 // Load reads a project config file and rejects unknown fields.

--- a/internal/agent/projectconfig/projectconfig_test.go
+++ b/internal/agent/projectconfig/projectconfig_test.go
@@ -15,6 +15,7 @@ func TestLoad(t *testing.T) {
 		name        string
 		content     string
 		want        *int
+		wantDisable bool
 		wantErrText string
 	}{
 		{
@@ -27,6 +28,13 @@ func TestLoad(t *testing.T) {
 default_max_alerts_per_rule: 7
 `,
 			want: intPtr(7),
+		},
+		{
+			name: "disable baseline rules is loaded",
+			content: `
+disable_baseline_rules: true
+`,
+			wantDisable: true,
 		},
 		{
 			name: "negative default is rejected",
@@ -86,6 +94,9 @@ manager:
 				t.Fatalf("default max alerts: got %v, want %v", got.DefaultMaxAlertsPerRule, tt.want)
 			case *got.DefaultMaxAlertsPerRule != *tt.want:
 				t.Fatalf("default max alerts: got %d, want %d", *got.DefaultMaxAlertsPerRule, *tt.want)
+			}
+			if got.DisableBaselineRules != tt.wantDisable {
+				t.Fatalf("disable baseline rules: got %v, want %v", got.DisableBaselineRules, tt.wantDisable)
 			}
 		})
 	}

--- a/internal/manager/config_loader.go
+++ b/internal/manager/config_loader.go
@@ -15,6 +15,7 @@ import (
 type ServedConfig struct {
 	ConfigRevision          string
 	DefaultMaxAlertsPerRule int
+	DisableBaselineRules    bool
 	OutputSettings          *managerv1beta1.OutputSettings
 }
 

--- a/internal/manager/config_service.go
+++ b/internal/manager/config_service.go
@@ -44,17 +44,19 @@ func (h *configServiceHandler) FetchConfig(ctx context.Context, req *connect.Req
 		h.server.logger.ErrorContext(ctx, "manager_rules_load_failed", "error", err)
 		return nil, connect.NewError(connect.CodeUnavailable, fmt.Errorf("manager rules load failed: %w", err))
 	}
-	baselineSource, err := h.server.baselineRules.LoadForProvider(ctx, h.server.logger, string(identity.Provider))
-	if err != nil {
-		h.server.logger.ErrorContext(ctx, "baseline_fetch_failed", "error", err)
-		return nil, connect.NewError(connect.CodeUnavailable, fmt.Errorf("baseline fetch failed: %w", err))
+	if !config.DisableBaselineRules {
+		baselineSource, err := h.server.baselineRules.LoadForProvider(ctx, h.server.logger, string(identity.Provider))
+		if err != nil {
+			h.server.logger.ErrorContext(ctx, "baseline_fetch_failed", "error", err)
+			return nil, connect.NewError(connect.CodeUnavailable, fmt.Errorf("baseline fetch failed: %w", err))
+		}
+		// Baseline first, then manual --rules-file. Rule source boundaries are
+		// preserved so OCI/local revisions remain visible to the agent.
+		merged := make([]rulesource.LoadedRules, 0, len(sources)+1)
+		merged = append(merged, baselineSource)
+		merged = append(merged, sources...)
+		sources = merged
 	}
-	// Baseline first, then manual --rules-file. Rule source boundaries are
-	// preserved so OCI/local revisions remain visible to the agent.
-	merged := make([]rulesource.LoadedRules, 0, len(sources)+1)
-	merged = append(merged, baselineSource)
-	merged = append(merged, sources...)
-	sources = merged
 
 	out := &managerv1beta1.FetchConfigResponse{
 		Config: &managerv1beta1.ServedConfig{

--- a/internal/manager/config_service_test.go
+++ b/internal/manager/config_service_test.go
@@ -31,9 +31,11 @@ type fakeBaselineRuleSource struct {
 	rules    rulesource.LoadedRules
 	err      error
 	provider string
+	calls    int
 }
 
 func (s *fakeBaselineRuleSource) LoadForProvider(ctx context.Context, logger *slog.Logger, provider string) (rulesource.LoadedRules, error) {
+	s.calls++
 	s.provider = provider
 	return s.rules, s.err
 }
@@ -304,6 +306,94 @@ rule_sets:
 	}
 	if got := sources[1].RuleSets[0].RulesetID; got != "manual-set" {
 		t.Fatalf("second ruleset: got %q, want manual-set", got)
+	}
+}
+
+func TestConfigService_FetchConfig_DisableBaselineRulesSkipsBaseline(t *testing.T) {
+	baselineRules := &fakeBaselineRuleSource{
+		rules: rulesource.LoadedRules{
+			RuleSets: []rule.RuleSet{{RulesetID: "baseline-set"}},
+		},
+	}
+	dir := t.TempDir()
+	rulesPath := writeManagerRuleBundle(t, dir, map[string]string{
+		"manual.yaml": `
+rule_sets:
+  - ruleset_id: "manual-set"
+    rules:
+      - rule_id: "manual_detect"
+        event_type: "process_exec"
+        condition: 'process_name == "sh"'
+        action: "detect"
+`,
+	})
+	server := NewServer(testLogger, ":0", testManagerTokens, &ServedConfig{
+		ConfigRevision:       "rev",
+		DisableBaselineRules: true,
+	}, rulesPath, &StartupConfig{DisableBaselineRules: true}, nil)
+	server.baselineRules = baselineRules
+	ts := newManagerHTTPTestServer(t, server.httpServer.Handler)
+	defer ts.Close()
+
+	client := managerv1beta1connect.NewConfigServiceClient(ts.Client(), ts.URL)
+	req := connect.NewRequest(&managerv1beta1.FetchConfigRequest{JobIdentity: &managerv1beta1.JobIdentity{
+		Provider:               "github",
+		ProviderHost:           "github.com",
+		ProjectPath:            "acme/example",
+		GithubRunId:            "123",
+		GithubJob:              "build",
+		GithubRunAttempt:       "1",
+		GithubRunnerTrackingId: "runner-1",
+	}})
+	req.Header().Set("Authorization", managerBearer(testManagerSecret))
+
+	resp, err := client.FetchConfig(context.Background(), req)
+	if err != nil {
+		t.Fatalf("fetch config: %v", err)
+	}
+	if baselineRules.calls != 0 {
+		t.Fatalf("baseline loader calls: got %d, want 0", baselineRules.calls)
+	}
+	sources := protoconv.FromProtoRuleSources(resp.Msg.RuleSources)
+	if got := len(sources); got != 1 {
+		t.Fatalf("rule sources: got %d, want 1", got)
+	}
+	if got := sources[0].RuleSets[0].RulesetID; got != "manual-set" {
+		t.Fatalf("ruleset: got %q, want manual-set", got)
+	}
+}
+
+func TestConfigService_FetchConfig_DisableBaselineRulesAllowsEmptyRuleSources(t *testing.T) {
+	baselineRules := &fakeBaselineRuleSource{}
+	server := NewServer(testLogger, ":0", testManagerTokens, &ServedConfig{
+		ConfigRevision:       "rev",
+		DisableBaselineRules: true,
+	}, "", &StartupConfig{DisableBaselineRules: true}, nil)
+	server.baselineRules = baselineRules
+	ts := newManagerHTTPTestServer(t, server.httpServer.Handler)
+	defer ts.Close()
+
+	client := managerv1beta1connect.NewConfigServiceClient(ts.Client(), ts.URL)
+	req := connect.NewRequest(&managerv1beta1.FetchConfigRequest{JobIdentity: &managerv1beta1.JobIdentity{
+		Provider:               "github",
+		ProviderHost:           "github.com",
+		ProjectPath:            "acme/example",
+		GithubRunId:            "123",
+		GithubJob:              "build",
+		GithubRunAttempt:       "1",
+		GithubRunnerTrackingId: "runner-1",
+	}})
+	req.Header().Set("Authorization", managerBearer(testManagerSecret))
+
+	resp, err := client.FetchConfig(context.Background(), req)
+	if err != nil {
+		t.Fatalf("fetch config: %v", err)
+	}
+	if baselineRules.calls != 0 {
+		t.Fatalf("baseline loader calls: got %d, want 0", baselineRules.calls)
+	}
+	if got := len(resp.Msg.RuleSources); got != 0 {
+		t.Fatalf("rule sources: got %d, want 0", got)
 	}
 }
 

--- a/internal/manager/startup_config.go
+++ b/internal/manager/startup_config.go
@@ -29,6 +29,7 @@ type StartupConfig struct {
 	Revision                string            `yaml:"-"`
 	Bind                    startupBindConfig `yaml:"bind"`
 	DefaultMaxAlertsPerRule int               `yaml:"default_max_alerts_per_rule,omitempty"`
+	DisableBaselineRules    bool              `yaml:"disable_baseline_rules,omitempty"`
 	Sinks                   SinksConfig       `yaml:"sinks,omitempty"`
 	Logs                    LogsConfig        `yaml:"logs,omitempty"`
 }

--- a/internal/manager/startup_config_test.go
+++ b/internal/manager/startup_config_test.go
@@ -15,6 +15,7 @@ func TestLoadStartupConfig(t *testing.T) {
 		wantPort    int
 		wantBind    string
 		wantDefault int
+		wantDisable bool
 		wantErrText string
 	}{
 		{
@@ -29,6 +30,16 @@ default_max_alerts_per_rule: 25
 			wantPort:    7443,
 			wantBind:    "127.0.0.1:7443",
 			wantDefault: 25,
+		},
+		{
+			name: "disable baseline rules is loaded",
+			content: `
+disable_baseline_rules: true
+`,
+			wantAddress: "0.0.0.0",
+			wantPort:    8080,
+			wantBind:    "0.0.0.0:8080",
+			wantDisable: true,
 		},
 		{
 			name: "missing bind address uses default",
@@ -125,6 +136,9 @@ unexpected_field: true
 			}
 			if got.DefaultMaxAlertsPerRule != tt.wantDefault {
 				t.Fatalf("default_max_alerts_per_rule: got %d, want %d", got.DefaultMaxAlertsPerRule, tt.wantDefault)
+			}
+			if got.DisableBaselineRules != tt.wantDisable {
+				t.Fatalf("disable_baseline_rules: got %v, want %v", got.DisableBaselineRules, tt.wantDisable)
 			}
 			if !strings.HasPrefix(got.Revision, "sha256:") {
 				t.Fatalf("revision: got %q, want sha256 prefix", got.Revision)


### PR DESCRIPTION
## What

Adds an explicit `disable_baseline_rules` configuration option for disabling cicd-sensor's built-in baseline rule fetch/prepend behavior.

## Background
#22 