### PR TITLE
docs: document event channel drops

### DIFF
--- a/docs/developer-guide/ebpf-runtime.md
+++ b/docs/developer-guide/ebpf-runtime.md
@@ -35,6 +35,29 @@ flowchart LR
     class KT cicdSensor
 ```
 
+## Event delivery pressure
+
+The runtime has two distinct drop points:
+
+| Signal | Where it happens | Meaning |
+| --- | --- | --- |
+| `bpf_ringbuf_drop` | Kernel ring buffer reservation | The kernel could not reserve space for a sample. |
+| `bpf_event_channel_drop` | KernelTracker's per-job userspace event channel | A decoded sample was already attributed to a Job, but that Job's event worker could not accept another `EventRecord` fast enough. |
+
+`bpf_event_channel_drop` is not a job attribution failure and does not mean events from different jobs were mixed.
+It means runtime events for that specific Job may be missing before rule evaluation and log delivery.
+
+The main known producer is bursty `file_open` volume.
+`file_open` is useful for credential-access and filesystem behavior rules, but it is also the easiest event type to generate at very high rates through package managers, installers, shell loops, and language runtimes.
+Kubernetes preview testing reproduced `bpf_event_channel_drop` in both GitLab Runner Kubernetes executor and GitHub ARC, so this is provider-independent.
+
+The preferred fixes are to reduce unnecessary event volume before it reaches per-job evaluation and to keep high-value `file_open` signals:
+
+- avoid emitting or retaining low-value file opens when no rule can use them,
+- add cheap path / access prefilters where the rule model allows it,
+- keep baseline rules conservative so normal package-manager activity does not force large runtime logs,
+- make buffer sizing or worker throughput tunable only after the event volume is understood.
+
 ## Tracking model
 
 | Pattern | Trigger | Role |

--- a/docs/user-guide/logging.md
+++ b/docs/user-guide/logging.md
@@ -93,4 +93,15 @@ This means a rule can match full argv content even when the corresponding log en
 
 When building a compatible log consumer, use the linked proto schema as the exact field reference.
 
+## Runtime event drops
+
+Agent logs may contain `bpf_event_channel_drop` during very high event volume.
+This means cicd-sensor attributed events to a Job, but the Job's userspace event worker could not process every `EventRecord` fast enough.
+
+The main known cause is bursty `file_open` activity, such as package installation or a tight loop that opens many files.
+When this happens, detection and runtime-event logs for that Job may be incomplete.
+It does not mean events were mixed between jobs.
+
+For the implementation model and mitigation direction, see [eBPF Runtime](../developer-guide/ebpf-runtime.md#event-delivery-pressure).
+
 For build verification rather than detailed log consumption, see [Attestation predicate](attestation-predicate.md).


### PR DESCRIPTION
## What

Document `bpf_event_channel_drop` as an event-delivery pressure signal.

This adds:

- a Developer Guide section that distinguishes `bpf_ringbuf_drop` from `bpf_event_channel_drop`,
- a User Guide logging note explaining what operators should infer when they see it,
- the current conclusion that bursty `file_open` volume is the main known producer,
- the mitigation direction: reduce unnecessary event volume before per-job rule evaluation while preserving high-value file signals.

## Why

During Kubernetes preview verification, `bpf_event_channel_drop` was reproduced with high-volume file-open workloads in both GitLab Runner Kubernetes executor and GitHub ARC.

That means the issue is not GitLab-specific and not a job-mixing problem. The events have already been attributed to a Job; the per-job userspace event worker simply cannot accept every `EventRecord` fast enough under bursty load.

The practical impact is that detection and runtime-event logs for the affected Job may be incomplete. The main follow-up should be reducing avoidable `file_open` volume, which also aligns with reducing unnecessary runtime logs.

## Validation

- `git diff --check`
