### PR TITLE
docs: add comparison table to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ Most other runtimes have their open-source defenders: Falco, Tetragon, Tracee, W
 | Network blocking | Partial | Yes |
 | Log export | Yes | No |
 
+Network blocking is "Partial" for cicd-sensor: it does not filter egress traffic at the network layer like a firewall, the way Harden-Runner does. Instead, when a rule matches, it kills the offending process immediately and stops the job, halting the activity at its source.
+
 Harden-Runner (Free) is compared here in its open-source public-repository path. StepSecurity also offers broader paid platform features such as private repository support, self-hosted runner support, posture checks, policy management, dashboards, richer runtime visibility, and export integrations. Some non-free or TLS/eBPF agent paths are release-only or proprietary and are outside this table.
 
 ## Supported CI/CD pipelines

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
 
 ## What cicd-sensor does
 
-When a supply-chain attack runs inside a CI/CD job, teams often can't see it happen or tell what it did. cicd-sensor is an open-source sensor that gives them both.
+When a supply-chain attack runs inside a CI/CD job, teams often can't see it happen or tell what it did. cicd-sensor is an open-source sensor that lets every team do both.
 
 **Detection:** Detects supply-chain attacks at runtime using process ancestry (e.g. credential access from a process descended from `npm install`) and correlation across signals (e.g. multiple credential categories read in one job). Baseline rules target patterns seen in real CI/CD attacks, and are opt-out: turn them off if you only want the logs and evidence below.
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,21 @@ CI/CD pipelines build, release, deploy, and manage cloud infrastructure, and the
 
 Most other runtimes have their open-source defenders: Falco, Tetragon, Tracee, Wazuh, OSQuery. Open-source coverage for CI/CD runtime has lagged behind. Sigstore proved *where* and *how* artifacts were built; cicd-sensor preserves *what actually ran* so teams can detect, respond, and audit.
 
+## How cicd-sensor compares
+
+| Capability | cicd-sensor | Harden-Runner Free |
+| --- | --- | --- |
+| Open source | Yes | Yes |
+| No SaaS required | Yes | No |
+| Private repos | Yes | No |
+| Self-hosted runners | Yes | No |
+| GitLab CI/CD | Yes | No |
+| Detection rules | Yes | Unconfirmed |
+| Network blocking | Partial | Yes |
+| Log export | Yes | No |
+
+Harden-Runner Free is compared here in its open-source public-repository path. StepSecurity also offers broader paid platform features such as private repository support, self-hosted runner support, posture checks, policy management, dashboards, richer runtime visibility, and export integrations. Some non-free or TLS/eBPF agent paths are release-only or proprietary and are outside this table.
+
 ## Supported CI/CD pipelines
 
 | Platform | Environment | Status |

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Most other runtimes have their open-source defenders: Falco, Tetragon, Tracee, W
 | GitHub Actions support | ✅ Yes | ✅ Yes |
 | GitLab CI/CD support | ✅ Yes | ❌ No |
 | **Capabilities** | | |
-| Detection rules | ✅ Yes | ❓ Unconfirmed |
+| Detection rules | ✅ Yes | ✅ Yes |
 | Network blocking | 🔶 Partial | ✅ Yes |
 | Log export | ✅ Yes | ❌ No |
 

--- a/README.md
+++ b/README.md
@@ -58,9 +58,9 @@ CI/CD pipelines build, release, deploy, and manage cloud infrastructure, and the
 
 Most other runtimes have their open-source defenders: Falco, Tetragon, Tracee, Wazuh, OSQuery. Open-source coverage for CI/CD runtime has lagged behind. Sigstore proved *where* and *how* artifacts were built; cicd-sensor preserves *what actually ran* so teams can detect, respond, and audit.
 
-## How cicd-sensor compares
+## Feature comparison
 
-| Capability | cicd-sensor | Harden-Runner Free |
+| Capability | cicd-sensor | Harden-Runner (Free) |
 | --- | --- | --- |
 | Open source | Yes | Yes |
 | No SaaS required | Yes | No |
@@ -71,7 +71,7 @@ Most other runtimes have their open-source defenders: Falco, Tetragon, Tracee, W
 | Network blocking | Partial | Yes |
 | Log export | Yes | No |
 
-Harden-Runner Free is compared here in its open-source public-repository path. StepSecurity also offers broader paid platform features such as private repository support, self-hosted runner support, posture checks, policy management, dashboards, richer runtime visibility, and export integrations. Some non-free or TLS/eBPF agent paths are release-only or proprietary and are outside this table.
+Harden-Runner (Free) is compared here in its open-source public-repository path. StepSecurity also offers broader paid platform features such as private repository support, self-hosted runner support, posture checks, policy management, dashboards, richer runtime visibility, and export integrations. Some non-free or TLS/eBPF agent paths are release-only or proprietary and are outside this table.
 
 ## Supported CI/CD pipelines
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@
 
 ## What cicd-sensor does
 
+When a supply-chain attack runs inside a CI/CD job, teams often can't see it happen or tell what it did. cicd-sensor is an open-source sensor that gives them both.
+
 **Detection:** Detects supply-chain attacks at runtime using process ancestry (e.g. credential access from a process descended from `npm install`) and correlation across signals (e.g. multiple credential categories read in one job). Baseline rules target patterns seen in real CI/CD attacks, and are opt-out: turn them off if you only want the logs and evidence below.
 
 **Logs and evidence:** Per run, cicd-sensor can emit logs for review, alerting, and forensics, routed through cicd-sensor Manager to cloud sinks like S3, GCS, and Pub/Sub. The cicd-sensor-action can also produce a graphical report and a build attestation per run. Your data stays under your control. cicd-sensor never sends anything to servers operated by the cicd-sensor project.

--- a/README.md
+++ b/README.md
@@ -71,9 +71,9 @@ Most other runtimes have their open-source defenders: Falco, Tetragon, Tracee, W
 | Network blocking | Partial | Yes |
 | Log export | Yes | No |
 
-Network blocking is "Partial" for cicd-sensor: it does not filter egress traffic at the network layer like a firewall, the way Harden-Runner does. Instead, when a rule matches, it kills the offending process immediately and stops the job, halting the activity at its source.
+cicd-sensor's network blocking is "Partial": it does not filter traffic like a firewall. Instead, on detection it immediately kills the process and stops the job.
 
-Harden-Runner (Free) is compared here in its open-source public-repository path. StepSecurity also offers broader paid platform features such as private repository support, self-hosted runner support, posture checks, policy management, dashboards, richer runtime visibility, and export integrations. Some non-free or TLS/eBPF agent paths are release-only or proprietary and are outside this table.
+This table compares the free version of Harden-Runner. StepSecurity's paid platform adds more, such as private repository and self-hosted runner support, dashboards, and policy management.
 
 ## Supported CI/CD pipelines
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ cicd-sensor's network blocking is "Partial": it does not filter traffic like a f
 
 This table compares the free version of Harden-Runner. StepSecurity's paid platform adds more, such as private repository and self-hosted runner support, dashboards, and policy management.
 
+Based on public information as of May 2026. Corrections welcome.
+
 ## Supported CI/CD pipelines
 
 | Platform | Environment | Status |

--- a/README.md
+++ b/README.md
@@ -50,10 +50,6 @@ jobs:
 
 For self-hosted GitHub Actions or GitLab CI/CD, see the [User Guide](https://cicd-sensor.github.io/user-guide/overview.html).
 
-## Rules
-
-cicd-sensor ships with a set of baseline rules. See the [Baseline Rules guide](https://cicd-sensor.github.io/user-guide/baseline-rules.html) for how they work; the rule definitions themselves live in [`rules/`](rules/). You can also write your own rules, or turn the baseline off entirely.
-
 ## Why CI/CD runtime needs this
 
 CI/CD pipelines build, release, deploy, and manage cloud infrastructure, and they hold the cloud credentials, signing keys, and registry tokens to do it. Supply-chain attackers run inside those jobs and disappear with the evidence when the job ends.
@@ -62,26 +58,25 @@ Most other runtimes have their open-source defenders: Falco, Tetragon, Tracee, W
 
 ## Feature comparison
 
-| Capability | cicd-sensor | Harden-Runner (Free) |
-| --- | --- | --- |
-| **Licensing & deployment** | | |
-| Open source | ✅ Yes | ✅ Yes |
-| No SaaS required | ✅ Yes | ❌ No |
-| **Platform coverage** | | |
-| Private repos | ✅ Yes | ❌ No |
-| Self-hosted runners | ✅ Yes | ❌ No |
-| GitHub Actions support | ✅ Yes | ✅ Yes |
-| GitLab CI/CD support | ✅ Yes | ❌ No |
-| **Capabilities** | | |
-| Detection rules | ✅ Yes | ✅ Yes |
-| Network blocking | 🔶 Partial | ✅ Yes |
-| Log export | ✅ Yes | ❌ No |
+| Capability | cicd-sensor | Harden-Runner (Free) | Comment |
+| --- | --- | --- | --- |
+| **Licensing & deployment** | | | |
+| Open source | ✅ Yes | ✅ Yes | |
+| No SaaS required | ✅ Yes | ❌ No | |
+| **Platform coverage** | | | |
+| Private repos | ✅ Yes | ❌ No | |
+| Self-hosted runners | ✅ Yes | ❌ No | |
+| GitHub Actions support | ✅ Yes | ✅ Yes | |
+| GitLab CI/CD support | ✅ Yes | ❌ No | |
+| **Capabilities** | | | |
+| Detection rules | ✅ Yes | ✅ Yes | |
+| Flexible custom rules | ✅ Yes | 🔶 Limited | cicd-sensor rules cover process ancestry, file access, and correlation across signals; Harden-Runner is mainly a network egress allowlist. |
+| Network blocking | 🔶 Partial | ✅ Yes | cicd-sensor kills the process and stops the job on detection instead of filtering traffic like a firewall. |
+| Log export | ✅ Yes | ❌ No | |
 
-cicd-sensor's network blocking is "Partial": it does not filter traffic like a firewall. Instead, on detection it immediately kills the process and stops the job.
+<sub>This table compares the free version of Harden-Runner. StepSecurity's paid platform adds more, such as private repository and self-hosted runner support, dashboards, and policy management.</sub>
 
-This table compares the free version of Harden-Runner. StepSecurity's paid platform adds more, such as private repository and self-hosted runner support, dashboards, and policy management.
-
-Based on public information as of May 2026. Corrections welcome.
+<sub>Based on public information as of May 2026. Corrections welcome.</sub>
 
 ## Supported CI/CD pipelines
 
@@ -97,6 +92,10 @@ Based on public information as of May 2026. Corrections welcome.
 Works on both public and private repositories, with no third-party SaaS dependency.
 
 Linux kernel: 5.15 or later on `amd64`, 6.1 or later on `arm64`.
+
+## Rules
+
+cicd-sensor ships with a set of baseline rules. See the [Baseline Rules guide](https://cicd-sensor.github.io/user-guide/baseline-rules.html) for how they work; the rule definitions themselves live in [`rules/`](rules/). You can also write your own rules, or turn the baseline off entirely.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -62,14 +62,18 @@ Most other runtimes have their open-source defenders: Falco, Tetragon, Tracee, W
 
 | Capability | cicd-sensor | Harden-Runner (Free) |
 | --- | --- | --- |
-| Open source | Yes | Yes |
-| No SaaS required | Yes | No |
-| Private repos | Yes | No |
-| Self-hosted runners | Yes | No |
-| GitLab CI/CD | Yes | No |
-| Detection rules | Yes | Unconfirmed |
-| Network blocking | Partial | Yes |
-| Log export | Yes | No |
+| **Licensing & deployment** | | |
+| Open source | ✅ Yes | ✅ Yes |
+| No SaaS required | ✅ Yes | ❌ No |
+| **Platform coverage** | | |
+| Private repos | ✅ Yes | ❌ No |
+| Self-hosted runners | ✅ Yes | ❌ No |
+| GitHub Actions support | ✅ Yes | ✅ Yes |
+| GitLab CI/CD support | ✅ Yes | ❌ No |
+| **Capabilities** | | |
+| Detection rules | ✅ Yes | ❓ Unconfirmed |
+| Network blocking | 🔶 Partial | ✅ Yes |
+| Log export | ✅ Yes | ❌ No |
 
 cicd-sensor's network blocking is "Partial": it does not filter traffic like a firewall. Instead, on detection it immediately kills the process and stops the job.
 

--- a/README.md
+++ b/README.md
@@ -87,12 +87,12 @@ Based on public information as of May 2026. Corrections welcome.
 
 | Platform | Environment | Status |
 | --- | --- | --- |
-| GitHub Actions | GitHub-hosted runner | Supported |
-| GitHub Actions | Self-hosted Machine Runner | Supported |
-| GitHub Actions | Actions Runner Controller on Kubernetes | Planned |
-| GitLab CI/CD | Self-hosted Docker executor | Supported |
-| GitLab CI/CD | Self-hosted Kubernetes executor | Planned |
-| GitLab CI/CD | GitLab-hosted runner | Not supported (technical constraints) |
+| GitHub Actions | GitHub-hosted runner | ✅ Supported |
+| GitHub Actions | Self-hosted Machine Runner | ✅ Supported |
+| GitHub Actions | Actions Runner Controller on Kubernetes | 🚧 Planned |
+| GitLab CI/CD | Self-hosted Docker executor | ✅ Supported |
+| GitLab CI/CD | Self-hosted Kubernetes executor | 🚧 Planned |
+| GitLab CI/CD | GitLab-hosted runner | ❌ Not supported (technical constraints) |
 
 Works on both public and private repositories, with no third-party SaaS dependency.
 


### PR DESCRIPTION
### What

Add a "How cicd-sensor compares" section to the README, with a capability table comparing cicd-sensor against Harden-Runner Free. A footnote scopes the comparison to Harden-Runner's open-source public-repository path and notes StepSecurity's broader paid platform features so the comparison stays fair.

### Why

Multiple people suggested adding a side-by-side comparison so readers can quickly place cicd-sensor against the tool they already know. Harden-Runner is the de facto reference point in CI/CD runtime security, so it's the most useful single comparison to surface in the README. Other open-source efforts were considered but left out to keep the table focused on the best-known tool.