### PR TITLE
ci: install Blacksmith BPF integration dependencies

### DIFF
--- a/.github/workflows/blacksmith-bpf-integration.yaml
+++ b/.github/workflows/blacksmith-bpf-integration.yaml
@@ -30,6 +30,11 @@ jobs:
           go-version-file: go.mod
           cache: true
 
+      - name: Install BPF integration deps
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq dnsutils libnss-resolve
+
       - name: Environment info
         run: |
           {


### PR DESCRIPTION
## What

Install the runtime dependencies needed by the Blacksmith BPF integration workflow before running `make bpf-integration`.

The workflow now installs:

- `dnsutils`
- `libnss-resolve`

## Why

The Blacksmith BPF integration gate runs the same `make bpf-integration` target as the existing BPF integration flow.

One of the DNS integration tests expects the system resolver path to include the `resolve` NSS backend so `getent` reaches systemd-resolved / Varlink. The Blacksmith runner image does not provide that by default, so the workflow failed before reaching the actual BPF compatibility signal.

The existing cross-kernel BPF integration workflow already installs the same DNS dependencies inside the LVH environment.
