### PR TITLE
feat(agent): gracefully degrade when fentry LSM hooks are unavailable (custom kernels)

### DIFF
--- a/internal/agent/kerneltracker/kernelio/kernel_io_linux.go
+++ b/internal/agent/kerneltracker/kernelio/kernel_io_linux.go
@@ -90,7 +90,14 @@ func NewLinux(logger *slog.Logger, config Config) (kernelIO *LinuxKernelIO, err 
 	} {
 		attached, err := link.AttachTracing(link.TracingOptions{Program: attach.program})
 		if err != nil {
-			return nil, fmt.Errorf("attach %s tracing program: %w", attach.name, err)
+			// Custom kernels (e.g. Blacksmith CI runners, kernel 6.5.13) do not
+			// expose some LSM hook functions as fentry-attachable, so AttachTracing
+			// fails for those programs. A single unsupported probe must not abort the
+			// whole agent: warn, skip it, and keep the probes that do attach.
+			// Coverage degrades but the agent starts. (Experimental fallback.)
+			kernelIO.logger.Warn("skipping tracing program not attachable on this kernel",
+				"program", attach.name, "error", err.Error())
+			continue
 		}
 		kernelIO.links = append(kernelIO.links, attached)
 	}
@@ -113,10 +120,18 @@ func NewLinux(logger *slog.Logger, config Config) (kernelIO *LinuxKernelIO, err 
 			Program: attach.program,
 		})
 		if err != nil {
-			return nil, fmt.Errorf("attach %s program: %w", attach.name, err)
+			// Same experimental fallback as the tracing loop above: don't abort the
+			// agent if a cgroup program cannot attach on this kernel.
+			kernelIO.logger.Warn("skipping cgroup program not attachable on this kernel",
+				"program", attach.name, "error", err.Error())
+			continue
 		}
 		kernelIO.links = append(kernelIO.links, attached)
 	}
+
+	// Surface how many probes actually attached so a degraded (custom-kernel)
+	// start is visible in the agent log.
+	kernelIO.logger.Info("kernel probes attached", "count", len(kernelIO.links))
 
 	reader, err := ringbuf.NewReader(kernelIO.objs.Events)
 	if err != nil {

--- a/internal/agent/kerneltracker/kernelio/kernel_io_linux.go
+++ b/internal/agent/kerneltracker/kernelio/kernel_io_linux.go
@@ -3,10 +3,13 @@
 package kernelio
 
 import (
+	"bufio"
 	"context"
 	"errors"
 	"fmt"
 	"log/slog"
+	"os"
+	"strings"
 	"sync"
 
 	bpfprog "github.com/cicd-sensor/cicd-sensor/internal/agent/bpf/generated"
@@ -17,7 +20,12 @@ import (
 
 // LinuxKernelIO owns BPF program, map, and ring buffer I/O.
 type LinuxKernelIO struct {
-	logger          *slog.Logger
+	logger *slog.Logger
+	// coll owns every loaded program and map FD. Close tears it down.
+	coll *ebpf.Collection
+	// objs holds typed map handles assigned from coll so the generated map
+	// helpers keep working. Program fields are unused: programs are taken from
+	// coll.Programs directly so unattachable ones can be pruned at load time.
 	objs            bpfprog.BPFProgramObjects
 	links           []link.Link
 	reader          *ringbuf.Reader
@@ -50,13 +58,23 @@ func NewLinux(logger *slog.Logger, config Config) (kernelIO *LinuxKernelIO, err 
 	if err := configureBPFProgramSpec(spec); err != nil {
 		return nil, fmt.Errorf("configure bpf program spec: %w", err)
 	}
-	if err := spec.LoadAndAssign(&kernelIO.objs, nil); err != nil {
+
+	// Custom kernels (e.g. Blacksmith CI runners, kernel 6.5.13) do not expose
+	// some LSM hook functions for fentry. cilium/ebpf resolves an fentry program's
+	// attach target at load time, so an unattachable target fails the whole
+	// collection load — not just the later attach step. Drop those programs up
+	// front so the agent starts with reduced coverage instead of failing on such
+	// kernels. On a fully-capable kernel this prunes nothing.
+	pruneUnattachableTracingPrograms(spec, kernelIO.logger)
+
+	coll, err := ebpf.NewCollectionWithOptions(spec, ebpf.CollectionOptions{})
+	if err != nil {
 		return nil, fmt.Errorf("load bpf objects: %w", err)
 	}
+	kernelIO.coll = coll
 
-	// NewLinux fails fast on any attach/open error, but earlier steps may
-	// already have loaded objects or attached links. Roll those back here
-	// because no caller-owned LinuxKernelIO exists on failure.
+	// NewLinux fails fast on any later error; roll back coll / links here because
+	// no caller-owned LinuxKernelIO exists on failure.
 	defer func() {
 		if err == nil {
 			return
@@ -64,37 +82,46 @@ func NewLinux(logger *slog.Logger, config Config) (kernelIO *LinuxKernelIO, err 
 		_ = kernelIO.Close()
 	}()
 
+	// Maps are always present; assign them to the generated struct so the typed
+	// map helpers (kernel_io_maps_linux.go) and the loop keep working unchanged.
+	kernelIO.objs.Events = coll.Maps["events"]
+	kernelIO.objs.PathScratch = coll.Maps["path_scratch"]
+	kernelIO.objs.RingbufDropCount = coll.Maps["ringbuf_drop_count"]
+	kernelIO.objs.StagingMap = coll.Maps["staging_map"]
+	kernelIO.objs.TrackedCgroups = coll.Maps["tracked_cgroups"]
+
 	// fentry/security_file_open is used instead of BPF LSM so deployments do
 	// not need lsm=..., Rename/symlink observation stays in inode hooks
 	// because security_path_* cannot use bpf_d_path in container filesystems.
+	// program is nil when pruned above (not attachable on this kernel) -> skip.
 	for _, attach := range []struct {
 		name    string
 		program *ebpf.Program
 	}{
-		{name: "sched_process_fork", program: kernelIO.objs.HandleSchedProcessFork},
-		{name: "sched_process_exec", program: kernelIO.objs.HandleSchedProcessExec},
-		{name: "cgroup_mkdir", program: kernelIO.objs.HandleCgroupMkdir},
-		{name: "cgroup_attach_task", program: kernelIO.objs.HandleCgroupAttachTask},
-		{name: "cgroup_rmdir", program: kernelIO.objs.HandleCgroupRmdir},
-		{name: "security_file_open", program: kernelIO.objs.HandleSecurityFileOpen},
-		{name: "security_inode_unlink", program: kernelIO.objs.HandleSecurityInodeUnlink},
-		{name: "security_inode_rmdir", program: kernelIO.objs.HandleSecurityInodeRmdir},
-		{name: "security_inode_rename", program: kernelIO.objs.HandleSecurityInodeRename},
-		{name: "security_inode_link", program: kernelIO.objs.HandleSecurityInodeLink},
-		{name: "security_inode_symlink", program: kernelIO.objs.HandleSecurityInodeSymlink},
-		{name: "udp_sendmsg", program: kernelIO.objs.HandleUdpSendmsg},
-		{name: "udpv6_sendmsg", program: kernelIO.objs.HandleUdpv6Sendmsg},
-		{name: "tcp_sendmsg", program: kernelIO.objs.HandleTcpSendmsg},
-		{name: "unix_stream_sendmsg", program: kernelIO.objs.HandleUnixStreamSendmsg},
-		{name: "security_socket_connect", program: kernelIO.objs.HandleSecuritySocketConnect},
+		{name: "sched_process_fork", program: coll.Programs["handle_sched_process_fork"]},
+		{name: "sched_process_exec", program: coll.Programs["handle_sched_process_exec"]},
+		{name: "cgroup_mkdir", program: coll.Programs["handle_cgroup_mkdir"]},
+		{name: "cgroup_attach_task", program: coll.Programs["handle_cgroup_attach_task"]},
+		{name: "cgroup_rmdir", program: coll.Programs["handle_cgroup_rmdir"]},
+		{name: "security_file_open", program: coll.Programs["handle_security_file_open"]},
+		{name: "security_inode_unlink", program: coll.Programs["handle_security_inode_unlink"]},
+		{name: "security_inode_rmdir", program: coll.Programs["handle_security_inode_rmdir"]},
+		{name: "security_inode_rename", program: coll.Programs["handle_security_inode_rename"]},
+		{name: "security_inode_link", program: coll.Programs["handle_security_inode_link"]},
+		{name: "security_inode_symlink", program: coll.Programs["handle_security_inode_symlink"]},
+		{name: "udp_sendmsg", program: coll.Programs["handle_udp_sendmsg"]},
+		{name: "udpv6_sendmsg", program: coll.Programs["handle_udpv6_sendmsg"]},
+		{name: "tcp_sendmsg", program: coll.Programs["handle_tcp_sendmsg"]},
+		{name: "unix_stream_sendmsg", program: coll.Programs["handle_unix_stream_sendmsg"]},
+		{name: "security_socket_connect", program: coll.Programs["handle_security_socket_connect"]},
 	} {
+		if attach.program == nil {
+			kernelIO.logger.Warn("skipping tracing program pruned at load (not attachable on this kernel)",
+				"program", attach.name)
+			continue
+		}
 		attached, err := link.AttachTracing(link.TracingOptions{Program: attach.program})
 		if err != nil {
-			// Custom kernels (e.g. Blacksmith CI runners, kernel 6.5.13) do not
-			// expose some LSM hook functions as fentry-attachable, so AttachTracing
-			// fails for those programs. A single unsupported probe must not abort the
-			// whole agent: warn, skip it, and keep the probes that do attach.
-			// Coverage degrades but the agent starts. (Experimental fallback.)
 			kernelIO.logger.Warn("skipping tracing program not attachable on this kernel",
 				"program", attach.name, "error", err.Error())
 			continue
@@ -111,17 +138,20 @@ func NewLinux(logger *slog.Logger, config Config) (kernelIO *LinuxKernelIO, err 
 		attachType ebpf.AttachType
 		program    *ebpf.Program
 	}{
-		{name: "cgroup/connect4", attachType: ebpf.AttachCGroupInet4Connect, program: kernelIO.objs.HandleCgroupConnect4},
-		{name: "cgroup/connect6", attachType: ebpf.AttachCGroupInet6Connect, program: kernelIO.objs.HandleCgroupConnect6},
+		{name: "cgroup/connect4", attachType: ebpf.AttachCGroupInet4Connect, program: coll.Programs["handle_cgroup_connect4"]},
+		{name: "cgroup/connect6", attachType: ebpf.AttachCGroupInet6Connect, program: coll.Programs["handle_cgroup_connect6"]},
 	} {
+		if attach.program == nil {
+			kernelIO.logger.Warn("skipping cgroup program pruned at load (not attachable on this kernel)",
+				"program", attach.name)
+			continue
+		}
 		attached, err := link.AttachCgroup(link.CgroupOptions{
 			Path:    config.CgroupV2RootPath,
 			Attach:  attach.attachType,
 			Program: attach.program,
 		})
 		if err != nil {
-			// Same experimental fallback as the tracing loop above: don't abort the
-			// agent if a cgroup program cannot attach on this kernel.
 			kernelIO.logger.Warn("skipping cgroup program not attachable on this kernel",
 				"program", attach.name, "error", err.Error())
 			continue
@@ -139,4 +169,64 @@ func NewLinux(logger *slog.Logger, config Config) (kernelIO *LinuxKernelIO, err 
 	}
 	kernelIO.reader = reader
 	return kernelIO, nil
+}
+
+// pruneUnattachableTracingPrograms removes fentry/fexit programs whose target
+// kernel function is not exposed for ftrace/fentry on this kernel. cilium/ebpf
+// verifies the attach target during BPF_PROG_LOAD, so leaving an unattachable
+// fentry program in the spec fails the entire collection load. When
+// available_filter_functions cannot be read the spec is left untouched.
+func pruneUnattachableTracingPrograms(spec *ebpf.CollectionSpec, logger *slog.Logger) {
+	available, err := readAvailableFilterFunctions()
+	if err != nil {
+		logger.Warn("cannot read available_filter_functions; not pruning tracing programs",
+			"error", err.Error())
+		return
+	}
+	for name, programSpec := range spec.Programs {
+		if programSpec.Type != ebpf.Tracing {
+			continue
+		}
+		if programSpec.AttachType != ebpf.AttachTraceFEntry && programSpec.AttachType != ebpf.AttachTraceFExit {
+			continue
+		}
+		target := programSpec.AttachTo
+		if target == "" || available[target] {
+			continue
+		}
+		logger.Warn("pruning tracing program: attach target not fentry-attachable on this kernel",
+			"program", name, "target", target)
+		delete(spec.Programs, name)
+	}
+}
+
+// readAvailableFilterFunctions returns the set of kernel functions that can be
+// attached via ftrace/fentry, read from tracefs. Each line is "funcname" or
+// "funcname [module]"; only the function name is kept.
+func readAvailableFilterFunctions() (map[string]bool, error) {
+	for _, path := range []string{
+		"/sys/kernel/tracing/available_filter_functions",
+		"/sys/kernel/debug/tracing/available_filter_functions",
+	} {
+		file, err := os.Open(path)
+		if err != nil {
+			continue
+		}
+		defer file.Close()
+
+		functions := make(map[string]bool)
+		scanner := bufio.NewScanner(file)
+		for scanner.Scan() {
+			name := scanner.Text()
+			if space := strings.IndexByte(name, ' '); space >= 0 {
+				name = name[:space]
+			}
+			functions[name] = true
+		}
+		if err := scanner.Err(); err != nil {
+			return nil, fmt.Errorf("scan %s: %w", path, err)
+		}
+		return functions, nil
+	}
+	return nil, errors.New("available_filter_functions not found under tracefs")
 }

--- a/internal/agent/kerneltracker/kernelio/kernel_io_loop_linux.go
+++ b/internal/agent/kerneltracker/kernelio/kernel_io_loop_linux.go
@@ -142,12 +142,11 @@ func (kernelIO *LinuxKernelIO) Close() error {
 			}
 		}
 	}
-	if err := kernelIO.objs.Close(); err != nil {
-		if firstErr == nil {
-			firstErr = err
-		} else {
-			kernelIO.logger.Warn("bpf_objects_close_failed", "error", err)
-		}
+	// coll owns all program/map FDs (objs only holds aliases into coll.Maps, so
+	// closing coll is enough and avoids a double close). Collection.Close has no
+	// return value.
+	if kernelIO.coll != nil {
+		kernelIO.coll.Close()
 	}
 
 	return firstErr


### PR DESCRIPTION
Refs #46.

## Problem
On runners with a custom kernel that does not expose certain LSM hook functions for fentry — e.g. Blacksmith CI runners (kernel 6.5.13), where `security_socket_connect` is absent from `available_filter_functions` — the agent fails to start. cilium/ebpf resolves an fentry program's attach target during `BPF_PROG_LOAD`, so a single unattachable target fails the entire collection load (see #46 for the full diagnosis).

## Change
- Replace `CollectionSpec.LoadAndAssign` with `NewCollectionWithOptions` so individual programs can be omitted from the load.
- Before load, prune fentry/fexit programs whose `AttachTo` is not present in `available_filter_functions` (read from tracefs). On a fully-capable kernel this prunes nothing.
- Attach loops skip pruned/unattachable programs and log a warning; the agent starts with reduced coverage instead of aborting.
- Maps are assigned from the collection into the generated struct so the typed map helpers stay unchanged; `Close` is consolidated on the collection.

## Verification (`agent start --provider github --runner machine`)
- **ubuntu-latest**: 18/18 probes attach, nothing pruned, agent starts.
- **Blacksmith 2vcpu / 4vcpu**: only `security_socket_connect` is pruned (17/18), agent starts. Other LSM-hook probes (`security_file_open`, `security_inode_*`) attach fine.

## Notes
- Marked draft: this is a working PoC to unblock custom-kernel / third-party runners. Happy to add tests and align with loader conventions per maintainer guidance.
- No BPF C changes, so the existing fentry-vs-BPF-LSM design choice is untouched.