### PR TITLE
docs: refine Kubernetes runner setup notes

### DIFF
--- a/docs/user-guide/kubernetes/github-arc.md
+++ b/docs/user-guide/kubernetes/github-arc.md
@@ -151,6 +151,8 @@ helm upgrade --install RUNNER_SCALE_SET_NAME \
 
 Use this when ARC should create workflow job containers, services, and container actions as Kubernetes Pods.
 This mode uses ARC `containerMode.type: kubernetes`.
+The workflow-created Pods are pinned to the runner's node so the same node-level agent can handle both job start and NRI staging.
+Size runner nodes for the combined runner, workflow, service, and container-action workload.
 
 Copy these files:
 
@@ -172,6 +174,7 @@ Merge these values into your existing runner scale set values:
 
 - `containerMode.type: kubernetes`
 - `kubernetesModeWorkVolumeClaim`
+- `template.spec.securityContext.fsGroup: 1001`
 - `ACTIONS_RUNNER_HOOK_JOB_STARTED`
 - `CICD_SENSOR_GITHUB_K8S_RUNNER_SOCKET`
 - `ACTIONS_RUNNER_CONTAINER_HOOKS`
@@ -179,6 +182,10 @@ Merge these values into your existing runner scale set values:
 - the job hook ConfigMap volume and mount
 - the GitHub Kubernetes runner socket hostPath volume and mount
 - the container hook wrapper ConfigMap volume and mount
+
+The Kubernetes mode example sets `fsGroup: 1001` because ARC shares the work volume between the runner and workflow Pods.
+This keeps `/home/runner/_work` and `_tool` writable by the official runner image's runner group.
+If your custom runner image uses a different runner GID, adjust `fsGroup` to match it.
 
 Apply and upgrade:
 

--- a/docs/user-guide/kubernetes/gitlab-runner.md
+++ b/docs/user-guide/kubernetes/gitlab-runner.md
@@ -15,6 +15,9 @@ Review the shared [Kubernetes runner setup](index.md), then install cicd-sensor 
 4. Configure GitLab Runner with the [Kubernetes executor](https://docs.gitlab.com/runner/executors/kubernetes/).
 5. Decide the namespace for GitLab Runner. This guide uses `gitlab-runner`.
 
+Use the current GitLab Runner authentication token flow and store the runner token in a Kubernetes Secret.
+Do not commit runner tokens or manager tokens into values files.
+
 Use pinned cicd-sensor image tags and pinned GitLab Runner chart versions in production.
 The example files use `:latest` only as a placeholder.
 
@@ -59,6 +62,7 @@ Edit `cicd-sensor-daemonset.yaml`:
 Merge the GitLab Runner values into your existing Helm values.
 The example is only a minimal Kubernetes executor snippet.
 Keep your existing `gitlabUrl`, runner registration, tags, cache, and resource settings.
+If you expect concurrent jobs, review the GitLab Runner `request_concurrency` setting as well; a low value can make Kubernetes runner verification look serialized even when the cluster has capacity.
 
 Apply cicd-sensor:
 

--- a/examples/kubernetes/github-arc/kubernetes-mode/values.yaml
+++ b/examples/kubernetes/github-arc/kubernetes-mode/values.yaml
@@ -17,6 +17,11 @@ containerMode:
 
 template:
   spec:
+    securityContext:
+      # The official runner image uses runner UID/GID 1001. ARC Kubernetes mode
+      # shares the work volume with workflow Pods, so keep the volume writable by
+      # the runner group. Adjust this if you use a custom runner image.
+      fsGroup: 1001
     containers:
       - name: runner
         image: ghcr.io/actions/actions-runner:latest


### PR DESCRIPTION
## What

Refine the Kubernetes runner docs and ARC Kubernetes mode example based on preview verification.

Changes:

- add `fsGroup: 1001` to the GitHub ARC Kubernetes mode values example,
- explain that `fsGroup` keeps the shared ARC work volume writable by the official runner image's runner group,
- note that ARC Kubernetes mode pins workflow-created Pods to the runner node,
- clarify that GitLab Runner authentication tokens should be stored in a Kubernetes Secret,
- mention `request_concurrency` when verifying or operating concurrent GitLab Runner jobs.

## Why

These are small install-time details that came up during Kubernetes preview verification.

They should be visible in the operator-facing setup docs, without moving runtime internals back into the User Guide.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cicd-sensor/codesmith/cicd-sensor/pr/69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783947633&installation_id=140049588&pr_number=69&repository=cicd-sensor%2Fcicd-sensor&return_to=https%3A%2F%2Fgithub.com%2Fcicd-sensor%2Fcicd-sensor%2Fpull%2F69&signature=190065693e78461838a77de492b0bdbdf4e362a6db3ddbd465f696ef400f5bdf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->