### PR TITLE
Add monitor mode for safe rule rollout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,7 +43,7 @@ The files below add detail that only applies when touching specific paths. **The
 | `cmd/cicd-sensor-manager` | Manager server |
 | `cmd/cicd-sensorctl` | Report / attestation / rule validation CLI |
 | `internal/agent` | Agent runtime (Listener, JobRegistry, Job, Scope, KernelTracker) |
-| `internal/rule` | RuleSet / RuleModifier schema, merge, CEL compile and evaluate |
+| `internal/rule` | RuleSet / RuleModifier schema, resolution, CEL compile and evaluate |
 | `internal/manager` | Config service, collector ingest, output routing |
 | `internal/ctl` | Report and attestation generation |
 | `proto/` | Connect / protobuf wire schema |

--- a/cmd/cicd-sensor-manager/main.go
+++ b/cmd/cicd-sensor-manager/main.go
@@ -229,6 +229,7 @@ func buildServedConfig(startup manager.StartupConfig, outputSettings *managerv1b
 		ConfigRevision:          startup.Revision,
 		DefaultMaxAlertsPerRule: startup.DefaultMaxAlertsPerRule,
 		DisableBaselineRules:    startup.DisableBaselineRules,
+		MonitorMode:             startup.MonitorMode,
 		OutputSettings:          outputSettings,
 	}
 }

--- a/cmd/cicd-sensor-manager/main_test.go
+++ b/cmd/cicd-sensor-manager/main_test.go
@@ -276,6 +276,7 @@ func TestBuildServedConfig(t *testing.T) {
 		Revision:                "sha256:config",
 		DefaultMaxAlertsPerRule: 7,
 		DisableBaselineRules:    true,
+		MonitorMode:             true,
 	}
 	settings := &managerv1beta1.OutputSettings{
 		Detection: &managerv1beta1.OutputSetting{
@@ -300,6 +301,9 @@ func TestBuildServedConfig(t *testing.T) {
 	}
 	if !served.DisableBaselineRules {
 		t.Fatalf("DisableBaselineRules: got false, want true")
+	}
+	if !served.MonitorMode {
+		t.Fatalf("MonitorMode: got false, want true")
 	}
 	if !served.OutputSettings.GetDetection().GetEnabled() {
 		t.Fatalf("detection settings: got false, want true")

--- a/cmd/cicd-sensor/project.go
+++ b/cmd/cicd-sensor/project.go
@@ -260,6 +260,9 @@ func buildProjectStartRequest(identity jobIdentityFlags, metadata jobMetadataFla
 		if projectConfig.DisableBaselineRules {
 			req["disable_baseline_rules"] = true
 		}
+		if projectConfig.MonitorMode {
+			req["monitor_mode"] = true
+		}
 	}
 
 	if rulesFile != "" {

--- a/cmd/cicd-sensor/project_test.go
+++ b/cmd/cicd-sensor/project_test.go
@@ -124,6 +124,21 @@ func TestBuildProjectStartRequest_ConfigDisablesBaselineRules(t *testing.T) {
 	}
 }
 
+func TestBuildProjectStartRequest_ConfigEnablesMonitorMode(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "project.yaml")
+	if err := os.WriteFile(configPath, []byte("monitor_mode: true\n"), 0o644); err != nil {
+		t.Fatalf("write project config: %v", err)
+	}
+
+	got, err := buildProjectStartRequest(githubIdentity(), jobMetadataFlags{}, configPath, "", managerConnectionConfig{}, false)
+	if err != nil {
+		t.Fatalf("buildProjectStartRequest: %v", err)
+	}
+	if got["monitor_mode"] != true {
+		t.Fatalf("monitor_mode: got %#v, want true", got["monitor_mode"])
+	}
+}
+
 func TestBuildProjectStartRequest_EmptyProjectConfigOmitsDefaultMaxAlerts(t *testing.T) {
 	configPath := filepath.Join(t.TempDir(), "project.yaml")
 	if err := os.WriteFile(configPath, []byte("{}\n"), 0o644); err != nil {
@@ -136,6 +151,9 @@ func TestBuildProjectStartRequest_EmptyProjectConfigOmitsDefaultMaxAlerts(t *tes
 	}
 	if _, ok := got["default_max_alerts_per_rule"]; ok {
 		t.Fatalf("default_max_alerts_per_rule: got unexpected field %#v", got["default_max_alerts_per_rule"])
+	}
+	if _, ok := got["monitor_mode"]; ok {
+		t.Fatalf("monitor_mode: got unexpected field %#v", got["monitor_mode"])
 	}
 }
 
@@ -151,6 +169,21 @@ func TestBuildProjectStartRequest_ZeroDefaultMaxAlertsIsUnset(t *testing.T) {
 	}
 	if _, ok := got["default_max_alerts_per_rule"]; ok {
 		t.Fatalf("default_max_alerts_per_rule: got unexpected field %#v", got["default_max_alerts_per_rule"])
+	}
+}
+
+func TestBuildProjectStartRequest_FalseMonitorModeIsUnset(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "project.yaml")
+	if err := os.WriteFile(configPath, []byte("monitor_mode: false\n"), 0o644); err != nil {
+		t.Fatalf("write project config: %v", err)
+	}
+
+	got, err := buildProjectStartRequest(githubIdentity(), jobMetadataFlags{}, configPath, "", managerConnectionConfig{}, false)
+	if err != nil {
+		t.Fatalf("buildProjectStartRequest: %v", err)
+	}
+	if _, ok := got["monitor_mode"]; ok {
+		t.Fatalf("monitor_mode: got unexpected field %#v", got["monitor_mode"])
 	}
 }
 

--- a/cmd/cicd-sensorctl/rule_validate.go
+++ b/cmd/cicd-sensorctl/rule_validate.go
@@ -39,11 +39,11 @@ func runRuleValidate(_ context.Context, args []string, stdout, stderr io.Writer)
 		printValidationErrors(stderr, []validationError{{Path: "bundle", Message: err.Error()}})
 		return 1, fmt.Errorf("rule validate: bundle failed validation")
 	}
-	merged := rule.Merge(rule.MergeInput{
+	resolved := rule.Resolve(rule.ResolveInput{
 		RuleSets:      loaded.RuleSets,
 		RuleModifiers: loaded.RuleModifiers,
 	})
-	printMergeWarnings(stderr, merged.Warnings)
+	printResolveWarnings(stderr, resolved.Warnings)
 
 	env, err := celengine.NewEnv()
 	if err != nil {
@@ -112,7 +112,7 @@ func printValidationErrors(stderr io.Writer, failures []validationError) {
 	}
 }
 
-func printMergeWarnings(stderr io.Writer, warnings []rule.MergeWarning) {
+func printResolveWarnings(stderr io.Writer, warnings []rule.ResolveWarning) {
 	for _, warning := range warnings {
 		if warning.Identity.RulesetID != "" && warning.Identity.RuleID != "" {
 			fmt.Fprintf(stderr, "warning: bundle: ruleset_id=%s rule_id=%s: %s\n", warning.Identity.RulesetID, warning.Identity.RuleID, warning.Kind)

--- a/docs/developer-guide/agent-ownership-boundaries.md
+++ b/docs/developer-guide/agent-ownership-boundaries.md
@@ -47,7 +47,7 @@ Each `Job` owns its own scope states: up to one host `JobScopeState` built by `A
 
 Scope state is therefore **per Job**, not shared across the registry.
 Host and project scope states attached to a Job never read or write each other.
-Rule actions, including `terminate`, only emit detections; the Job ends through external triggers (Runner termination, cgroup removal).
+Rule actions are resolved per scope before per-Job evaluation; `monitor_mode` must be applied before evaluation merging so a scope can downgrade its own `terminate` rules without changing another scope's policy.
 
 ## Where each type holds state
 
@@ -87,7 +87,7 @@ Per-scope config does not become a Job-level field: it lives on the referenced `
 
 | Holds | Does not hold |
 | --- | --- |
-| <ul><li>`Type`: host or project</li><li>`RuleSets`</li><li>`RuleModifiers`</li><li>`ConfigRevision`</li><li>`OutputSettings`</li><li>`ResolvedRules`</li><li>`Observations`</li><li>`DefaultMaxAlertsPerRule`</li><li>scope-local manager job-log routing</li></ul> | <ul><li>state that assumes host and project share it</li></ul> |
+| <ul><li>`Type`: host or project</li><li>`RuleSets`</li><li>`RuleModifiers`</li><li>`ConfigRevision`</li><li>`OutputSettings`</li><li>`ResolvedRules`</li><li>`Observations`</li><li>`DefaultMaxAlertsPerRule`</li><li>`MonitorMode`</li><li>scope-local manager job-log routing</li></ul> | <ul><li>state that assumes host and project share it</li></ul> |
 
 If host and project could diverge in the future, the value is scope-local from the start. Equal values today are not a reason to hoist. Shared queues, connection reuse, and similar optimizations come after ownership is clear.
 

--- a/docs/developer-guide/agent-ownership-boundaries.md
+++ b/docs/developer-guide/agent-ownership-boundaries.md
@@ -47,7 +47,7 @@ Each `Job` owns its own scope states: up to one host `JobScopeState` built by `A
 
 Scope state is therefore **per Job**, not shared across the registry.
 Host and project scope states attached to a Job never read or write each other.
-Rule actions are resolved per scope before per-Job evaluation; `monitor_mode` must be applied before evaluation merging so a scope can downgrade its own `terminate` rules without changing another scope's policy.
+Rule actions are resolved per scope before per-Job evaluation; `monitor_mode` must be applied before cross-scope evaluation merging so a scope can downgrade its own `terminate` rules without changing another scope's policy.
 
 ## Where each type holds state
 
@@ -101,7 +101,7 @@ Configuration flows along the diagram's edges: host config from the host operato
 
 Host scope and project scope are separate rule sets, but they normally overlap heavily in practice: both sides typically include the same Baseline rules independently. Evaluating the same compiled rule twice (once per scope) would scale the CEL hot path with the number of scopes for no behavioural gain.
 
-Rule evaluation is therefore done **per Job, not per scope**: `mergeEvaluationRules` de-duplicates rules across the Job's host and project `JobScopeState`s, `NewEvaluationState` compiles the merged set once, and each event is evaluated against that merged set in a single pass by the Job's one event worker. Per-rule `FeedHost` / `FeedProject` flags then route each hit back to the host `JobScopeState`, the project `JobScopeState`, or both. Scope isolation is preserved in the **output routing**, not by duplicating evaluation per scope.
+Rule evaluation is therefore done **per Job, not per scope**: `mergeEvaluationRules` de-duplicates scope-resolved rules across the Job's host and project `JobScopeState`s, `NewEvaluationState` compiles the evaluation-merged set once, and each event is evaluated against that evaluation-merged set in a single pass by the Job's one event worker. Per-rule `FeedHost` / `FeedProject` flags then route each hit back to the host `JobScopeState`, the project `JobScopeState`, or both. Scope isolation is preserved in the **output routing**, not by duplicating evaluation per scope.
 
 For job lifecycle and tracking entrypoints, see [Agent Architecture](agent.md).
 For kernel-side observation details, see [eBPF Runtime](ebpf-runtime.md).

--- a/docs/developer-guide/manager.md
+++ b/docs/developer-guide/manager.md
@@ -71,7 +71,7 @@ The Manager process accepts file locations through either CLI flags or environme
 Only file locations are accepted through this CLI / environment interface.
 The settings themselves live in `manager.yaml`; custom rules live in the rule bundle file.
 
-Rule sources returned by the Manager are merged and compiled by the Agent.
+Rule sources returned by the Manager are resolved into scope-local rules and compiled by the Agent.
 The Manager holds the rule bundle, but it does not evaluate runtime events.
 
 ## Log ingest and outputs

--- a/docs/developer-guide/overview.md
+++ b/docs/developer-guide/overview.md
@@ -13,7 +13,7 @@ The goal is to understand the main subsystem responsibilities and boundaries.
 | `cmd/cicd-sensor-manager` | Manager server |
 | `cmd/cicd-sensorctl` | Utility CLI for reports, attestations, rule validation, and related tasks |
 | `internal/agent` | Agent runtime that observes CI/CD job runtime |
-| `internal/rule` | RuleSet / RuleModifier schema, merge, CEL compile, and evaluation |
+| `internal/rule` | RuleSet / RuleModifier schema, resolution, CEL compile, and evaluation |
 | `internal/manager` | Config service, collector ingest, and output routing |
 | `internal/ctl` | Report and attestation generation |
 

--- a/docs/developer-guide/rule-engine.md
+++ b/docs/developer-guide/rule-engine.md
@@ -10,13 +10,13 @@ This page explains how that surface maps to the implementation.
 ```mermaid
 flowchart LR
     SRC["Rule sources<br/>baseline / local / manager"]
-    MERGE["RuleSet / RuleModifier merge"]
+    RESOLVE["RuleSet / RuleModifier resolution"]
     COMPILE["CEL compile"]
     EVAL["EvaluationState"]
     EVENT["Runtime EventRecord"]
     LOGS["Detection / runtime event logs"]
 
-    SRC --> MERGE --> COMPILE --> EVAL
+    SRC --> RESOLVE --> COMPILE --> EVAL
     EVENT --> EVAL --> LOGS
 ```
 
@@ -25,7 +25,7 @@ flowchart LR
 | Area | Responsibility |
 | --- | --- |
 | Schema | YAML schema validation for RuleSet / RuleModifier |
-| Merge | Merge baseline, local, and manager rule sources with modifiers |
+| Resolution | Resolve rule sources with modifiers |
 | CEL | Build activations per event type and compile conditions / correlations |
 | Evaluation | Evaluate runtime events against rules and apply actions / tags / max alerts |
 | Correlation | Multi-signal detection with `rule.<rule_id>.total_count` |

--- a/docs/user-guide/github-hosted.md
+++ b/docs/user-guide/github-hosted.md
@@ -74,12 +74,14 @@ Use project-local files only for repository-specific tuning or additional detect
 ```yaml
 default_max_alerts_per_rule: 20
 disable_baseline_rules: false
+monitor_mode: true
 ```
 
 | Field | Meaning |
 | --- | --- |
 | `default_max_alerts_per_rule` | Default Detection Log limit for rules that do not set `max_alerts`. Allowed values are 1-100. |
 | `disable_baseline_rules` | Disable cicd-sensor baseline rules for standalone project-local mode. Defaults to `false`. |
+| `monitor_mode` | Treat `terminate` rules as `detect` rules. Recommended for first rollout. Defaults to `false`. |
 
 See [RuleSet max_alerts](rule-set.md#max_alerts) for per-rule limits.
 

--- a/docs/user-guide/github-hosted.md
+++ b/docs/user-guide/github-hosted.md
@@ -120,7 +120,7 @@ In this mode, the cicd-sensor Agent can still generate the HTML report and attes
 
 Important: when `manager-url` is set, repository-local `.cicd-sensor/config.yaml` and `.cicd-sensor/rules/` are not used.
 Config and rules are fetched from the manager.
-Repository-local rules and manager rules are not merged together.
+Repository-local rules and manager rules are not combined.
 Baseline policy is also owned by the manager, not by repository-local config.
 
 ```yaml

--- a/docs/user-guide/manager.md
+++ b/docs/user-guide/manager.md
@@ -137,6 +137,7 @@ bind:
 
 default_max_alerts_per_rule: 10
 disable_baseline_rules: false
+monitor_mode: false
 
 sinks:
   s3-out:
@@ -164,6 +165,7 @@ For richer routing (per-log-kind destinations, multiple sinks), see
 | `bind` | Manager listen address and port. `bind.port` must be in 0-65535. | `address: "0.0.0.0"`, `port: 8080` | Manager restart |
 | `default_max_alerts_per_rule` | Default per-rule Detection Log limit for rules that do not set `max_alerts`. Use 1-100 to set a value; omit it or set 0 to use the system default. | `10` | Manager restart |
 | `disable_baseline_rules` | Disable cicd-sensor baseline rule fetch/prepend when using the manager. Custom rule bundles from `--rules-file` are still served. | `false` | Manager restart |
+| `monitor_mode` | Treat `terminate` rules as `detect` rules. Use this for first rollout or collection-only operation without job stopping. | `false` | Manager restart |
 | `sinks` | Physical cloud output destinations, such as S3, GCS, or Pub/Sub. | none | Manager restart |
 | `logs` | Mapping from each manager-ingested `log_type` to one configured sink. | none | Manager restart |
 

--- a/docs/user-guide/rule-modifiers.md
+++ b/docs/user-guide/rule-modifiers.md
@@ -51,6 +51,7 @@ targets:
 
 Use this when you want to change how a rule is displayed or handled as `detect`, `collect`, or `terminate`.
 Both `detect` and `collect` are emitted to the Detection Log, but they appear as different actions in reports and logs.
+When `monitor_mode` is enabled, `override_action: terminate` is treated as `detect`.
 
 ```yaml
 rule_modifiers:

--- a/docs/user-guide/rule-set.md
+++ b/docs/user-guide/rule-set.md
@@ -83,6 +83,8 @@ See [Correlation](rule-correlation.md) for details.
 | `collect` | Record as a signal for investigation or correlation | emitted |
 | `terminate` | Attempt to stop the job | emitted |
 
+When `monitor_mode` is enabled, `terminate` rules are treated as `detect`.
+
 Today, the difference between `detect` and `collect` is how they are displayed in reports and logs.
 Both are emitted to the Detection Log.
 

--- a/internal/agent/correlation_test.go
+++ b/internal/agent/correlation_test.go
@@ -452,7 +452,7 @@ func TestEvaluateEvent_CorrelationAggregatesIdentityCollisionHits(t *testing.T) 
 				RulesetID: "shared-set",
 			},
 		},
-		Warnings: []rule.MergeWarning{{
+		Warnings: []rule.ResolveWarning{{
 			Kind:     "duplicate_identity_diff_content",
 			Identity: rule.RuleIdentity{RulesetID: "shared-set", RuleID: "x"},
 		}},

--- a/internal/agent/evaluation/compile.go
+++ b/internal/agent/evaluation/compile.go
@@ -11,7 +11,7 @@ import (
 func compileRuleExceptions(env *celengine.Env, resolved rule.ResolvedRule) ([]celengine.CompiledException, error) {
 	var out []celengine.CompiledException
 
-	// resolved is scope-local after rule.Merge. Shared host/project entries
+	// resolved is scope-local after rule.Resolve. Shared host/project entries
 	// reach here only when their exception clauses are content-equivalent.
 	if strings.TrimSpace(resolved.Rule.Exceptions) != "" {
 		prog, err := env.Compile(resolved.CanonicalRuleID.String(), resolved.Rule.EventType, resolved.Rule.Exceptions, resolved.PredefinedLists)
@@ -50,7 +50,7 @@ func compileAndMergeEvaluationCorrelations(host, project *rule.ResolvedRules, en
 
 	// Correlations compile per scope because rule refs resolve against that
 	// scope's enabled rules, then equivalent host/project correlations share CEL.
-	// Scope-local duplicates are resolved by rule.Merge. This tracks the first
+	// Scope-local duplicates are resolved by rule.Resolve. This tracks the first
 	// out index for each canonical ID so equivalent correlations share CEL.
 	sharedEvalIndexByCanonical := make(map[rule.CanonicalRuleID]int)
 	out := make([]compiledCorrelationEntry, 0)
@@ -138,8 +138,8 @@ func dropPreviousCompileWarnings(rr *rule.ResolvedRules) {
 		return
 	}
 
-	// Rebuilds reuse scope state, so preserve merge warnings and refresh only
-	// compile warnings.
+	// Rebuilds reuse scope state, so preserve resolution warnings and refresh
+	// only compile warnings.
 	filtered := rr.Warnings[:0]
 	for _, warning := range rr.Warnings {
 		if warning.Kind == "compile_error" {
@@ -164,7 +164,7 @@ func appendCompileWarning(rr *rule.ResolvedRules, resolvedRule rule.ResolvedRule
 		return
 	}
 
-	rr.Warnings = append(rr.Warnings, rule.MergeWarning{
+	rr.Warnings = append(rr.Warnings, rule.ResolveWarning{
 		Kind:     "compile_error",
 		Identity: resolvedRule.Identity(),
 		Reason:   reason,

--- a/internal/agent/evaluation/merge.go
+++ b/internal/agent/evaluation/merge.go
@@ -30,7 +30,7 @@ func mergeEvaluationRules(host, project *rule.ResolvedRules) []compiledRuleEntry
 		projectRules = project.Rules
 	}
 
-	// Scope-local duplicates are resolved by rule.Merge. This tracks the first
+	// Scope-local duplicates are resolved by rule.Resolve. This tracks the first
 	// out index for each canonical ID so equivalent host/project rules share CEL.
 	sharedEvalIndexByCanonical := make(map[rule.CanonicalRuleID]int)
 	out := make([]compiledRuleEntry, 0, len(hostRules)+len(projectRules))

--- a/internal/agent/evaluation/state.go
+++ b/internal/agent/evaluation/state.go
@@ -21,7 +21,7 @@ type EvaluationState struct {
 	Correlations []celengine.CompiledCorrelation
 }
 
-// NewEvaluationState merges host/project rules and compiles CEL programs.
+// NewEvaluationState merges scope-resolved host/project rules and compiles CEL programs.
 // Compile warnings are written back to the originating ResolvedRules.
 func NewEvaluationState(host, project *rule.ResolvedRules) *EvaluationState {
 	dropPreviousCompileWarnings(host)

--- a/internal/agent/jobregistry/jobregistry.go
+++ b/internal/agent/jobregistry/jobregistry.go
@@ -233,6 +233,7 @@ func managerConfigFromFetchResult(result *managerclient.FetchResult) jobscope.Ma
 		ConfigRevision:          result.ConfigRevision,
 		OutputSettings:          result.OutputSettings,
 		DefaultMaxAlertsPerRule: result.DefaultMaxAlertsPerRule,
+		MonitorMode:             result.MonitorMode,
 	}
 }
 

--- a/internal/agent/jobregistry/project_start.go
+++ b/internal/agent/jobregistry/project_start.go
@@ -19,6 +19,7 @@ type GitHubProjectStartConfig struct {
 	PeerPID                 int32
 	DefaultMaxAlertsPerRule int
 	DisableBaselineRules    bool
+	MonitorMode             bool
 	RuleSources             []rulesource.LoadedRules
 	ManagerConnection       managerclient.Connection
 	ManagerClient           ManagerConfigFetcher
@@ -60,7 +61,7 @@ func (jr *JobRegistry) attachGitHubProjectScopeToExistingJob(
 	if cfg.ManagerClient != nil {
 		projectScope, err = jr.buildProjectScopeFromManagerConfig(ctx, cfg.Identity, cfg.Metadata, cfg.RunnerType, cfg.ManagerConnection, cfg.ManagerClient)
 	} else {
-		projectScope, err = jr.buildProjectScopeFromLocalConfig(ctx, cfg.Identity, cfg.DefaultMaxAlertsPerRule, cfg.DisableBaselineRules, cfg.RuleSources)
+		projectScope, err = jr.buildProjectScopeFromLocalConfig(ctx, cfg.Identity, cfg)
 	}
 	if err != nil {
 		return nil, err
@@ -82,7 +83,7 @@ func (jr *JobRegistry) startGitHubProjectOnlyJob(
 	if cfg.ManagerClient != nil {
 		projectScope, err = jr.buildProjectScopeFromManagerConfig(ctx, cfg.Identity, cfg.Metadata, cfg.RunnerType, cfg.ManagerConnection, cfg.ManagerClient)
 	} else {
-		projectScope, err = jr.buildProjectScopeFromLocalConfig(ctx, cfg.Identity, cfg.DefaultMaxAlertsPerRule, cfg.DisableBaselineRules, cfg.RuleSources)
+		projectScope, err = jr.buildProjectScopeFromLocalConfig(ctx, cfg.Identity, cfg)
 	}
 	if err != nil {
 		return nil, err
@@ -139,9 +140,9 @@ func (jr *JobRegistry) buildProjectScopeFromManagerConfig(ctx context.Context, i
 }
 
 // buildProjectScopeFromLocalConfig builds a resolved project scope from project-local config.
-func (jr *JobRegistry) buildProjectScopeFromLocalConfig(ctx context.Context, identity jobcontext.JobIdentity, projectDefaultMaxAlertsPerRule int, disableBaselineRules bool, projectRuleSources []rulesource.LoadedRules) (*jobscope.JobScopeState, error) {
+func (jr *JobRegistry) buildProjectScopeFromLocalConfig(ctx context.Context, identity jobcontext.JobIdentity, cfg GitHubProjectStartConfig) (*jobscope.JobScopeState, error) {
 	projectScope := jobscope.NewProject()
-	if !disableBaselineRules {
+	if !cfg.DisableBaselineRules {
 		baselineSource, err := jr.loadBaselineRules(ctx, identity)
 		if err != nil {
 			return nil, err
@@ -151,8 +152,9 @@ func (jr *JobRegistry) buildProjectScopeFromLocalConfig(ctx context.Context, ide
 		}
 	}
 	if err := projectScope.ApplyProjectLocalConfig(jobscope.ProjectLocalConfig{
-		RuleSources:             projectRuleSources,
-		DefaultMaxAlertsPerRule: projectDefaultMaxAlertsPerRule,
+		RuleSources:             cfg.RuleSources,
+		DefaultMaxAlertsPerRule: cfg.DefaultMaxAlertsPerRule,
+		MonitorMode:             cfg.MonitorMode,
 	}); err != nil {
 		return nil, err
 	}

--- a/internal/agent/jobregistry/project_start_internal_test.go
+++ b/internal/agent/jobregistry/project_start_internal_test.go
@@ -27,17 +27,20 @@ func TestBuildProjectScopeFromLocalConfigCanAddBaselineFallback(t *testing.T) {
 		}}}, nil
 	})
 
-	scope, err := jr.buildProjectScopeFromLocalConfig(testCtx, id, 7, false, []rulesource.LoadedRules{{
-		RuleSets: []rule.RuleSet{{
-			RulesetID: "project",
-			Rules: []rule.Rule{{
-				RuleID:    "project_exec",
-				EventType: jobevent.ProcessExec,
-				Condition: `process_name == "go"`,
-				Action:    rule.RuleActionDetect,
+	scope, err := jr.buildProjectScopeFromLocalConfig(testCtx, id, GitHubProjectStartConfig{
+		DefaultMaxAlertsPerRule: 7,
+		RuleSources: []rulesource.LoadedRules{{
+			RuleSets: []rule.RuleSet{{
+				RulesetID: "project",
+				Rules: []rule.Rule{{
+					RuleID:    "project_exec",
+					EventType: jobevent.ProcessExec,
+					Condition: `process_name == "go"`,
+					Action:    rule.RuleActionDetect,
+				}},
 			}},
 		}},
-	}})
+	})
 	if err != nil {
 		t.Fatalf("buildProjectScopeFromLocalConfig: %v", err)
 	}
@@ -67,17 +70,19 @@ func TestBuildProjectScopeFromLocalConfigKeepsBaselineFirst(t *testing.T) {
 		}}}, nil
 	})
 
-	scope, err := jr.buildProjectScopeFromLocalConfig(testCtx, id, 0, false, []rulesource.LoadedRules{{
-		RuleSets: []rule.RuleSet{{
-			RulesetID: "shared",
-			Rules: []rule.Rule{{
-				RuleID:    "duplicate",
-				EventType: jobevent.ProcessExec,
-				Condition: `process_name == "project"`,
-				Action:    rule.RuleActionDetect,
+	scope, err := jr.buildProjectScopeFromLocalConfig(testCtx, id, GitHubProjectStartConfig{
+		RuleSources: []rulesource.LoadedRules{{
+			RuleSets: []rule.RuleSet{{
+				RulesetID: "shared",
+				Rules: []rule.Rule{{
+					RuleID:    "duplicate",
+					EventType: jobevent.ProcessExec,
+					Condition: `process_name == "project"`,
+					Action:    rule.RuleActionDetect,
+				}},
 			}},
 		}},
-	}})
+	})
 	if err != nil {
 		t.Fatalf("buildProjectScopeFromLocalConfig: %v", err)
 	}
@@ -98,17 +103,21 @@ func TestBuildProjectScopeFromLocalConfigCanDisableBaseline(t *testing.T) {
 		return rulesource.LoadedRules{}, nil
 	})
 
-	scope, err := jr.buildProjectScopeFromLocalConfig(testCtx, id, 7, true, []rulesource.LoadedRules{{
-		RuleSets: []rule.RuleSet{{
-			RulesetID: "project",
-			Rules: []rule.Rule{{
-				RuleID:    "project_exec",
-				EventType: jobevent.ProcessExec,
-				Condition: `process_name == "go"`,
-				Action:    rule.RuleActionDetect,
+	scope, err := jr.buildProjectScopeFromLocalConfig(testCtx, id, GitHubProjectStartConfig{
+		DefaultMaxAlertsPerRule: 7,
+		DisableBaselineRules:    true,
+		RuleSources: []rulesource.LoadedRules{{
+			RuleSets: []rule.RuleSet{{
+				RulesetID: "project",
+				Rules: []rule.Rule{{
+					RuleID:    "project_exec",
+					EventType: jobevent.ProcessExec,
+					Condition: `process_name == "go"`,
+					Action:    rule.RuleActionDetect,
+				}},
 			}},
 		}},
-	}})
+	})
 	if err != nil {
 		t.Fatalf("buildProjectScopeFromLocalConfig: %v", err)
 	}
@@ -123,6 +132,41 @@ func TestBuildProjectScopeFromLocalConfigCanDisableBaseline(t *testing.T) {
 	}
 	if got := len(scope.ResolvedRules.Rules); got != 1 {
 		t.Fatalf("resolved rules: got %d, want 1", got)
+	}
+}
+
+func TestBuildProjectScopeFromLocalConfigMonitorModeDowngradesTerminate(t *testing.T) {
+	jr := newTestJobRegistry()
+	id := jobcontext.GitHubJobIdentity("github.com", "acme/example", "1", "build", "1", "runner-1")
+	jr.SetBaselineLoadForTesting(func(context.Context, *slog.Logger, string) (rulesource.LoadedRules, error) {
+		t.Fatal("baseline loader should not be called when baseline rules are disabled")
+		return rulesource.LoadedRules{}, nil
+	})
+
+	scope, err := jr.buildProjectScopeFromLocalConfig(testCtx, id, GitHubProjectStartConfig{
+		DisableBaselineRules: true,
+		MonitorMode:          true,
+		RuleSources: []rulesource.LoadedRules{{
+			RuleSets: []rule.RuleSet{{
+				RulesetID: "project",
+				Rules: []rule.Rule{{
+					RuleID:    "project_exec",
+					EventType: jobevent.ProcessExec,
+					Condition: `process_name == "go"`,
+					Action:    rule.RuleActionTerminate,
+				}},
+			}},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("buildProjectScopeFromLocalConfig: %v", err)
+	}
+	resolved, ok := scope.ResolvedRules.Lookup(rule.RuleIdentity{RulesetID: "project", RuleID: "project_exec"})
+	if !ok {
+		t.Fatal("project rule was not resolved")
+	}
+	if got := resolved.Rule.Action; got != rule.RuleActionDetect {
+		t.Fatalf("action: got %q, want %q", got, rule.RuleActionDetect)
 	}
 }
 

--- a/internal/agent/jobscope/manager_config_test.go
+++ b/internal/agent/jobscope/manager_config_test.go
@@ -31,6 +31,7 @@ func TestJobScopeState_ApplyManagerConfig_AppendsAndResolvesHostScope(t *testing
 
 	cfg := jobscope.ManagerConfig{
 		ConfigRevision: "sha256:test",
+		MonitorMode:    true,
 		RuleSources: []rulesource.LoadedRules{{
 			RuleSets: []rule.RuleSet{{
 				RulesetID: "manager-set",
@@ -62,6 +63,13 @@ func TestJobScopeState_ApplyManagerConfig_AppendsAndResolvesHostScope(t *testing
 	}
 	if len(scope.ResolvedRules.Rules) != 2 {
 		t.Fatalf("resolved rules: got %d, want 2", len(scope.ResolvedRules.Rules))
+	}
+	resolved, ok := scope.ResolvedRules.Lookup(rule.RuleIdentity{RulesetID: "manager-set", RuleID: "manager-rule"})
+	if !ok {
+		t.Fatal("manager rule was not resolved")
+	}
+	if got := resolved.Rule.Action; got != rule.RuleActionDetect {
+		t.Fatalf("manager rule action: got %q, want %q", got, rule.RuleActionDetect)
 	}
 }
 
@@ -110,6 +118,7 @@ func TestJobScopeState_ApplyProjectLocalConfig(t *testing.T) {
 
 	err := scope.ApplyProjectLocalConfig(jobscope.ProjectLocalConfig{
 		DefaultMaxAlertsPerRule: 12,
+		MonitorMode:             true,
 		RuleSources: []rulesource.LoadedRules{{
 			RuleSets: []rule.RuleSet{{RulesetID: "project-set"}},
 		}},
@@ -122,6 +131,9 @@ func TestJobScopeState_ApplyProjectLocalConfig(t *testing.T) {
 	}
 	if len(scope.RuleSets) != 1 || scope.RuleSets[0].RulesetID != "project-set" {
 		t.Fatalf("project rule sets: %#v", scope.RuleSets)
+	}
+	if !scope.MonitorMode {
+		t.Fatal("monitor mode: got false, want true")
 	}
 }
 

--- a/internal/agent/jobscope/state.go
+++ b/internal/agent/jobscope/state.go
@@ -31,7 +31,7 @@ type JobScopeState struct {
 	Observations   *observations.State
 	managerJobLogs joblogs.ManagerJobLogs
 	debugOutput    *joblogs.DebugOutput
-	// Zero means this scope did not configure a default; rule.Merge uses the system fallback.
+	// Zero means this scope did not configure a default; rule.Resolve uses the system fallback.
 	DefaultMaxAlertsPerRule int
 	// MonitorMode downgrades terminate actions to detect when rules are resolved.
 	MonitorMode bool
@@ -122,7 +122,7 @@ func (s *JobScopeState) ApplyBaselineRules(source rulesource.LoadedRules) error 
 }
 
 func (s *JobScopeState) ResolveRules(identity jobcontext.JobIdentity) {
-	s.ResolvedRules = rule.Merge(rule.MergeInput{
+	s.ResolvedRules = rule.Resolve(rule.ResolveInput{
 		RuleSets:                s.RuleSets,
 		RuleModifiers:           s.RuleModifiers,
 		DefaultMaxAlertsPerRule: s.DefaultMaxAlertsPerRule,

--- a/internal/agent/jobscope/state.go
+++ b/internal/agent/jobscope/state.go
@@ -33,6 +33,8 @@ type JobScopeState struct {
 	debugOutput    *joblogs.DebugOutput
 	// Zero means this scope did not configure a default; rule.Merge uses the system fallback.
 	DefaultMaxAlertsPerRule int
+	// MonitorMode downgrades terminate actions to detect when rules are resolved.
+	MonitorMode bool
 }
 
 // ProjectLocalConfig is only for project-local mode. Manager-backed project
@@ -40,6 +42,7 @@ type JobScopeState struct {
 type ProjectLocalConfig struct {
 	RuleSources             []rulesource.LoadedRules
 	DefaultMaxAlertsPerRule int
+	MonitorMode             bool
 }
 
 // ManagerConfig is the config payload returned by cicd-sensor-manager.
@@ -48,6 +51,7 @@ type ManagerConfig struct {
 	ConfigRevision          string
 	OutputSettings          *managerv1beta1.OutputSettings
 	DefaultMaxAlertsPerRule int
+	MonitorMode             bool
 }
 
 func NewHost() *JobScopeState {
@@ -87,6 +91,7 @@ func (s *JobScopeState) ApplyProjectLocalConfig(cfg ProjectLocalConfig) error {
 	if cfg.DefaultMaxAlertsPerRule != 0 {
 		s.DefaultMaxAlertsPerRule = cfg.DefaultMaxAlertsPerRule
 	}
+	s.MonitorMode = cfg.MonitorMode
 	return nil
 }
 
@@ -103,6 +108,7 @@ func (s *JobScopeState) ApplyManagerConfig(cfg ManagerConfig) error {
 	if cfg.DefaultMaxAlertsPerRule != 0 {
 		s.DefaultMaxAlertsPerRule = cfg.DefaultMaxAlertsPerRule
 	}
+	s.MonitorMode = cfg.MonitorMode
 	return nil
 }
 
@@ -120,6 +126,7 @@ func (s *JobScopeState) ResolveRules(identity jobcontext.JobIdentity) {
 		RuleSets:                s.RuleSets,
 		RuleModifiers:           s.RuleModifiers,
 		DefaultMaxAlertsPerRule: s.DefaultMaxAlertsPerRule,
+		MonitorMode:             s.MonitorMode,
 		ProviderHost:            identity.ProviderHost,
 		ProjectPath:             identity.ProjectPath,
 	})

--- a/internal/agent/listener/github.go
+++ b/internal/agent/listener/github.go
@@ -96,6 +96,7 @@ func (l *Listener) handleGitHubProjectStart(w http.ResponseWriter, r *http.Reque
 		PeerPID:                 peerPID,
 		DefaultMaxAlertsPerRule: req.DefaultMaxAlertsPerRule,
 		DisableBaselineRules:    req.DisableBaselineRules,
+		MonitorMode:             req.MonitorMode,
 		RuleSources:             req.RuleSources,
 		ManagerConnection:       managerConnection,
 		ManagerClient:           projectManagerClient,

--- a/internal/agent/listener/github_test.go
+++ b/internal/agent/listener/github_test.go
@@ -717,6 +717,56 @@ func TestListener_ProjectStart_AcceptsProjectRules(t *testing.T) {
 	}
 }
 
+func TestListener_ProjectStart_MonitorModeDowngradesTerminate(t *testing.T) {
+	client, jobRegistry, cleanup := setupListenerWithRegistry(t)
+	defer cleanup()
+
+	body, _ := json.Marshal(map[string]any{
+		"provider":                  "github",
+		"provider_host":             "github.com",
+		"project_path":              "acme/example",
+		"github_run_id":             "123456789",
+		"github_job":                "build",
+		"github_run_attempt":        "1",
+		"github_runner_tracking_id": "github_tracking_monitor_mode",
+		"disable_baseline_rules":    true,
+		"monitor_mode":              true,
+		"rule_sources": []rulesource.LoadedRules{{
+			RuleSets: []rule.RuleSet{{
+				RulesetID: "project",
+				Rules: []rule.Rule{{
+					RuleID:    "terminate_exec",
+					EventType: jobevent.ProcessExec,
+					Condition: `process_name == "bash"`,
+					Action:    rule.RuleActionTerminate,
+				}},
+			}},
+		}},
+	})
+	resp, err := client.Post("http://cicd-sensor/v1/github/project/start", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status: got %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+
+	id := jobcontext.GitHubJobIdentity("github.com", "acme/example", "123456789", "build", "1", "github_tracking_monitor_mode")
+	job := listenerRegisteredJob(jobRegistry, id)
+	if job == nil || job.ProjectScope() == nil {
+		t.Fatal("expected project scope to be created")
+	}
+	resolved, ok := job.ProjectScope().ResolvedRules.Lookup(rule.RuleIdentity{RulesetID: "project", RuleID: "terminate_exec"})
+	if !ok {
+		t.Fatal("terminate_exec rule was not resolved")
+	}
+	if got := resolved.Rule.Action; got != rule.RuleActionDetect {
+		t.Fatalf("resolved action: got %q, want %q", got, rule.RuleActionDetect)
+	}
+}
+
 func TestListener_ProjectStart_DisableBaselineRulesKeepsProjectRules(t *testing.T) {
 	client, jobRegistry, cleanup := setupListenerWithRegistry(t)
 	defer cleanup()
@@ -779,11 +829,12 @@ func TestListener_ProjectStart_AppliesProjectManagerConfig(t *testing.T) {
 					RuleID:    "project-manager-rule",
 					EventType: jobevent.ProcessExec,
 					Condition: `process_name == "bash"`,
-					Action:    rule.RuleActionDetect,
+					Action:    rule.RuleActionTerminate,
 				}},
 			}}, nil)
 			return connect.NewResponse(&managerv1beta1.FetchConfigResponse{
 				Config: &managerv1beta1.ServedConfig{
+					MonitorMode: true,
 					OutputSettings: &managerv1beta1.OutputSettings{
 						Detection: &managerv1beta1.OutputSetting{Enabled: true},
 					},
@@ -826,6 +877,13 @@ func TestListener_ProjectStart_AppliesProjectManagerConfig(t *testing.T) {
 	}
 	if got := len(job.ProjectScope().ResolvedRules.Rules); got != 1 {
 		t.Fatalf("project manager rules: got %d, want 1", got)
+	}
+	resolved, ok := job.ProjectScope().ResolvedRules.Lookup(rule.RuleIdentity{RulesetID: "project-manager", RuleID: "project-manager-rule"})
+	if !ok {
+		t.Fatal("project-manager-rule was not resolved")
+	}
+	if got := resolved.Rule.Action; got != rule.RuleActionDetect {
+		t.Fatalf("project manager action: got %q, want %q", got, rule.RuleActionDetect)
 	}
 	if !job.ProjectScope().OutputSettings.GetDetection().GetEnabled() {
 		t.Fatal("project output detection: got false, want true")
@@ -918,6 +976,43 @@ func TestListener_ProjectStart_RejectsProjectManagerWithDisableBaselineRules(t *
 	}
 	if result.Error != "disable_baseline_rules cannot be combined with manager_url" {
 		t.Fatalf("error: got %q, want %q", result.Error, "disable_baseline_rules cannot be combined with manager_url")
+	}
+}
+
+func TestListener_ProjectStart_RejectsProjectManagerWithMonitorMode(t *testing.T) {
+	client, cleanup := setupListener(t)
+	defer cleanup()
+
+	body, _ := json.Marshal(map[string]any{
+		"provider":                  "github",
+		"provider_host":             "github.com",
+		"project_path":              "acme/example",
+		"github_run_id":             "123456789",
+		"github_job":                "build",
+		"github_run_attempt":        "1",
+		"github_runner_tracking_id": "github_tracking_manager_monitor_mode",
+		"manager_url":               "https://project-manager.example.com",
+		"manager_token":             managerauth.TokenPrefix + strings.Repeat("a", 64),
+		"monitor_mode":              true,
+	})
+	resp, err := client.Post("http://cicd-sensor/v1/github/project/start", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status: got %d, want %d", resp.StatusCode, http.StatusBadRequest)
+	}
+
+	var result struct {
+		Error string `json:"error"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if result.Error != "monitor_mode cannot be combined with manager_url" {
+		t.Fatalf("error: got %q, want %q", result.Error, "monitor_mode cannot be combined with manager_url")
 	}
 }
 

--- a/internal/agent/listener/requests.go
+++ b/internal/agent/listener/requests.go
@@ -24,6 +24,7 @@ type githubProjectStartRequest struct {
 	Metadata                jobcontext.JobMetadata   `json:"metadata,omitempty"`
 	DefaultMaxAlertsPerRule int                      `json:"default_max_alerts_per_rule,omitempty"`
 	DisableBaselineRules    bool                     `json:"disable_baseline_rules,omitempty"`
+	MonitorMode             bool                     `json:"monitor_mode,omitempty"`
 	RuleSources             []rulesource.LoadedRules `json:"rule_sources,omitempty"`
 	ManagerURL              string                   `json:"manager_url,omitempty"`
 	ManagerToken            string                   `json:"manager_token,omitempty"`
@@ -42,6 +43,9 @@ func (r *githubProjectStartRequest) Validate() error {
 	}
 	if r.ManagerURL != "" && r.DisableBaselineRules {
 		errs = append(errs, errors.New("disable_baseline_rules cannot be combined with manager_url"))
+	}
+	if r.ManagerURL != "" && r.MonitorMode {
+		errs = append(errs, errors.New("monitor_mode cannot be combined with manager_url"))
 	}
 	if r.ManagerURL == "" {
 		cfg := projectconfig.ProjectConfig{DefaultMaxAlertsPerRule: &r.DefaultMaxAlertsPerRule}

--- a/internal/agent/managerclient/config_client.go
+++ b/internal/agent/managerclient/config_client.go
@@ -89,6 +89,7 @@ func warnIfInsecureManagerURL(logger *slog.Logger, parsed *url.URL, raw string) 
 type FetchResult struct {
 	ConfigRevision          string
 	DefaultMaxAlertsPerRule int
+	MonitorMode             bool
 	RuleSources             []rulesource.LoadedRules
 	OutputSettings          *managerv1beta1.OutputSettings
 }
@@ -134,6 +135,7 @@ func (c *ConfigClient) FetchConfig(ctx context.Context, req *managerv1beta1.Fetc
 	return &FetchResult{
 		ConfigRevision:          config.GetConfigRevision(),
 		DefaultMaxAlertsPerRule: int(config.GetDefaultMaxAlertsPerRule()),
+		MonitorMode:             config.GetMonitorMode(),
 		RuleSources:             ruleSources,
 		OutputSettings:          config.GetOutputSettings(),
 	}, nil

--- a/internal/agent/managerclient/config_client_integration_test.go
+++ b/internal/agent/managerclient/config_client_integration_test.go
@@ -57,6 +57,7 @@ rule_modifiers:
 	served := &manager.ServedConfig{
 		ConfigRevision:          "sha256:config",
 		DefaultMaxAlertsPerRule: 23,
+		MonitorMode:             true,
 		OutputSettings: &managerv1beta1.OutputSettings{
 			Summary:      &managerv1beta1.OutputSetting{Enabled: true},
 			Detection:    &managerv1beta1.OutputSetting{Enabled: true},
@@ -97,6 +98,9 @@ rule_modifiers:
 	if result.DefaultMaxAlertsPerRule != 23 {
 		t.Fatalf("default_max_alerts_per_rule: got %d, want 23", result.DefaultMaxAlertsPerRule)
 	}
+	if !result.MonitorMode {
+		t.Fatalf("monitor_mode: got false, want true")
+	}
 	if len(result.RuleSources) != 2 {
 		t.Fatalf("rule_sources: got %d, want 2", len(result.RuleSources))
 	}
@@ -125,6 +129,7 @@ rule_modifiers:
 		ConfigRevision:          result.ConfigRevision,
 		OutputSettings:          result.OutputSettings,
 		DefaultMaxAlertsPerRule: result.DefaultMaxAlertsPerRule,
+		MonitorMode:             result.MonitorMode,
 	}); err != nil {
 		t.Fatalf("ApplyManagerConfig: %v", err)
 	}

--- a/internal/agent/managerclient/config_client_test.go
+++ b/internal/agent/managerclient/config_client_test.go
@@ -42,6 +42,7 @@ func TestManagerClient_FetchConfig_Success(t *testing.T) {
 				Config: &managerv1beta1.ServedConfig{
 					ConfigRevision:          "sha256:test",
 					DefaultMaxAlertsPerRule: 17,
+					MonitorMode:             true,
 					OutputSettings: &managerv1beta1.OutputSettings{
 						Summary:      &managerv1beta1.OutputSetting{Enabled: true},
 						Detection:    &managerv1beta1.OutputSetting{Enabled: true},
@@ -76,6 +77,9 @@ func TestManagerClient_FetchConfig_Success(t *testing.T) {
 	}
 	if result.DefaultMaxAlertsPerRule != 17 {
 		t.Fatalf("default_max_alerts_per_rule: got %d, want 17", result.DefaultMaxAlertsPerRule)
+	}
+	if !result.MonitorMode {
+		t.Fatalf("monitor_mode: got false, want true")
 	}
 	if result.OutputSettings == nil ||
 		!result.OutputSettings.GetSummary().GetEnabled() ||

--- a/internal/agent/projectconfig/projectconfig.go
+++ b/internal/agent/projectconfig/projectconfig.go
@@ -19,6 +19,7 @@ import (
 type ProjectConfig struct {
 	DefaultMaxAlertsPerRule *int `yaml:"default_max_alerts_per_rule,omitempty"`
 	DisableBaselineRules    bool `yaml:"disable_baseline_rules,omitempty"`
+	MonitorMode             bool `yaml:"monitor_mode,omitempty"`
 }
 
 // Load reads a project config file and rejects unknown fields.

--- a/internal/agent/projectconfig/projectconfig_test.go
+++ b/internal/agent/projectconfig/projectconfig_test.go
@@ -16,6 +16,7 @@ func TestLoad(t *testing.T) {
 		content     string
 		want        *int
 		wantDisable bool
+		wantMonitor bool
 		wantErrText string
 	}{
 		{
@@ -35,6 +36,19 @@ default_max_alerts_per_rule: 7
 disable_baseline_rules: true
 `,
 			wantDisable: true,
+		},
+		{
+			name: "monitor mode is loaded",
+			content: `
+monitor_mode: true
+`,
+			wantMonitor: true,
+		},
+		{
+			name: "monitor mode false is accepted",
+			content: `
+monitor_mode: false
+`,
 		},
 		{
 			name: "negative default is rejected",
@@ -97,6 +111,9 @@ manager:
 			}
 			if got.DisableBaselineRules != tt.wantDisable {
 				t.Fatalf("disable baseline rules: got %v, want %v", got.DisableBaselineRules, tt.wantDisable)
+			}
+			if got.MonitorMode != tt.wantMonitor {
+				t.Fatalf("monitor mode: got %v, want %v", got.MonitorMode, tt.wantMonitor)
 			}
 		})
 	}

--- a/internal/agent/projectresult/report_document_test.go
+++ b/internal/agent/projectresult/report_document_test.go
@@ -68,7 +68,7 @@ func TestBuildJobEventSummaryForReportBuildsPassSummary(t *testing.T) {
 				resolvedRule("set", "curl_token", "Curl token"),
 				resolvedRule("set", "bash_exec", "Bash exec"),
 			},
-			Warnings: []rule.MergeWarning{{Kind: "duplicate_rule"}},
+			Warnings: []rule.ResolveWarning{{Kind: "duplicate_rule"}},
 		},
 		Snapshot: observations.StateSnapshot{
 			ObservationDomain: observations.DomainObservationSnapshot{Records: []observations.DomainObservationRecord{{

--- a/internal/manager/config_loader.go
+++ b/internal/manager/config_loader.go
@@ -16,6 +16,7 @@ type ServedConfig struct {
 	ConfigRevision          string
 	DefaultMaxAlertsPerRule int
 	DisableBaselineRules    bool
+	MonitorMode             bool
 	OutputSettings          *managerv1beta1.OutputSettings
 }
 

--- a/internal/manager/config_service.go
+++ b/internal/manager/config_service.go
@@ -62,6 +62,7 @@ func (h *configServiceHandler) FetchConfig(ctx context.Context, req *connect.Req
 		Config: &managerv1beta1.ServedConfig{
 			ConfigRevision:          config.ConfigRevision,
 			DefaultMaxAlertsPerRule: int32(config.DefaultMaxAlertsPerRule),
+			MonitorMode:             config.MonitorMode,
 			OutputSettings:          config.OutputSettings,
 		},
 		RuleSources: protoconv.ToProtoRuleSources(sources),

--- a/internal/manager/config_service.go
+++ b/internal/manager/config_service.go
@@ -52,10 +52,10 @@ func (h *configServiceHandler) FetchConfig(ctx context.Context, req *connect.Req
 		}
 		// Baseline first, then manual --rules-file. Rule source boundaries are
 		// preserved so OCI/local revisions remain visible to the agent.
-		merged := make([]rulesource.LoadedRules, 0, len(sources)+1)
-		merged = append(merged, baselineSource)
-		merged = append(merged, sources...)
-		sources = merged
+		sourcesWithBaseline := make([]rulesource.LoadedRules, 0, len(sources)+1)
+		sourcesWithBaseline = append(sourcesWithBaseline, baselineSource)
+		sourcesWithBaseline = append(sourcesWithBaseline, sources...)
+		sources = sourcesWithBaseline
 	}
 
 	out := &managerv1beta1.FetchConfigResponse{

--- a/internal/manager/config_service_test.go
+++ b/internal/manager/config_service_test.go
@@ -65,6 +65,7 @@ func TestConfigService_FetchConfig(t *testing.T) {
 		wantRuleSets int
 		wantManager  bool
 		wantDefault  int32
+		wantMonitor  bool
 	}{
 		{
 			name:  "valid request returns cached config response",
@@ -86,6 +87,7 @@ bind:
   address: 127.0.0.1
   port: 0
 default_max_alerts_per_rule: 25
+monitor_mode: true
 sinks:
   test-sink:
     type: google_storage
@@ -97,6 +99,7 @@ logs:
 			wantRuleSets: 2,
 			wantManager:  true,
 			wantDefault:  25,
+			wantMonitor:  true,
 		},
 		{
 			name:      "baseline response is allowed when no rules file is configured",
@@ -160,6 +163,7 @@ bind:
 			config := &ServedConfig{
 				ConfigRevision:          startupCfg.Revision,
 				DefaultMaxAlertsPerRule: startupCfg.DefaultMaxAlertsPerRule,
+				MonitorMode:             startupCfg.MonitorMode,
 			}
 			var rulesPath string
 			if len(tt.ruleFiles) > 0 {
@@ -229,6 +233,9 @@ bind:
 			}
 			if resp.Msg.GetConfig().GetDefaultMaxAlertsPerRule() != tt.wantDefault {
 				t.Fatalf("default_max_alerts_per_rule: got %d, want %d", resp.Msg.GetConfig().GetDefaultMaxAlertsPerRule(), tt.wantDefault)
+			}
+			if resp.Msg.GetConfig().GetMonitorMode() != tt.wantMonitor {
+				t.Fatalf("monitor_mode: got %v, want %v", resp.Msg.GetConfig().GetMonitorMode(), tt.wantMonitor)
 			}
 			hasManager := resp.Msg.GetConfig().GetOutputSettings().GetSummary().GetEnabled()
 			if hasManager != tt.wantManager {

--- a/internal/manager/startup_config.go
+++ b/internal/manager/startup_config.go
@@ -30,6 +30,7 @@ type StartupConfig struct {
 	Bind                    startupBindConfig `yaml:"bind"`
 	DefaultMaxAlertsPerRule int               `yaml:"default_max_alerts_per_rule,omitempty"`
 	DisableBaselineRules    bool              `yaml:"disable_baseline_rules,omitempty"`
+	MonitorMode             bool              `yaml:"monitor_mode,omitempty"`
 	Sinks                   SinksConfig       `yaml:"sinks,omitempty"`
 	Logs                    LogsConfig        `yaml:"logs,omitempty"`
 }

--- a/internal/manager/startup_config_test.go
+++ b/internal/manager/startup_config_test.go
@@ -16,6 +16,7 @@ func TestLoadStartupConfig(t *testing.T) {
 		wantBind    string
 		wantDefault int
 		wantDisable bool
+		wantMonitor bool
 		wantErrText string
 	}{
 		{
@@ -40,6 +41,25 @@ disable_baseline_rules: true
 			wantPort:    8080,
 			wantBind:    "0.0.0.0:8080",
 			wantDisable: true,
+		},
+		{
+			name: "monitor mode is loaded",
+			content: `
+monitor_mode: true
+`,
+			wantAddress: "0.0.0.0",
+			wantPort:    8080,
+			wantBind:    "0.0.0.0:8080",
+			wantMonitor: true,
+		},
+		{
+			name: "monitor mode false is accepted",
+			content: `
+monitor_mode: false
+`,
+			wantAddress: "0.0.0.0",
+			wantPort:    8080,
+			wantBind:    "0.0.0.0:8080",
 		},
 		{
 			name: "missing bind address uses default",
@@ -139,6 +159,9 @@ unexpected_field: true
 			}
 			if got.DisableBaselineRules != tt.wantDisable {
 				t.Fatalf("disable_baseline_rules: got %v, want %v", got.DisableBaselineRules, tt.wantDisable)
+			}
+			if got.MonitorMode != tt.wantMonitor {
+				t.Fatalf("monitor_mode: got %v, want %v", got.MonitorMode, tt.wantMonitor)
 			}
 			if !strings.HasPrefix(got.Revision, "sha256:") {
 				t.Fatalf("revision: got %q, want sha256 prefix", got.Revision)

--- a/internal/proto/cicd_sensor/manager/v1beta1/config.pb.go
+++ b/internal/proto/cicd_sensor/manager/v1beta1/config.pb.go
@@ -157,6 +157,7 @@ type ServedConfig struct {
 	ConfigRevision          string                 `protobuf:"bytes,1,opt,name=config_revision,json=configRevision,proto3" json:"config_revision,omitempty"`
 	DefaultMaxAlertsPerRule int32                  `protobuf:"varint,2,opt,name=default_max_alerts_per_rule,json=defaultMaxAlertsPerRule,proto3" json:"default_max_alerts_per_rule,omitempty"`
 	OutputSettings          *OutputSettings        `protobuf:"bytes,3,opt,name=output_settings,json=outputSettings,proto3" json:"output_settings,omitempty"`
+	MonitorMode             bool                   `protobuf:"varint,4,opt,name=monitor_mode,json=monitorMode,proto3" json:"monitor_mode,omitempty"`
 	unknownFields           protoimpl.UnknownFields
 	sizeCache               protoimpl.SizeCache
 }
@@ -210,6 +211,13 @@ func (x *ServedConfig) GetOutputSettings() *OutputSettings {
 		return x.OutputSettings
 	}
 	return nil
+}
+
+func (x *ServedConfig) GetMonitorMode() bool {
+	if x != nil {
+		return x.MonitorMode
+	}
+	return false
 }
 
 // FetchConfigResponse is the FetchConfig output.
@@ -278,11 +286,12 @@ const file_cicd_sensor_manager_v1beta1_config_proto_rawDesc = "" +
 	"\vrunner_type\x18\x01 \x01(\tR\n" +
 	"runnerType\x12K\n" +
 	"\fjob_identity\x18\x02 \x01(\v2(.cicd_sensor.manager.v1beta1.JobIdentityR\vjobIdentity\x12Z\n" +
-	"\x11requested_outputs\x18\x03 \x01(\v2-.cicd_sensor.manager.v1beta1.RequestedOutputsR\x10requestedOutputs\"\xcb\x01\n" +
+	"\x11requested_outputs\x18\x03 \x01(\v2-.cicd_sensor.manager.v1beta1.RequestedOutputsR\x10requestedOutputs\"\xee\x01\n" +
 	"\fServedConfig\x12'\n" +
 	"\x0fconfig_revision\x18\x01 \x01(\tR\x0econfigRevision\x12<\n" +
 	"\x1bdefault_max_alerts_per_rule\x18\x02 \x01(\x05R\x17defaultMaxAlertsPerRule\x12T\n" +
-	"\x0foutput_settings\x18\x03 \x01(\v2+.cicd_sensor.manager.v1beta1.OutputSettingsR\x0eoutputSettings\"\xa4\x01\n" +
+	"\x0foutput_settings\x18\x03 \x01(\v2+.cicd_sensor.manager.v1beta1.OutputSettingsR\x0eoutputSettings\x12!\n" +
+	"\fmonitor_mode\x18\x04 \x01(\bR\vmonitorMode\"\xa4\x01\n" +
 	"\x13FetchConfigResponse\x12A\n" +
 	"\x06config\x18\x01 \x01(\v2).cicd_sensor.manager.v1beta1.ServedConfigR\x06config\x12J\n" +
 	"\frule_sources\x18\x02 \x03(\v2'.cicd_sensor.manager.v1beta1.RuleSourceR\vruleSources2\x81\x01\n" +

--- a/internal/rule/lists.go
+++ b/internal/rule/lists.go
@@ -2,7 +2,7 @@ package rule
 
 // PredefinedLists holds rule-set-defined lists after lowercasing and NFC
 // normalization. It is rule data, not a CEL list<T> value, and lives in the
-// rule domain package so rule merge and CEL engine can both depend on it
+// rule domain package so rule resolution and CEL engine can both depend on it
 // without forming a cycle.
 type PredefinedLists map[string][]string
 

--- a/internal/rule/merge.go
+++ b/internal/rule/merge.go
@@ -11,6 +11,7 @@ type MergeInput struct {
 	RuleSets                []RuleSet
 	RuleModifiers           []RuleModifier
 	DefaultMaxAlertsPerRule int
+	MonitorMode             bool
 	ProviderHost            string
 	ProjectPath             string
 }
@@ -22,6 +23,7 @@ func Merge(in MergeInput) ResolvedRules {
 	warnings = append(warnings, modifierWarnings...)
 	rules = applyModifiers(rules, validModifiers)
 	rules = applyTargetFilter(rules, in.ProviderHost, in.ProjectPath)
+	rules = applyMonitorMode(rules, in.MonitorMode)
 	rules, maxAlertWarnings := applyMaxAlertsDefaultsAndCeiling(rules, in.DefaultMaxAlertsPerRule)
 	warnings = append(warnings, maxAlertWarnings...)
 	return ResolvedRules{
@@ -132,6 +134,20 @@ func applyModifiers(rules []ResolvedRule, mods []RuleModifier) []ResolvedRule {
 		if !disabled {
 			out = append(out, resolvedRule)
 		}
+	}
+	return out
+}
+
+func applyMonitorMode(rules []ResolvedRule, enabled bool) []ResolvedRule {
+	if !enabled {
+		return rules
+	}
+	out := make([]ResolvedRule, 0, len(rules))
+	for _, resolvedRule := range rules {
+		if resolvedRule.Rule.Action == RuleActionTerminate {
+			resolvedRule.Rule.Action = RuleActionDetect
+		}
+		out = append(out, resolvedRule)
 	}
 	return out
 }

--- a/internal/rule/merge_test.go
+++ b/internal/rule/merge_test.go
@@ -160,6 +160,84 @@ func TestMerge_ModifierCanEscalateAction(t *testing.T) {
 	}
 }
 
+func TestMerge_MonitorModeDowngradesTerminateActions(t *testing.T) {
+	tests := []struct {
+		name       string
+		monitor    bool
+		rule       rule.Rule
+		modifier   *rule.RuleModifier
+		wantAction rule.RuleAction
+	}{
+		{
+			name:       "disabled leaves terminate rule unchanged",
+			rule:       testRule("r1", jobevent.ProcessExec, rule.RuleActionTerminate),
+			wantAction: rule.RuleActionTerminate,
+		},
+		{
+			name:       "enabled downgrades terminate rule to detect",
+			monitor:    true,
+			rule:       testRule("r1", jobevent.ProcessExec, rule.RuleActionTerminate),
+			wantAction: rule.RuleActionDetect,
+		},
+		{
+			name:       "enabled leaves detect rule unchanged",
+			monitor:    true,
+			rule:       testRule("r1", jobevent.ProcessExec, rule.RuleActionDetect),
+			wantAction: rule.RuleActionDetect,
+		},
+		{
+			name:       "enabled leaves collect rule unchanged",
+			monitor:    true,
+			rule:       testRule("r1", jobevent.ProcessExec, rule.RuleActionCollect),
+			wantAction: rule.RuleActionCollect,
+		},
+		{
+			name:    "enabled downgrades modifier escalation",
+			monitor: true,
+			rule:    testRule("r1", jobevent.ProcessExec, rule.RuleActionDetect),
+			modifier: &rule.RuleModifier{
+				ModifierID:     "local/escalate",
+				Targets:        []rule.RuleModifierTarget{{RulesetID: "s1"}},
+				OverrideAction: actionPtr(rule.RuleActionTerminate),
+			},
+			wantAction: rule.RuleActionDetect,
+		},
+		{
+			name:    "enabled downgrades terminate correlation rule",
+			monitor: true,
+			rule: rule.Rule{
+				RuleID:    "r1",
+				Type:      "correlation",
+				Condition: `rule.a.total_count > 0`,
+				Action:    rule.RuleActionTerminate,
+			},
+			wantAction: rule.RuleActionDetect,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			in := rule.MergeInput{
+				MonitorMode: tt.monitor,
+				RuleSets: []rule.RuleSet{
+					testSet("s1", tt.rule),
+				},
+			}
+			if tt.modifier != nil {
+				in.RuleModifiers = []rule.RuleModifier{*tt.modifier}
+			}
+
+			got := rule.Merge(in)
+			if len(got.Rules) != 1 {
+				t.Fatalf("rules: got %d, want 1", len(got.Rules))
+			}
+			if got.Rules[0].Rule.Action != tt.wantAction {
+				t.Fatalf("action: got %q, want %q", got.Rules[0].Rule.Action, tt.wantAction)
+			}
+		})
+	}
+}
+
 func TestMerge_InvalidEmptyOverrideActionIsSkippedWithWarning(t *testing.T) {
 	empty := rule.RuleAction("")
 	got := rule.Merge(rule.MergeInput{

--- a/internal/rule/resolve.go
+++ b/internal/rule/resolve.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 )
 
-// MergeInput collects all sets and modifiers to be merged into ResolvedRules.
-type MergeInput struct {
+// ResolveInput collects all sets and modifiers to be resolved into ResolvedRules.
+type ResolveInput struct {
 	RuleSets                []RuleSet
 	RuleModifiers           []RuleModifier
 	DefaultMaxAlertsPerRule int
@@ -16,8 +16,8 @@ type MergeInput struct {
 	ProjectPath             string
 }
 
-// Merge flattens sets, applies modifiers, and produces ResolvedRules.
-func Merge(in MergeInput) ResolvedRules {
+// Resolve flattens sets, applies modifiers, and produces ResolvedRules.
+func Resolve(in ResolveInput) ResolvedRules {
 	rules, warnings := flattenRules(in.RuleSets)
 	validModifiers, modifierWarnings := filterValidModifiers(in.RuleModifiers)
 	warnings = append(warnings, modifierWarnings...)
@@ -32,7 +32,7 @@ func Merge(in MergeInput) ResolvedRules {
 	}
 }
 
-func flattenRules(sets []RuleSet) ([]ResolvedRule, []MergeWarning) {
+func flattenRules(sets []RuleSet) ([]ResolvedRule, []ResolveWarning) {
 	type seen struct {
 		rule      Rule
 		lists     PredefinedLists
@@ -41,7 +41,7 @@ func flattenRules(sets []RuleSet) ([]ResolvedRule, []MergeWarning) {
 
 	index := map[CanonicalRuleID]seen{}
 	var out []ResolvedRule
-	var warnings []MergeWarning
+	var warnings []ResolveWarning
 
 	for _, s := range sets {
 		predefinedLists := NormalizePredefinedLists(s.Lists)
@@ -52,7 +52,7 @@ func flattenRules(sets []RuleSet) ([]ResolvedRule, []MergeWarning) {
 				if isRuleContentEqual(prev.rule, r) && isPredefinedListsEqual(prev.lists, predefinedLists) {
 					continue
 				}
-				warnings = append(warnings, MergeWarning{
+				warnings = append(warnings, ResolveWarning{
 					Kind:     "duplicate_identity_diff_content",
 					Identity: identity,
 				})
@@ -78,12 +78,12 @@ func flattenRules(sets []RuleSet) ([]ResolvedRule, []MergeWarning) {
 	return out, warnings
 }
 
-func filterValidModifiers(mods []RuleModifier) ([]RuleModifier, []MergeWarning) {
+func filterValidModifiers(mods []RuleModifier) ([]RuleModifier, []ResolveWarning) {
 	valid := make([]RuleModifier, 0, len(mods))
-	var warnings []MergeWarning
+	var warnings []ResolveWarning
 	for _, modifier := range mods {
 		if err := ValidateRuleModifier(&modifier); err != nil {
-			warnings = append(warnings, MergeWarning{
+			warnings = append(warnings, ResolveWarning{
 				Kind:       "invalid_modifier_skipped",
 				EntryLabel: modifier.ModifierID,
 				Reason:     err.Error(),
@@ -109,7 +109,7 @@ func applyModifiers(rules []ResolvedRule, mods []RuleModifier) []ResolvedRule {
 				resolvedRule.AppliedModifiers = append(resolvedRule.AppliedModifiers, modifier.ModifierID)
 				continue
 			}
-			// Validation already rejects override_action: "". Keep merge
+			// Validation already rejects override_action: "". Keep resolution
 			// defensive so a bypassed invalid bundle does not silently disable
 			// the rule or overwrite its action with an empty value.
 			if modifier.OverrideAction != nil && *modifier.OverrideAction != "" {
@@ -188,16 +188,16 @@ func targetMatcherMatches(matcher RuleTargetMatcher, providerHost, projectPath s
 
 // applyMaxAlertsDefaultsAndCeiling bakes the final max_alerts cap into each
 // rule. Rule-local max_alerts wins, then the host/project configured default,
-// then the system fallback. Out-of-range values should be rejected before merge,
-// but this stays defensive and falls back with a warning instead of dropping
-// the rule.
+// then the system fallback. Out-of-range values should be rejected before
+// resolution, but this stays defensive and falls back with a warning instead
+// of dropping the rule.
 //
 // The function builds a fresh out slice so the caller's input is left
-// untouched. Merge is called once per host/project start, so the extra
+// untouched. Resolve is called once per host/project start, so the extra
 // allocation is not on a hot path.
-func applyMaxAlertsDefaultsAndCeiling(rules []ResolvedRule, configuredDefault int) ([]ResolvedRule, []MergeWarning) {
+func applyMaxAlertsDefaultsAndCeiling(rules []ResolvedRule, configuredDefault int) ([]ResolvedRule, []ResolveWarning) {
 	out := make([]ResolvedRule, 0, len(rules))
-	var warnings []MergeWarning
+	var warnings []ResolveWarning
 	for _, r := range rules {
 		final, fellBack := ResolveMaxAlertsCap(r.Rule.MaxAlerts, configuredDefault)
 		r.Rule.MaxAlerts = final
@@ -205,7 +205,7 @@ func applyMaxAlertsDefaultsAndCeiling(rules []ResolvedRule, configuredDefault in
 		if !fellBack {
 			continue
 		}
-		warnings = append(warnings, MergeWarning{
+		warnings = append(warnings, ResolveWarning{
 			Kind:     "max_alerts_out_of_range",
 			Identity: r.Identity(),
 			Reason: fmt.Sprintf(

--- a/internal/rule/resolve_test.go
+++ b/internal/rule/resolve_test.go
@@ -27,8 +27,8 @@ func boolPtr(v bool) *bool                         { return &v }
 func intPtr(v int) *int                            { return &v }
 func actionPtr(v rule.RuleAction) *rule.RuleAction { return &v }
 
-func TestMerge_FlattenSingleSet(t *testing.T) {
-	in := rule.MergeInput{
+func TestResolve_FlattenSingleSet(t *testing.T) {
+	in := rule.ResolveInput{
 		RuleSets: []rule.RuleSet{
 			testSet("s1",
 				testRule("r1", jobevent.ProcessExec, rule.RuleActionDetect),
@@ -36,7 +36,7 @@ func TestMerge_FlattenSingleSet(t *testing.T) {
 			),
 		},
 	}
-	got := rule.Merge(in)
+	got := rule.Resolve(in)
 	if len(got.Rules) != 2 {
 		t.Fatalf("got %d rules, want 2", len(got.Rules))
 	}
@@ -51,9 +51,9 @@ func TestMerge_FlattenSingleSet(t *testing.T) {
 	}
 }
 
-func TestMerge_CanonicalRuleIDCollision_SameContent_SilentDedupe(t *testing.T) {
+func TestResolve_CanonicalRuleIDCollision_SameContent_SilentDedupe(t *testing.T) {
 	r := testRule("r1", jobevent.ProcessExec, rule.RuleActionDetect)
-	got := rule.Merge(rule.MergeInput{
+	got := rule.Resolve(rule.ResolveInput{
 		RuleSets: []rule.RuleSet{
 			testSet("s1", r),
 			testSet("s1", r),
@@ -67,10 +67,10 @@ func TestMerge_CanonicalRuleIDCollision_SameContent_SilentDedupe(t *testing.T) {
 	}
 }
 
-func TestMerge_CanonicalRuleIDCollision_DifferentContent_WarnsAndKeepsFirst(t *testing.T) {
+func TestResolve_CanonicalRuleIDCollision_DifferentContent_WarnsAndKeepsFirst(t *testing.T) {
 	r1 := testRule("r1", jobevent.ProcessExec, rule.RuleActionDetect)
 	r2 := testRule("r1", jobevent.ProcessExec, rule.RuleActionTerminate)
-	got := rule.Merge(rule.MergeInput{
+	got := rule.Resolve(rule.ResolveInput{
 		RuleSets: []rule.RuleSet{
 			testSet("s1", r1),
 			testSet("s1", r2),
@@ -93,8 +93,8 @@ func TestMerge_CanonicalRuleIDCollision_DifferentContent_WarnsAndKeepsFirst(t *t
 	}
 }
 
-func TestMerge_ModifierDisable(t *testing.T) {
-	got := rule.Merge(rule.MergeInput{
+func TestResolve_ModifierDisable(t *testing.T) {
+	got := rule.Resolve(rule.ResolveInput{
 		RuleSets: []rule.RuleSet{
 			testSet("s1",
 				testRule("r1", jobevent.ProcessExec, rule.RuleActionDetect),
@@ -117,8 +117,8 @@ func TestMerge_ModifierDisable(t *testing.T) {
 	}
 }
 
-func TestMerge_ModifierOverrideAction(t *testing.T) {
-	got := rule.Merge(rule.MergeInput{
+func TestResolve_ModifierOverrideAction(t *testing.T) {
+	got := rule.Resolve(rule.ResolveInput{
 		RuleSets: []rule.RuleSet{
 			testSet("s1",
 				testRule("r1", jobevent.ProcessExec, rule.RuleActionTerminate),
@@ -140,8 +140,8 @@ func TestMerge_ModifierOverrideAction(t *testing.T) {
 	}
 }
 
-func TestMerge_ModifierCanEscalateAction(t *testing.T) {
-	got := rule.Merge(rule.MergeInput{
+func TestResolve_ModifierCanEscalateAction(t *testing.T) {
+	got := rule.Resolve(rule.ResolveInput{
 		RuleSets: []rule.RuleSet{
 			testSet("s1",
 				testRule("r1", jobevent.ProcessExec, rule.RuleActionDetect),
@@ -160,7 +160,7 @@ func TestMerge_ModifierCanEscalateAction(t *testing.T) {
 	}
 }
 
-func TestMerge_MonitorModeDowngradesTerminateActions(t *testing.T) {
+func TestResolve_MonitorModeDowngradesTerminateActions(t *testing.T) {
 	tests := []struct {
 		name       string
 		monitor    bool
@@ -217,7 +217,7 @@ func TestMerge_MonitorModeDowngradesTerminateActions(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			in := rule.MergeInput{
+			in := rule.ResolveInput{
 				MonitorMode: tt.monitor,
 				RuleSets: []rule.RuleSet{
 					testSet("s1", tt.rule),
@@ -227,7 +227,7 @@ func TestMerge_MonitorModeDowngradesTerminateActions(t *testing.T) {
 				in.RuleModifiers = []rule.RuleModifier{*tt.modifier}
 			}
 
-			got := rule.Merge(in)
+			got := rule.Resolve(in)
 			if len(got.Rules) != 1 {
 				t.Fatalf("rules: got %d, want 1", len(got.Rules))
 			}
@@ -238,9 +238,9 @@ func TestMerge_MonitorModeDowngradesTerminateActions(t *testing.T) {
 	}
 }
 
-func TestMerge_InvalidEmptyOverrideActionIsSkippedWithWarning(t *testing.T) {
+func TestResolve_InvalidEmptyOverrideActionIsSkippedWithWarning(t *testing.T) {
 	empty := rule.RuleAction("")
-	got := rule.Merge(rule.MergeInput{
+	got := rule.Resolve(rule.ResolveInput{
 		RuleSets: []rule.RuleSet{
 			testSet("s1",
 				testRule("r1", jobevent.ProcessExec, rule.RuleActionDetect),
@@ -271,8 +271,8 @@ func TestMerge_InvalidEmptyOverrideActionIsSkippedWithWarning(t *testing.T) {
 	}
 }
 
-func TestMerge_InvalidModifierIsSkippedWithWarning(t *testing.T) {
-	got := rule.Merge(rule.MergeInput{
+func TestResolve_InvalidModifierIsSkippedWithWarning(t *testing.T) {
+	got := rule.Resolve(rule.ResolveInput{
 		RuleSets: []rule.RuleSet{
 			testSet("s1",
 				testRule("r1", jobevent.ProcessExec, rule.RuleActionDetect),
@@ -312,8 +312,8 @@ func TestMerge_InvalidModifierIsSkippedWithWarning(t *testing.T) {
 	}
 }
 
-func TestMerge_ModifierMaxAlertsAndExceptions(t *testing.T) {
-	got := rule.Merge(rule.MergeInput{
+func TestResolve_ModifierMaxAlertsAndExceptions(t *testing.T) {
+	got := rule.Resolve(rule.ResolveInput{
 		RuleSets: []rule.RuleSet{
 			testSet("s1",
 				rule.Rule{
@@ -352,8 +352,8 @@ func TestMerge_ModifierMaxAlertsAndExceptions(t *testing.T) {
 	}
 }
 
-func TestMerge_ModifierAddsTargetExclude(t *testing.T) {
-	got := rule.Merge(rule.MergeInput{
+func TestResolve_ModifierAddsTargetExclude(t *testing.T) {
+	got := rule.Resolve(rule.ResolveInput{
 		RuleSets: []rule.RuleSet{
 			testSet("s1", rule.Rule{
 				RuleID:    "r1",
@@ -388,8 +388,8 @@ func TestMerge_ModifierAddsTargetExclude(t *testing.T) {
 	}
 }
 
-func TestMerge_AppliesScopeDefaultMaxAlertsWhenRuleOmitsValue(t *testing.T) {
-	got := rule.Merge(rule.MergeInput{
+func TestResolve_AppliesScopeDefaultMaxAlertsWhenRuleOmitsValue(t *testing.T) {
+	got := rule.Resolve(rule.ResolveInput{
 		DefaultMaxAlertsPerRule: 7,
 		RuleSets: []rule.RuleSet{
 			testSet("s1",
@@ -402,10 +402,10 @@ func TestMerge_AppliesScopeDefaultMaxAlertsWhenRuleOmitsValue(t *testing.T) {
 	}
 }
 
-func TestMerge_KeepsRuleMaxAlertsWhenPresent(t *testing.T) {
+func TestResolve_KeepsRuleMaxAlertsWhenPresent(t *testing.T) {
 	r := testRule("r1", jobevent.ProcessExec, rule.RuleActionDetect)
 	r.MaxAlerts = 5
-	got := rule.Merge(rule.MergeInput{
+	got := rule.Resolve(rule.ResolveInput{
 		DefaultMaxAlertsPerRule: 7,
 		RuleSets: []rule.RuleSet{
 			testSet("s1", r),
@@ -416,7 +416,7 @@ func TestMerge_KeepsRuleMaxAlertsWhenPresent(t *testing.T) {
 	}
 }
 
-func TestMerge_TargetFilter(t *testing.T) {
+func TestResolve_TargetFilter(t *testing.T) {
 	tests := []struct {
 		name      string
 		target    rule.RuleTarget
@@ -620,7 +620,7 @@ func TestMerge_TargetFilter(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := rule.Merge(rule.MergeInput{
+			got := rule.Resolve(rule.ResolveInput{
 				RuleSets: []rule.RuleSet{
 					testSet("s1", rule.Rule{
 						RuleID:    "r1",
@@ -640,8 +640,8 @@ func TestMerge_TargetFilter(t *testing.T) {
 	}
 }
 
-func TestMerge_AppliesSystemDefaultMaxAlertsWhenScopeDefaultMissing(t *testing.T) {
-	got := rule.Merge(rule.MergeInput{
+func TestResolve_AppliesSystemDefaultMaxAlertsWhenScopeDefaultMissing(t *testing.T) {
+	got := rule.Resolve(rule.ResolveInput{
 		RuleSets: []rule.RuleSet{
 			testSet("s1",
 				testRule("r1", jobevent.ProcessExec, rule.RuleActionDetect),
@@ -653,11 +653,11 @@ func TestMerge_AppliesSystemDefaultMaxAlertsWhenScopeDefaultMissing(t *testing.T
 	}
 }
 
-func TestMerge_FallsBackToDefaultWhenResolvedMaxAlertsOutOfRange(t *testing.T) {
+func TestResolve_FallsBackToDefaultWhenResolvedMaxAlertsOutOfRange(t *testing.T) {
 	// configured default > ceiling is a defensive case: upstream Validate*
-	// functions should reject it, but if it slips through merge keeps the
+	// functions should reject it, but if it slips through resolution keeps the
 	// rule alive at the system default rather than dropping it.
-	got := rule.Merge(rule.MergeInput{
+	got := rule.Resolve(rule.ResolveInput{
 		DefaultMaxAlertsPerRule: rule.MaxAlertsHardCeiling + 1,
 		RuleSets: []rule.RuleSet{
 			testSet("s1",
@@ -682,8 +682,8 @@ func TestMerge_FallsBackToDefaultWhenResolvedMaxAlertsOutOfRange(t *testing.T) {
 	}
 }
 
-func TestMerge_ModifierExceptionClausesPreserveOrder(t *testing.T) {
-	got := rule.Merge(rule.MergeInput{
+func TestResolve_ModifierExceptionClausesPreserveOrder(t *testing.T) {
+	got := rule.Resolve(rule.ResolveInput{
 		RuleSets: []rule.RuleSet{
 			testSet("s1",
 				rule.Rule{
@@ -720,8 +720,8 @@ func TestMerge_ModifierExceptionClausesPreserveOrder(t *testing.T) {
 	}
 }
 
-func TestMerge_PredefinedListsParticipateInContentEquality(t *testing.T) {
-	got := rule.Merge(rule.MergeInput{
+func TestResolve_PredefinedListsParticipateInContentEquality(t *testing.T) {
+	got := rule.Resolve(rule.ResolveInput{
 		RuleSets: []rule.RuleSet{
 			{
 				RulesetID: "s1",
@@ -750,7 +750,7 @@ func TestMerge_PredefinedListsParticipateInContentEquality(t *testing.T) {
 	}
 }
 
-func TestMerge_RuleTargetParticipatesInContentEquality(t *testing.T) {
+func TestResolve_RuleTargetParticipatesInContentEquality(t *testing.T) {
 	left := rule.Rule{
 		RuleID:    "r1",
 		EventType: jobevent.NetworkConnect,
@@ -765,7 +765,7 @@ func TestMerge_RuleTargetParticipatesInContentEquality(t *testing.T) {
 		Exclude: []rule.RuleTargetMatcher{{Path: "acme/sandbox"}},
 	}
 
-	got := rule.Merge(rule.MergeInput{
+	got := rule.Resolve(rule.ResolveInput{
 		ProviderHost: "github.com",
 		ProjectPath:  "acme/repo",
 		RuleSets: []rule.RuleSet{
@@ -787,7 +787,7 @@ func TestMerge_RuleTargetParticipatesInContentEquality(t *testing.T) {
 	}
 }
 
-func TestMerge_RuleTagsParticipateInContentEquality(t *testing.T) {
+func TestResolve_RuleTagsParticipateInContentEquality(t *testing.T) {
 	left := rule.Rule{
 		RuleID:    "r1",
 		EventType: jobevent.NetworkConnect,
@@ -798,7 +798,7 @@ func TestMerge_RuleTagsParticipateInContentEquality(t *testing.T) {
 	right := left
 	right.Tags = map[string]string{"severity": "high"}
 
-	got := rule.Merge(rule.MergeInput{
+	got := rule.Resolve(rule.ResolveInput{
 		RuleSets: []rule.RuleSet{
 			testSet("s1", left),
 			testSet("s1", right),
@@ -818,8 +818,8 @@ func TestMerge_RuleTagsParticipateInContentEquality(t *testing.T) {
 	}
 }
 
-func TestMerge_PredefinedListsDifferentKeyCountWarns(t *testing.T) {
-	got := rule.Merge(rule.MergeInput{
+func TestResolve_PredefinedListsDifferentKeyCountWarns(t *testing.T) {
+	got := rule.Resolve(rule.ResolveInput{
 		RuleSets: []rule.RuleSet{
 			{
 				RulesetID: "s1",
@@ -853,8 +853,8 @@ func TestMerge_PredefinedListsDifferentKeyCountWarns(t *testing.T) {
 	}
 }
 
-func TestMerge_PredefinedListsSliceOrderParticipatesInContentEquality(t *testing.T) {
-	got := rule.Merge(rule.MergeInput{
+func TestResolve_PredefinedListsSliceOrderParticipatesInContentEquality(t *testing.T) {
+	got := rule.Resolve(rule.ResolveInput{
 		RuleSets: []rule.RuleSet{
 			{
 				RulesetID: "s1",

--- a/internal/rule/rule.go
+++ b/internal/rule/rule.go
@@ -1,11 +1,11 @@
-// Package rule holds rule types, validation, and merge logic.
+// Package rule holds rule types, validation, and resolution logic.
 package rule
 
 import (
 	"slices"
 )
 
-// ResolvedRule is a scope-local rule after merge. Rule.RuleID remains the
+// ResolvedRule is a scope-local rule after resolution. Rule.RuleID remains the
 // author-facing local ID; CanonicalRuleID is the runtime key
 // "<ruleset_id>/<rule_id>" used by evaluation and summaries.
 type ResolvedRule struct {
@@ -23,25 +23,25 @@ func (r ResolvedRule) Identity() RuleIdentity {
 }
 
 // ResolvedExceptionClause is one additional exception clause attached during
-// rule merge from a modifier's add_exceptions field.
+// rule resolution from a modifier's add_exceptions field.
 type ResolvedExceptionClause struct {
 	Source           string `json:"source"`
 	ModifierIdentity string `json:"modifier_identity,omitempty"`
 }
 
-// MergeWarning records a collision or skip during rule merge.
-type MergeWarning struct {
+// ResolveWarning records a collision or skip during rule resolution.
+type ResolveWarning struct {
 	Kind       string       `json:"kind"`
 	Identity   RuleIdentity `json:"identity,omitempty"`
 	EntryLabel string       `json:"entry_label,omitempty"`
 	Reason     string       `json:"reason,omitempty"`
 }
 
-// ResolvedRules is the agent-side output of merging all sets and modifiers.
+// ResolvedRules is the agent-side output of resolving all sets and modifiers.
 // The manager never produces it.
 type ResolvedRules struct {
-	Rules    []ResolvedRule `json:"rules"`
-	Warnings []MergeWarning `json:"warnings,omitempty"`
+	Rules    []ResolvedRule   `json:"rules"`
+	Warnings []ResolveWarning `json:"warnings,omitempty"`
 }
 
 func (r ResolvedRules) Lookup(identity RuleIdentity) (ResolvedRule, bool) {

--- a/proto/cicd_sensor/manager/v1beta1/config.proto
+++ b/proto/cicd_sensor/manager/v1beta1/config.proto
@@ -45,6 +45,7 @@ message ServedConfig {
   string config_revision = 1;
   int32 default_max_alerts_per_rule = 2;
   OutputSettings output_settings = 3;
+  bool monitor_mode = 4;
 }
 
 // FetchConfigResponse is the FetchConfig output.


### PR DESCRIPTION
## What

Adds `monitor_mode` as a safety mode for cicd-sensor rule evaluation. When enabled, rules that resolve to `terminate` are evaluated as `detect`, including actions set through rule modifiers.

## Why
- https://github.com/cicd-sensor/cicd-sensor/issues/22#issuecomment-4556269455