### PR TITLE
docs: add CONTRIBUTING and SECURITY policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,13 @@
+# Contributing to cicd-sensor
+
+Thanks for your interest! Contributions and pull requests are welcome. Please note that this is maintained alongside other work, so reviews may not be immediate.
+
+For larger changes, please open an issue to settle the design before implementation.
+
+## Development
+
+See the [Developer Guide](https://cicd-sensor.github.io/developer-guide/overview.html) for the repository layout and how the implementation is structured. Before opening a PR, run `make check` (the full test and validation gate), and follow [Conventional Commits](https://www.conventionalcommits.org/) for commit messages.
+
+## Security
+
+For security vulnerabilities, do not open a public issue — see [SECURITY.md](SECURITY.md).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,17 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Please report security vulnerabilities through GitHub's **Private vulnerability reporting** (the "Security" tab of this repository), not through public issues.
+
+This is a community-maintained open source project, so we cannot promise a fixed response time, but we will look into every report as quickly as we reasonably can and coordinate a fix and disclosure with you.
+
+## Scope
+
+Report issues in cicd-sensor itself — the agent, manager, CLI, or rule engine.
+
+For a vulnerability in a third-party dependency, please don't file it here; those are tracked upstream and via our dependency update tooling. The cicd-sensor-action is maintained in its own repository and has its own policy.
+
+## Supported Versions
+
+Fixes land on the latest release, so please run the most recent version.


### PR DESCRIPTION
## What

Add `CONTRIBUTING.md` and `SECURITY.md`.

## Why

These standard OSS community health files were missing.

- **CONTRIBUTING.md** — sets the expectation that PRs are welcome but reviews may not be immediate, asks for an issue to settle design on larger changes, and points to the Developer Guide plus the `make check` / Conventional Commits requirements.
- **SECURITY.md** — directs vulnerability reports to GitHub Private vulnerability reporting instead of public issues, and clarifies scope (cicd-sensor itself vs. dependencies / the separate action repo).