### PR TITLE
ci: add Blacksmith BPF integration release gate

### DIFF
--- a/.github/workflows/blacksmith-bpf-integration.yaml
+++ b/.github/workflows/blacksmith-bpf-integration.yaml
@@ -1,5 +1,5 @@
 ---
-name: Blacksmith BPF Smoke
+name: Blacksmith BPF Integration
 
 "on":
   workflow_dispatch:
@@ -10,12 +10,12 @@ permissions:
   contents: read
 
 concurrency:
-  group: blacksmith-bpf-smoke-${{ github.ref }}
+  group: blacksmith-bpf-integration-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  smoke:
-    name: BPF smoke
+  bpf-integration:
+    name: BPF integration
     runs-on: blacksmith-2vcpu-ubuntu-2404
     timeout-minutes: 20
     env:

--- a/.github/workflows/blacksmith-bpf-smoke.yaml
+++ b/.github/workflows/blacksmith-bpf-smoke.yaml
@@ -1,0 +1,46 @@
+---
+name: Blacksmith BPF Smoke
+
+"on":
+  workflow_dispatch:
+  # Let release-sensor reuse this as a Blacksmith runner compatibility gate.
+  workflow_call:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: blacksmith-bpf-smoke-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  smoke:
+    name: BPF smoke
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    timeout-minutes: 20
+    env:
+      GOCACHE: ${{ github.workspace }}/.gocache
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Environment info
+        run: |
+          {
+            echo "## Blacksmith environment"
+            echo '```'
+            uname -a
+            cat /etc/os-release
+            go version
+            echo '```'
+          } | tee -a "$GITHUB_STEP_SUMMARY"
+
+      - name: Run BPF integration tests
+        run: |
+          make bpf-integration SUDO=sudo

--- a/.github/workflows/releases-sensor.yaml
+++ b/.github/workflows/releases-sensor.yaml
@@ -78,9 +78,14 @@ jobs:
     needs: [validate]
     uses: ./.github/workflows/bpf-cross-kernel.yaml
 
+  blacksmith-bpf-smoke:
+    name: Blacksmith BPF smoke gate
+    needs: [validate]
+    uses: ./.github/workflows/blacksmith-bpf-smoke.yaml
+
   approval:
     name: Approve release
-    needs: [validate, ci, bpf-integration]
+    needs: [validate, ci, bpf-integration, blacksmith-bpf-smoke]
     runs-on: ubuntu-24.04
     environment: sensor-releases/approval
     permissions:

--- a/.github/workflows/releases-sensor.yaml
+++ b/.github/workflows/releases-sensor.yaml
@@ -78,14 +78,14 @@ jobs:
     needs: [validate]
     uses: ./.github/workflows/bpf-cross-kernel.yaml
 
-  blacksmith-bpf-smoke:
-    name: Blacksmith BPF smoke gate
+  blacksmith-bpf-integration:
+    name: Blacksmith BPF integration gate
     needs: [validate]
-    uses: ./.github/workflows/blacksmith-bpf-smoke.yaml
+    uses: ./.github/workflows/blacksmith-bpf-integration.yaml
 
   approval:
     name: Approve release
-    needs: [validate, ci, bpf-integration, blacksmith-bpf-smoke]
+    needs: [validate, ci, bpf-integration, blacksmith-bpf-integration]
     runs-on: ubuntu-24.04
     environment: sensor-releases/approval
     permissions:


### PR DESCRIPTION
## What

Add a Blacksmith-hosted BPF integration workflow and wire it into the sensor release flow.

The workflow runs on `blacksmith-2vcpu-ubuntu-2404` and executes the existing BPF integration target:

```sh
make bpf-integration SUDO=sudo
```

It is available through `workflow_dispatch` and `workflow_call`. The sensor release workflow now requires it before approval.

## Why

Blacksmith previously exposed a kernel-specific attachability issue around AF_UNIX connect observation.

Running the existing BPF integration suite on the actual Blacksmith runner environment gives us a release-time compatibility gate without adding Blacksmith to normal PR or main CI.
