### PR TITLE
docs: clarify Kubernetes runner install guides

### DIFF
--- a/docs/developer-guide/kubernetes-runtime.md
+++ b/docs/developer-guide/kubernetes-runtime.md
@@ -11,11 +11,35 @@ Runner modes are install recipes; the runtime implementation uses NRI and hooks 
 | Job hook | GitHub ARC default, dind, Kubernetes mode | Runs after GitHub job assignment and calls the GitHub Kubernetes runner socket so cicd-sensor can bind the runner cgroup. |
 | Container customization hook wrapper | GitHub ARC Kubernetes mode | Wraps `ACTIONS_RUNNER_CONTAINER_HOOKS` and injects GitHub identity into workflow Pod annotations before ARC creates Kubernetes workflow containers. |
 
-References:
+GitHub and ARC references:
 
-- GitHub job hooks: `https://docs.github.com/actions/hosting-your-own-runners/managing-self-hosted-runners/running-scripts-before-or-after-a-job`
-- GitHub container customization hooks: `https://docs.github.com/en/actions/how-tos/manage-runners/self-hosted-runners/customize-containers`
-- ARC runner scale set deployment and hook extensions: `https://docs.github.com/en/enterprise-cloud@latest/actions/tutorials/use-actions-runner-controller/deploy-runner-scale-sets`
+| GitHub concept | GitHub docs | cicd-sensor integration point |
+| --- | --- | --- |
+| ARC runner scale sets | [Deploy runner scale sets](https://docs.github.com/en/actions/how-tos/manage-runners/use-actions-runner-controller/deploy-runner-scale-sets) | The user guide provides mode-specific DaemonSet and Helm values snippets for the official `gha-runner-scale-set` chart. |
+| ARC authentication | [Authenticate to the GitHub API](https://docs.github.com/en/actions/how-tos/manage-runners/use-actions-runner-controller/authenticate-to-the-api) | Required before installing the runner scale set; cicd-sensor does not replace ARC authentication. |
+| Workflow `runs-on` | [Use ARC runners in a workflow](https://docs.github.com/en/actions/how-tos/manage-runners/use-actions-runner-controller/use-arc-in-a-workflow) | The runner scale set name selected in GitHub is the workflow label users target. |
+| Job hooks | [Run scripts before or after a job](https://docs.github.com/actions/hosting-your-own-runners/managing-self-hosted-runners/running-scripts-before-or-after-a-job) | `ACTIONS_RUNNER_HOOK_JOB_STARTED` calls the GitHub Kubernetes runner socket after assignment and before workflow steps. |
+| Container customization hooks | [Customize containers used by jobs](https://docs.github.com/en/actions/how-tos/manage-runners/self-hosted-runners/customize-containers) | `ACTIONS_RUNNER_CONTAINER_HOOKS` is wrapped only in ARC Kubernetes mode to inject identity before workflow Pods are created. |
+
+For install order and mode-specific example files, see the [GitHub ARC user guide](../user-guide/kubernetes/github-arc.md).
+This page explains why the GitHub hooks and node-level components are needed.
+
+GitLab references:
+
+| GitLab concept | GitLab docs | cicd-sensor integration point |
+| --- | --- | --- |
+| GitLab Runner Helm chart | [Install GitLab Runner on Kubernetes](https://docs.gitlab.com/runner/install/kubernetes/) | The user guide provides a node-level DaemonSet and a minimal values snippet for the official GitLab Runner chart. |
+| Kubernetes executor | [GitLab Runner Kubernetes executor](https://docs.gitlab.com/runner/executors/kubernetes/) | GitLab Runner creates job Pods; cicd-sensor reads their labels and annotations through NRI. |
+
+For install order and example files, see the [GitLab Runner Kubernetes executor user guide](../user-guide/kubernetes/gitlab-runner.md).
+
+## ARC values merging
+
+ARC Helm values need manual merging because runner containers, environment
+variables, volume mounts, and volumes are YAML lists. Helm replaces lists from
+later values files instead of merging list entries, so a separate cicd-sensor
+values file can silently remove either existing runner settings or the
+cicd-sensor hook settings.
 
 ## Node runtime requirements
 
@@ -43,8 +67,15 @@ Consumed sources, in identity precedence order:
 Container environment variables such as `CI_PROJECT_PATH` and `CI_SERVER_HOST` are last-resort identity fallbacks, and variables such as `CI_PIPELINE_SOURCE` and `CI_COMMIT_SHA` fill metadata.
 Job configuration can override environment values, so an identity built from env alone is job-author-influenced; runner-set annotations are preferred for identity fields.
 
-`build` and user-defined service containers are monitored.
-`helper` and `init-permissions` are GitLab Runner infrastructure containers and are skipped by default.
+Default container handling:
+
+| GitLab Runner container | Handling |
+| --- | --- |
+| `build` | Monitored. |
+| user-defined service containers | Monitored as part of the same CI job. |
+| `helper` | Skipped by default. |
+| `init-permissions` | Skipped by default. |
+
 Containers without enough trusted Pod metadata to build a job identity are skipped.
 
 GitLab Kubernetes staging is a single local agent call.
@@ -92,6 +123,12 @@ Injected annotations:
 The container customization hook wrapper does not replace NRI.
 It supplies identity before Pod creation; NRI still supplies the runtime cgroup path at container creation time.
 Using the hook alone would require post-create Kubernetes API lookup or exposing a staging socket to the runner, and would no longer match the existing cgroup-mkdir staging model.
+
+The wrapper currently generates its own temporary hook template and overwrites
+any existing `ACTIONS_RUNNER_CONTAINER_HOOK_TEMPLATE` setting. Operators that
+use a custom ARC hook template for security context, labels, or other PodSpec
+overrides need to merge those settings into the cicd-sensor wrapper flow before
+enabling Kubernetes mode.
 
 ARC Kubernetes mode keeps workflow-created Pods on the same node as the runner Pod.
 Agent state and cgroup tracking are node-local, so the agent that receives the GitHub job start must be the same node agent that receives the NRI `CreateContainer` events for the workflow job, service, and container-action Pods.

--- a/docs/user-guide/kubernetes/github-arc.md
+++ b/docs/user-guide/kubernetes/github-arc.md
@@ -1,99 +1,242 @@
 # GitHub ARC runner scale sets
 
 GitHub Actions support for Actions Runner Controller is available as preview support.
-This page describes the deployment model for ARC runner scale sets.
+This page is an install guide for ARC runner scale sets.
+For runtime details such as NRI, cgroups, and hook behavior, see [Kubernetes Runtime](../../developer-guide/kubernetes-runtime.md).
 
-Use the official `gha-runner-scale-set` Helm chart.
-Install the shared [Kubernetes runner setup](index.md) first, then configure the ARC runner scale set for the mode you use.
-The node-level cicd-sensor DaemonSet runs privileged as root; do not mount host runtime or cicd-sensor staging sockets into workflow-created Pods.
+Use GitHub's official [`gha-runner-scale-set` Helm chart](https://docs.github.com/en/actions/how-tos/manage-runners/use-actions-runner-controller/deploy-runner-scale-sets).
+Review the shared [Kubernetes runner setup](index.md), then install the mode that matches your ARC runner scale set.
 
-## Mode summary
+## Choose a mode
 
-| ARC mode | What runs where | cicd-sensor setup | Notes |
-| --- | --- | --- | --- |
-| [`containerMode` unset](#default-mode) | The job runs in the runner container. | Job hook + GitHub Kubernetes runner socket. | Best for script, JavaScript action, and composite action workflows. |
-| [`containerMode.type: dind`](#dind-mode) | The runner talks to a privileged dind sidecar. | Job hook + GitHub Kubernetes runner socket. | Highest compatibility with Docker workflows, but higher security risk. |
-| [`containerMode.type: kubernetes`](#kubernetes-mode) | Job containers, services, and container actions become Kubernetes Pods. | Job hook + GitHub Kubernetes runner socket + container customization hook wrapper + NRI. | Kubernetes-native and avoids dind, but Docker daemon workflows need alternatives. |
+| ARC mode | Use when | cicd-sensor setup |
+| --- | --- | --- |
+| [Default mode](#default-mode) | `containerMode` is not set. Jobs run in the runner container. | DaemonSet + GitHub job hook + runner socket mount. |
+| [dind mode](#dind-mode) | Workflows need Docker compatibility, such as `docker build` or Docker Compose. | DaemonSet + GitHub job hook + runner socket mount. |
+| [Kubernetes mode](#kubernetes-mode) | Workflow `container:`, `services:`, and container actions should run as Kubernetes Pods. | DaemonSet + NRI + GitHub job hook + ARC container hook wrapper. |
 
-## Hook types
+## Before you start
 
-GitHub ARC support uses two different GitHub runner hook mechanisms:
+1. Install [cicd-sensor Manager](../manager.md) and create a manager token.
+2. Confirm the node requirements on [Kubernetes runner install](index.md), including Linux cgroup v2, containerd NRI, and runc systemd cgroups.
+3. Install and authenticate ARC using GitHub's [Actions Runner Controller](https://docs.github.com/en/actions/concepts/runners/actions-runner-controller), [authentication](https://docs.github.com/en/actions/how-tos/manage-runners/use-actions-runner-controller/authenticate-to-the-api), and [runner scale set deployment](https://docs.github.com/en/actions/how-tos/manage-runners/use-actions-runner-controller/deploy-runner-scale-sets) docs.
+4. Decide the namespace for your runner scale set. This guide uses `arc-runners`.
+5. Set GitHub workflow `runs-on` to your ARC runner scale set name, as described in GitHub's [Using ARC runners in a workflow](https://docs.github.com/en/actions/how-tos/manage-runners/use-actions-runner-controller/use-arc-in-a-workflow) docs.
 
-| Hook mechanism | GitHub setting | When it runs | cicd-sensor use |
-| --- | --- | --- | --- |
-| [Job hook](https://docs.github.com/actions/hosting-your-own-runners/managing-self-hosted-runners/running-scripts-before-or-after-a-job) | `ACTIONS_RUNNER_HOOK_JOB_STARTED` | After a job is assigned to the runner and before workflow steps run. | Calls the GitHub Kubernetes runner socket to start monitoring and bind the runner cgroup. |
-| [Container customization hook wrapper](https://docs.github.com/en/actions/how-tos/manage-runners/self-hosted-runners/customize-containers) | `ACTIONS_RUNNER_CONTAINER_HOOKS` | During GitHub's container customization flow, such as `prepare_job` and `run_container_step`. | Kubernetes mode only: injects GitHub identity into Pod annotations before ARC creates workflow job, service, and container-action Pods. |
+Use pinned cicd-sensor image tags and pinned ARC chart versions in production.
+The example files use `:latest` only as a placeholder.
 
-The job hook is the job lifecycle hook.
-The container customization hook wrapper is a wrapper around ARC's Kubernetes container hook implementation.
-The ConfigMap exists only to distribute that wrapper, so it is only needed in Kubernetes mode.
+## Security and operational notes
 
-For ARC runner scale set and Kubernetes-mode hook extension details, see GitHub's [Deploying runner scale sets with Actions Runner Controller](https://docs.github.com/en/enterprise-cloud@latest/actions/tutorials/use-actions-runner-controller/deploy-runner-scale-sets) documentation.
+- The cicd-sensor DaemonSet is a privileged node agent.
+- The GitHub job hook is fail-closed. If the agent or GitHub Kubernetes runner socket is unavailable on a node, jobs scheduled on that node can fail before workflow steps run.
+- Do not mount host `containerd.sock`, CRI socket, NRI socket, or `/run/cicd-sensor` internal sockets into workflow-created job, service, or step Pods.
+- The GitHub Kubernetes runner socket mounted into ARC runner containers is the only cicd-sensor socket exception in this guide.
+- The ARC runner namespace must allow the hostPath volume used for the GitHub Kubernetes runner socket.
+- dind mode runs a privileged Docker daemon sidecar and should be treated as a higher-risk compatibility mode.
+- Kubernetes mode uses `ACTIONS_RUNNER_CONTAINER_HOOKS`; the example wrapper currently overwrites any existing `ACTIONS_RUNNER_CONTAINER_HOOK_TEMPLATE` setting.
 
-## Deploy by mode
+## Shared setup
 
-### Default mode
+Create the cicd-sensor namespace and the ARC runner namespace before applying ConfigMaps or installing the runner scale set.
+The job hook ConfigMap is namespaced, so it must exist before ARC creates runner Pods that reference it.
 
-When `containerMode` is not set, ARC creates the runner Pod and the GitHub job runs inside the runner container.
-The runner Pod is created before GitHub assigns a job, so NRI cannot build the job identity from the runner container creation event.
+```sh
+kubectl create namespace cicd-sensor-system --dry-run=client -o yaml | kubectl apply -f -
+kubectl create namespace arc-runners --dry-run=client -o yaml | kubectl apply -f -
+```
 
-| Requirement | Default mode |
+If your cluster enforces Pod Security Admission or another admission policy, make sure `arc-runners` allows the hostPath volume used by the runner socket mount.
+
+Create the manager token secret from your shell environment instead of writing the token into a manifest file:
+
+```sh
+kubectl -n cicd-sensor-system create secret generic cicd-sensor-manager \
+  --from-literal=token="${CICD_SENSOR_MANAGER_TOKEN}" \
+  --dry-run=client -o yaml | kubectl apply -f -
+```
+
+## Values merge rule
+
+Do not pass your existing ARC values and the cicd-sensor example as two separate `--values` files.
+Helm deep-merges maps, but lists are replaced by the later file.
+The ARC runner container, `env`, `volumeMounts`, and `volumes` are lists, so a second values file can silently remove either your existing runner settings or the cicd-sensor hook settings.
+
+For each mode below, copy the example values and merge the listed entries into your existing ARC runner scale set values.
+Save the merged result as `cicd-sensor-arc-values.yaml`, then pass only that one values file to Helm.
+
+## Default mode
+
+Use this when `containerMode` is not set.
+Jobs run directly in the ARC runner container.
+This mode is suitable for script, JavaScript action, and composite action workflows.
+
+Copy these files:
+
+| Local file | Copy from |
 | --- | --- |
-| Node install | [`examples/kubernetes/github-arc/default-mode/daemonset.yaml`](https://github.com/cicd-sensor/cicd-sensor/blob/main/examples/kubernetes/github-arc/default-mode/daemonset.yaml) |
-| Job hook | `ACTIONS_RUNNER_HOOK_JOB_STARTED` in the runner container. |
-| Job hook ConfigMap | [`examples/kubernetes/github-arc/common/job-hook-configmap.yaml`](https://github.com/cicd-sensor/cicd-sensor/blob/main/examples/kubernetes/github-arc/common/job-hook-configmap.yaml) |
-| GitHub Kubernetes runner socket | Required in the runner container so the job hook can start monitoring and bind the runner cgroup. |
-| NRI | Not used in this mode. |
-| ARC values | [`examples/kubernetes/github-arc/default-mode/values.yaml`](https://github.com/cicd-sensor/cicd-sensor/blob/main/examples/kubernetes/github-arc/default-mode/values.yaml) |
+| `cicd-sensor-daemonset.yaml` | [`examples/kubernetes/github-arc/default-mode/daemonset.yaml`](https://github.com/cicd-sensor/cicd-sensor/blob/main/examples/kubernetes/github-arc/default-mode/daemonset.yaml) |
+| `cicd-sensor-job-hook.yaml` | [`examples/kubernetes/github-arc/common/job-hook-configmap.yaml`](https://github.com/cicd-sensor/cicd-sensor/blob/main/examples/kubernetes/github-arc/common/job-hook-configmap.yaml) |
+| `cicd-sensor-arc-values.yaml` | merge [`examples/kubernetes/github-arc/default-mode/values.yaml`](https://github.com/cicd-sensor/cicd-sensor/blob/main/examples/kubernetes/github-arc/default-mode/values.yaml) into your existing ARC values |
 
-### dind mode
+Edit `cicd-sensor-daemonset.yaml`:
 
-In dind mode, ARC creates a runner container and a privileged dind sidecar in the same Pod.
+- set `CICD_SENSOR_MANAGER_URL`
+- set namespace names if you do not use `cicd-sensor-system`
+- pin the cicd-sensor image tag
+- confirm the `cicd-sensor-manager` secret name matches the secret you created
 
-| Requirement | dind mode |
+Merge these values into your existing runner container definition:
+
+- `ACTIONS_RUNNER_HOOK_JOB_STARTED`
+- `CICD_SENSOR_GITHUB_K8S_RUNNER_SOCKET`
+- the job hook ConfigMap volume and mount
+- the GitHub Kubernetes runner socket hostPath volume and mount
+
+Apply and upgrade:
+
+```sh
+kubectl apply -f cicd-sensor-daemonset.yaml
+kubectl apply -f cicd-sensor-job-hook.yaml
+
+helm upgrade --install RUNNER_SCALE_SET_NAME \
+  oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set \
+  --namespace arc-runners \
+  --version ARC_CHART_VERSION \
+  --values cicd-sensor-arc-values.yaml
+```
+
+## dind mode
+
+Use this when workflows need Docker compatibility, such as `docker build` or Docker Compose.
+This mode uses ARC `containerMode.type: dind`.
+
+Copy these files:
+
+| Local file | Copy from |
 | --- | --- |
-| Node install | [`examples/kubernetes/github-arc/dind-mode/daemonset.yaml`](https://github.com/cicd-sensor/cicd-sensor/blob/main/examples/kubernetes/github-arc/dind-mode/daemonset.yaml) |
-| Job hook | `ACTIONS_RUNNER_HOOK_JOB_STARTED` in the runner container. |
-| Job hook ConfigMap | [`examples/kubernetes/github-arc/common/job-hook-configmap.yaml`](https://github.com/cicd-sensor/cicd-sensor/blob/main/examples/kubernetes/github-arc/common/job-hook-configmap.yaml) |
-| GitHub Kubernetes runner socket | Required in the runner container so the job hook can start monitoring and bind the runner plus dind sidecar cgroups. |
-| NRI | Not used in this mode. Host NRI does not see inner Docker lifecycle created by dind. |
-| ARC values | [`examples/kubernetes/github-arc/dind-mode/values.yaml`](https://github.com/cicd-sensor/cicd-sensor/blob/main/examples/kubernetes/github-arc/dind-mode/values.yaml) |
+| `cicd-sensor-daemonset.yaml` | [`examples/kubernetes/github-arc/dind-mode/daemonset.yaml`](https://github.com/cicd-sensor/cicd-sensor/blob/main/examples/kubernetes/github-arc/dind-mode/daemonset.yaml) |
+| `cicd-sensor-job-hook.yaml` | [`examples/kubernetes/github-arc/common/job-hook-configmap.yaml`](https://github.com/cicd-sensor/cicd-sensor/blob/main/examples/kubernetes/github-arc/common/job-hook-configmap.yaml) |
+| `cicd-sensor-arc-values.yaml` | merge [`examples/kubernetes/github-arc/dind-mode/values.yaml`](https://github.com/cicd-sensor/cicd-sensor/blob/main/examples/kubernetes/github-arc/dind-mode/values.yaml) into your existing ARC values |
 
-dind is a compatibility mode.
-It supports existing Docker-heavy workflows, but privileged dind materially increases the risk of host compromise compared with ordinary Kubernetes job containers.
+Edit `cicd-sensor-daemonset.yaml`:
 
-### Kubernetes mode
+- set `CICD_SENSOR_MANAGER_URL`
+- set namespace names if you do not use `cicd-sensor-system`
+- pin the cicd-sensor image tag
+- confirm the `cicd-sensor-manager` secret name matches the secret you created
 
-In Kubernetes mode, ARC uses GitHub's container hooks to create workflow job containers, services, and container actions as Kubernetes Pods.
+Merge these values into your existing runner scale set values:
 
-| Requirement | Kubernetes mode |
+- `containerMode.type: dind`
+- `ACTIONS_RUNNER_HOOK_JOB_STARTED`
+- `CICD_SENSOR_GITHUB_K8S_RUNNER_SOCKET`
+- the job hook ConfigMap volume and mount
+- the GitHub Kubernetes runner socket hostPath volume and mount
+
+Apply and upgrade:
+
+```sh
+kubectl apply -f cicd-sensor-daemonset.yaml
+kubectl apply -f cicd-sensor-job-hook.yaml
+
+helm upgrade --install RUNNER_SCALE_SET_NAME \
+  oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set \
+  --namespace arc-runners \
+  --version ARC_CHART_VERSION \
+  --values cicd-sensor-arc-values.yaml
+```
+
+## Kubernetes mode
+
+Use this when ARC should create workflow job containers, services, and container actions as Kubernetes Pods.
+This mode uses ARC `containerMode.type: kubernetes`.
+
+Copy these files:
+
+| Local file | Copy from |
 | --- | --- |
-| Node install | [`examples/kubernetes/github-arc/kubernetes-mode/daemonset.yaml`](https://github.com/cicd-sensor/cicd-sensor/blob/main/examples/kubernetes/github-arc/kubernetes-mode/daemonset.yaml) |
-| Job hook | `ACTIONS_RUNNER_HOOK_JOB_STARTED` in the runner container. |
-| Job hook ConfigMap | [`examples/kubernetes/github-arc/common/job-hook-configmap.yaml`](https://github.com/cicd-sensor/cicd-sensor/blob/main/examples/kubernetes/github-arc/common/job-hook-configmap.yaml) |
-| GitHub Kubernetes runner socket | Required in the runner container so the job hook can start monitoring and bind the runner cgroup. |
-| Container customization hook wrapper | Required. Use [`examples/kubernetes/github-arc/kubernetes-mode/container-hook-wrapper-configmap.yaml`](https://github.com/cicd-sensor/cicd-sensor/blob/main/examples/kubernetes/github-arc/kubernetes-mode/container-hook-wrapper-configmap.yaml). |
-| NRI | Required. NRI reads injected Pod annotations and runtime cgroup paths for workflow job, service, and container-action Pods. |
-| ARC values | [`examples/kubernetes/github-arc/kubernetes-mode/values.yaml`](https://github.com/cicd-sensor/cicd-sensor/blob/main/examples/kubernetes/github-arc/kubernetes-mode/values.yaml) |
+| `cicd-sensor-daemonset.yaml` | [`examples/kubernetes/github-arc/kubernetes-mode/daemonset.yaml`](https://github.com/cicd-sensor/cicd-sensor/blob/main/examples/kubernetes/github-arc/kubernetes-mode/daemonset.yaml) |
+| `cicd-sensor-job-hook.yaml` | [`examples/kubernetes/github-arc/common/job-hook-configmap.yaml`](https://github.com/cicd-sensor/cicd-sensor/blob/main/examples/kubernetes/github-arc/common/job-hook-configmap.yaml) |
+| `cicd-sensor-container-hook-wrapper.yaml` | [`examples/kubernetes/github-arc/kubernetes-mode/container-hook-wrapper-configmap.yaml`](https://github.com/cicd-sensor/cicd-sensor/blob/main/examples/kubernetes/github-arc/kubernetes-mode/container-hook-wrapper-configmap.yaml) |
+| `cicd-sensor-arc-values.yaml` | merge [`examples/kubernetes/github-arc/kubernetes-mode/values.yaml`](https://github.com/cicd-sensor/cicd-sensor/blob/main/examples/kubernetes/github-arc/kubernetes-mode/values.yaml) into your existing ARC values |
 
-The Kubernetes mode values pass the runner Pod's `spec.nodeName` to the container hook wrapper.
-The wrapper pins workflow-created Pods to the same node so the node-local agent that receives the job start also receives the NRI container events.
+Edit `cicd-sensor-daemonset.yaml`:
 
-Do not mount cicd-sensor sockets into workflow-created job, service, or step containers.
+- set `CICD_SENSOR_MANAGER_URL`
+- set namespace names if you do not use `cicd-sensor-system`
+- pin the cicd-sensor image tag
+- confirm the `cicd-sensor-manager` secret name matches the secret you created
 
-## Example files
+Merge these values into your existing runner scale set values:
 
-Current Kubernetes examples:
+- `containerMode.type: kubernetes`
+- `kubernetesModeWorkVolumeClaim`
+- `ACTIONS_RUNNER_HOOK_JOB_STARTED`
+- `CICD_SENSOR_GITHUB_K8S_RUNNER_SOCKET`
+- `ACTIONS_RUNNER_CONTAINER_HOOKS`
+- `CICD_SENSOR_K8S_NODE_NAME`
+- the job hook ConfigMap volume and mount
+- the GitHub Kubernetes runner socket hostPath volume and mount
+- the container hook wrapper ConfigMap volume and mount
 
-| File | Use |
+Apply and upgrade:
+
+```sh
+kubectl apply -f cicd-sensor-daemonset.yaml
+kubectl apply -f cicd-sensor-job-hook.yaml
+kubectl apply -f cicd-sensor-container-hook-wrapper.yaml
+
+helm upgrade --install RUNNER_SCALE_SET_NAME \
+  oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set \
+  --namespace arc-runners \
+  --version ARC_CHART_VERSION \
+  --values cicd-sensor-arc-values.yaml
+```
+
+## Verify
+
+Check the cicd-sensor DaemonSet:
+
+```sh
+kubectl -n cicd-sensor-system rollout status daemonset/cicd-sensor
+kubectl -n cicd-sensor-system logs daemonset/cicd-sensor -c agent
+```
+
+For Kubernetes mode, also check the NRI container:
+
+```sh
+kubectl -n cicd-sensor-system logs daemonset/cicd-sensor -c nri
+```
+
+Expected logs:
+
+| Mode | Log signal |
 | --- | --- |
-| [`examples/kubernetes/github-arc/default-mode/daemonset.yaml`](https://github.com/cicd-sensor/cicd-sensor/blob/main/examples/kubernetes/github-arc/default-mode/daemonset.yaml) | Node-level install for ARC default mode. |
-| [`examples/kubernetes/github-arc/default-mode/values.yaml`](https://github.com/cicd-sensor/cicd-sensor/blob/main/examples/kubernetes/github-arc/default-mode/values.yaml) | ARC default mode runner scale set values. |
-| [`examples/kubernetes/github-arc/dind-mode/daemonset.yaml`](https://github.com/cicd-sensor/cicd-sensor/blob/main/examples/kubernetes/github-arc/dind-mode/daemonset.yaml) | Node-level install for ARC dind mode. |
-| [`examples/kubernetes/github-arc/dind-mode/values.yaml`](https://github.com/cicd-sensor/cicd-sensor/blob/main/examples/kubernetes/github-arc/dind-mode/values.yaml) | ARC dind mode runner scale set values. |
-| [`examples/kubernetes/github-arc/common/job-hook-configmap.yaml`](https://github.com/cicd-sensor/cicd-sensor/blob/main/examples/kubernetes/github-arc/common/job-hook-configmap.yaml) | Job hook script used by all ARC modes. |
-| [`examples/kubernetes/github-arc/kubernetes-mode/daemonset.yaml`](https://github.com/cicd-sensor/cicd-sensor/blob/main/examples/kubernetes/github-arc/kubernetes-mode/daemonset.yaml) | Node-level install for ARC Kubernetes mode. |
-| [`examples/kubernetes/github-arc/kubernetes-mode/container-hook-wrapper-configmap.yaml`](https://github.com/cicd-sensor/cicd-sensor/blob/main/examples/kubernetes/github-arc/kubernetes-mode/container-hook-wrapper-configmap.yaml) | ARC Kubernetes mode container customization hook wrapper. |
-| [`examples/kubernetes/github-arc/kubernetes-mode/values.yaml`](https://github.com/cicd-sensor/cicd-sensor/blob/main/examples/kubernetes/github-arc/kubernetes-mode/values.yaml) | ARC Kubernetes mode Helm values snippet. |
+| all modes | `github_k8s_start_accepted` after a GitHub job starts |
+| Kubernetes mode | `nri_observer_starting` when the NRI observer registers |
+| Kubernetes mode | `nri_staging_put` when workflow-created Pods are staged |
 
-For implementation details, see [Kubernetes Runtime](../../developer-guide/kubernetes-runtime.md).
+Check that ARC runner Pods include the job hook and runner socket mount:
+
+```sh
+kubectl -n arc-runners describe pod RUNNER_POD_NAME
+```
+
+Look for `ACTIONS_RUNNER_HOOK_JOB_STARTED` and the `/run/cicd-sensor/github-k8s` volume mount.
+Then run a GitHub Actions workflow whose `runs-on` matches the runner scale set name.
+The job should appear in cicd-sensor Manager logs.
+
+## Uninstall
+
+1. Remove the cicd-sensor env, volume mounts, and volumes from your ARC values, then run `helm upgrade` for the runner scale set.
+2. Delete the hook ConfigMaps you applied.
+3. Delete the cicd-sensor DaemonSet, ServiceAccount, and manager token secret.
+
+```sh
+kubectl -n arc-runners delete configmap cicd-sensor-github-arc-job-hook --ignore-not-found
+kubectl -n arc-runners delete configmap cicd-sensor-github-arc-kubernetes-mode-hook-wrapper --ignore-not-found
+kubectl -n cicd-sensor-system delete secret cicd-sensor-manager --ignore-not-found
+kubectl -n cicd-sensor-system delete daemonset cicd-sensor --ignore-not-found
+kubectl -n cicd-sensor-system delete serviceaccount cicd-sensor --ignore-not-found
+```

--- a/docs/user-guide/kubernetes/gitlab-runner.md
+++ b/docs/user-guide/kubernetes/gitlab-runner.md
@@ -1,29 +1,112 @@
 # GitLab Runner Kubernetes executor
 
 GitLab Runner Kubernetes executor support is available as preview support.
+This page is an install guide for GitLab Runner on Kubernetes.
+For runtime details such as NRI, cgroups, and GitLab identity extraction, see [Kubernetes Runtime](../../developer-guide/kubernetes-runtime.md).
 
-Install the shared [Kubernetes runner setup](index.md) first, then configure GitLab Runner with the Kubernetes executor.
-cicd-sensor does not require a GitLab-specific hook in this mode.
-The node-level cicd-sensor DaemonSet runs privileged as root; GitLab job Pods do not mount host runtime or cicd-sensor staging sockets.
+Use GitLab's official [GitLab Runner Helm chart](https://docs.gitlab.com/runner/install/kubernetes/) with the [Kubernetes executor](https://docs.gitlab.com/runner/executors/kubernetes/).
+Review the shared [Kubernetes runner setup](index.md), then install cicd-sensor on the nodes that run GitLab Runner jobs.
 
-## Runner behavior
+## Before you start
 
-| GitLab Runner container | Default handling |
+1. Install [cicd-sensor Manager](../manager.md) and create a manager token.
+2. Confirm the node requirements on [Kubernetes runner install](index.md), including Linux cgroup v2, containerd NRI, and runc systemd cgroups.
+3. Install or prepare GitLab Runner using GitLab's [Helm chart](https://docs.gitlab.com/runner/install/kubernetes/) docs.
+4. Configure GitLab Runner with the [Kubernetes executor](https://docs.gitlab.com/runner/executors/kubernetes/).
+5. Decide the namespace for GitLab Runner. This guide uses `gitlab-runner`.
+
+Use pinned cicd-sensor image tags and pinned GitLab Runner chart versions in production.
+The example files use `:latest` only as a placeholder.
+
+## Security and operational notes
+
+- The cicd-sensor DaemonSet is a privileged node agent.
+- GitLab Runner Kubernetes executor does not need a GitLab-specific hook.
+- GitLab job Pods do not mount host `containerd.sock`, CRI socket, NRI socket, or `/run/cicd-sensor` internal sockets.
+- cicd-sensor reads GitLab Runner-created Pod labels and annotations from host-side NRI events.
+
+## Install
+
+Create the cicd-sensor namespace and the GitLab Runner namespace:
+
+```sh
+kubectl create namespace cicd-sensor-system --dry-run=client -o yaml | kubectl apply -f -
+kubectl create namespace gitlab-runner --dry-run=client -o yaml | kubectl apply -f -
+```
+
+Create the manager token secret from your shell environment instead of writing the token into a manifest file:
+
+```sh
+kubectl -n cicd-sensor-system create secret generic cicd-sensor-manager \
+  --from-literal=token="${CICD_SENSOR_MANAGER_TOKEN}" \
+  --dry-run=client -o yaml | kubectl apply -f -
+```
+
+Copy these files into your environment-specific install directory:
+
+| Local file | Copy from |
 | --- | --- |
-| `build` | Monitored. |
-| user-defined service containers | Monitored as part of the same CI job. |
-| `helper` | Not monitored by default. |
-| `init-permissions` | Not monitored by default. |
+| `cicd-sensor-daemonset.yaml` | [`examples/kubernetes/gitlab-runner/kubernetes-executor/daemonset.yaml`](https://github.com/cicd-sensor/cicd-sensor/blob/main/examples/kubernetes/gitlab-runner/kubernetes-executor/daemonset.yaml) |
+| `gitlab-runner-values.yaml` | merge [`examples/kubernetes/gitlab-runner/kubernetes-executor/values.yaml`](https://github.com/cicd-sensor/cicd-sensor/blob/main/examples/kubernetes/gitlab-runner/kubernetes-executor/values.yaml) into your existing GitLab Runner values |
 
-## Install shape
+Edit `cicd-sensor-daemonset.yaml`:
 
-Install cicd-sensor as a node-level DaemonSet with NRI enabled:
+- set `CICD_SENSOR_MANAGER_URL`
+- set namespace names if you do not use `cicd-sensor-system`
+- pin the cicd-sensor image tag
+- confirm the `cicd-sensor-manager` secret name matches the secret you created
 
-- [`examples/kubernetes/gitlab-runner/kubernetes-executor/daemonset.yaml`](https://github.com/cicd-sensor/cicd-sensor/blob/main/examples/kubernetes/gitlab-runner/kubernetes-executor/daemonset.yaml)
+Merge the GitLab Runner values into your existing Helm values.
+The example is only a minimal Kubernetes executor snippet.
+Keep your existing `gitlabUrl`, runner registration, tags, cache, and resource settings.
 
-Configure GitLab Runner Kubernetes executor with:
+Apply cicd-sensor:
 
-- [`examples/kubernetes/gitlab-runner/kubernetes-executor/values.yaml`](https://github.com/cicd-sensor/cicd-sensor/blob/main/examples/kubernetes/gitlab-runner/kubernetes-executor/values.yaml)
+```sh
+kubectl apply -f cicd-sensor-daemonset.yaml
+```
 
-See [Kubernetes runner install](index.md) for shared node requirements.
-For implementation details, see [Kubernetes Runtime](../../developer-guide/kubernetes-runtime.md).
+Install or upgrade GitLab Runner with your merged values:
+
+```sh
+helm repo add gitlab https://charts.gitlab.io
+helm repo update
+
+helm upgrade --install gitlab-runner gitlab/gitlab-runner \
+  --namespace gitlab-runner \
+  --version GITLAB_RUNNER_CHART_VERSION \
+  --values gitlab-runner-values.yaml
+```
+
+## Verify
+
+Check the cicd-sensor DaemonSet:
+
+```sh
+kubectl -n cicd-sensor-system rollout status daemonset/cicd-sensor
+kubectl -n cicd-sensor-system logs daemonset/cicd-sensor -c agent
+kubectl -n cicd-sensor-system logs daemonset/cicd-sensor -c nri
+```
+
+Expected logs:
+
+| Container | Log signal |
+| --- | --- |
+| `nri` | `nri_observer_starting` when the NRI observer registers |
+| `nri` | `nri_staging_put` when GitLab build or service containers are staged |
+
+Run a GitLab pipeline on the Kubernetes runner.
+If the project also has shared runners enabled, use a runner tag or disable shared runners for the verification job so the job is guaranteed to run on this Kubernetes runner.
+The job should appear in cicd-sensor Manager logs.
+
+## Uninstall
+
+1. Remove the cicd-sensor DaemonSet.
+2. Remove the manager token secret if it is no longer used.
+3. Uninstall GitLab Runner only if this cluster no longer needs it.
+
+```sh
+kubectl -n cicd-sensor-system delete secret cicd-sensor-manager --ignore-not-found
+kubectl -n cicd-sensor-system delete daemonset cicd-sensor --ignore-not-found
+kubectl -n cicd-sensor-system delete serviceaccount cicd-sensor --ignore-not-found
+```

--- a/examples/kubernetes/github-arc/default-mode/daemonset.yaml
+++ b/examples/kubernetes/github-arc/default-mode/daemonset.yaml
@@ -9,15 +9,6 @@ metadata:
   name: cicd-sensor
   namespace: cicd-sensor-system
 ---
-apiVersion: v1
-kind: Secret
-metadata:
-  name: cicd-sensor-manager
-  namespace: cicd-sensor-system
-type: Opaque
-stringData:
-  token: sk_cs_replace_me
----
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:

--- a/examples/kubernetes/github-arc/dind-mode/daemonset.yaml
+++ b/examples/kubernetes/github-arc/dind-mode/daemonset.yaml
@@ -9,15 +9,6 @@ metadata:
   name: cicd-sensor
   namespace: cicd-sensor-system
 ---
-apiVersion: v1
-kind: Secret
-metadata:
-  name: cicd-sensor-manager
-  namespace: cicd-sensor-system
-type: Opaque
-stringData:
-  token: sk_cs_replace_me
----
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:

--- a/examples/kubernetes/github-arc/kubernetes-mode/daemonset.yaml
+++ b/examples/kubernetes/github-arc/kubernetes-mode/daemonset.yaml
@@ -9,15 +9,6 @@ metadata:
   name: cicd-sensor
   namespace: cicd-sensor-system
 ---
-apiVersion: v1
-kind: Secret
-metadata:
-  name: cicd-sensor-manager
-  namespace: cicd-sensor-system
-type: Opaque
-stringData:
-  token: sk_cs_replace_me
----
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:

--- a/examples/kubernetes/gitlab-runner/kubernetes-executor/daemonset.yaml
+++ b/examples/kubernetes/gitlab-runner/kubernetes-executor/daemonset.yaml
@@ -9,15 +9,6 @@ metadata:
   name: cicd-sensor
   namespace: cicd-sensor-system
 ---
-apiVersion: v1
-kind: Secret
-metadata:
-  name: cicd-sensor-manager
-  namespace: cicd-sensor-system
-type: Opaque
-stringData:
-  token: sk_cs_replace_me
----
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:


### PR DESCRIPTION
## Summary

- Rework the GitHub ARC Kubernetes guide into mode-specific install paths for default, dind, and Kubernetes mode.
- Rework the GitLab Runner Kubernetes executor guide into an install-focused flow.
- Move runtime details and provider-specific behavior into the Kubernetes runtime developer guide.
- Remove inline manager token Secret resources from Kubernetes example DaemonSets.

## Why

The previous Kubernetes user guide mixed install steps with runtime details and made the GitHub ARC modes hard to distinguish. This version keeps the user guide focused on operator actions and links each mode to the exact example YAML that should be copied and merged.

## Validation

- YAML parse for Kubernetes examples.
- DaemonSet `apiVersion: apps/v1` check for all Kubernetes example DaemonSets.
- Checked that inline token Secret placeholders and direct `examples/...` apply commands are absent.
- `git diff --check`.

Manual runtime verification on k3s:

- GitHub ARC default mode: `nri arc observe` succeeded, with `github_k8s_start_accepted` and Pod cgroup tree bind logs.
- GitHub ARC dind mode: `nri arc dind cgroup` succeeded, with runner/dind Pod cgroup tree bind logs.
- GitHub ARC Kubernetes mode: container job and docker action workflows succeeded, with NRI staging logs.
- GitLab Runner Kubernetes executor: tagged Kubernetes runner pipeline succeeded, with GitLab NRI staging and job finalization logs.
