### PR TITLE
fix: relax cgroup.procs baseline rule for dind

### DIFF
--- a/rules/generic-tracking-escape.yaml
+++ b/rules/generic-tracking-escape.yaml
@@ -43,17 +43,21 @@ rule_sets:
         rule_name: "Tracking escape: cgroup.procs write (manual migration)"
         description: |
           What:
-            Terminates on a write to a cgroup.procs file under /sys/fs/cgroup, which migrates a process between cgroups.
+            Detects writes to cgroup.procs files under /sys/fs/cgroup, which migrate processes between cgroups.
           Why:
             Writing into another cgroup's cgroup.procs is the direct way to move a process out of cicd-sensor's tracked set. With sufficient privilege the destination can be outside the Job's cgroup tree, and post-migration execution is invisible to the agent.
           Notes:
-            CI workloads do not normally touch cgroup.procs directly; containerised work goes through the runtime. Review the writing process and the target cgroup path before adding any exception.
+            CI workloads do not normally touch cgroup.procs directly. Docker-in-Docker runtimes may write to /sys/fs/cgroup/docker/<container-id>/cgroup.procs through runc as part of normal container startup.
         event_type: file_open
         condition: |
           is_write &&
           path.startsWith("/sys/fs/cgroup/") &&
           path.endsWith("/cgroup.procs")
-        action: terminate
+        exceptions: |
+          process.exec_path.endsWith("/bin/runc") &&
+          path.startsWith("/sys/fs/cgroup/docker/") &&
+          path.endsWith("/cgroup.procs")
+        action: detect
         tags:
           mitre_tactic: defense-evasion
 
@@ -74,4 +78,3 @@ rule_sets:
         action: detect
         tags:
           mitre_tactic: defense-evasion,privilege-escalation
-


### PR DESCRIPTION
## What

- Change `cgroup_procs_write` from `terminate` to `detect`.
- Add a narrow exception for Docker-in-Docker container startup:
  - `process.exec_path.endsWith("/bin/runc")`
  - `/sys/fs/cgroup/docker/.../cgroup.procs`

## Why

GitHub ARC dind mode normally starts inner Docker containers through `containerd-shim-runc-v2` and `runc`. During startup, `runc` writes to `/sys/fs/cgroup/docker/<container-id>/cgroup.procs`.

With Kubernetes host-scope tracking enabled, the dind sidecar is correctly tracked, so this normal runtime operation became visible and the baseline `terminate` action killed the container startup.

The rule is still useful as a tracking-escape signal, but path-only termination is too aggressive for container runtime workloads.

## Validation

- `make rules-validate`
- `make rules-bundle-validate`

Runtime evidence from GKE preview testing showed the terminating event came from `/usr/local/bin/runc` writing `/sys/fs/cgroup/docker/<inner-container-id>/cgroup.procs` in GitHub ARC dind mode.
