### PR TITLE
docs: add design doc guidance for agents

### DIFF
--- a/.claude/rules/50-design-docs.md
+++ b/.claude/rules/50-design-docs.md
@@ -1,0 +1,57 @@
+# Design Doc Rules
+
+Use a Design Doc for large feature additions or substantial behavior changes before implementation. Keep it useful as a local working document, not a ceremony.
+
+The format should roughly follow a Google-style design doc, with extra implementation guidance for AI agents and an explicit progress checklist:
+
+- **Context and Scope**: what problem this addresses, where in the system it lives, and what is out of scope.
+- **Goals**: concrete outcomes the implementation must achieve.
+- **Non-Goals**: adjacent work that must not be pulled into this change.
+- **Findings**: investigation results, measurements, source links, runtime observations, or constraints that justify the design.
+- **Design**: the proposed behavior, ownership boundaries, data flow, state lifecycle, and implementation notes as needed.
+- **Alternatives Considered**: plausible options and why they were rejected.
+- **Security Considerations**: trust boundaries, attacker-controlled inputs, privilege changes, socket / filesystem / network exposure, sensitive data handling, and what must not be weakened.
+- **Cross-Cutting Concerns**: correctness, performance, memory, observability, compatibility, rollout, and operations when relevant.
+- **Test Plan**: unit, integration, manual, migration, and regression checks.
+- **Rollout and Progress**: checklist of decided, implemented, verified, and follow-up items. Use this section to track progress while the local implementation work is ongoing.
+
+## AI-oriented implementation detail
+
+For this repo, the **Design** section should include more implementation detail than a typical high-level design doc. Add a `### Implementation Notes` subsection under `## Design` when the change is large enough that an AI coding agent would otherwise need to guess.
+
+In `Design > Implementation Notes`, include these details when they are known:
+
+- Which component owns the change. Use the ownership map in `AGENTS.md`.
+- Which package / file / function boundaries are expected to change.
+- What state is introduced, who owns its lifecycle, and when it is cleaned up.
+- What library, standard API, protocol, socket, hook, or runtime mechanism should be used.
+- What must not be touched.
+- The intended control flow or data flow, preferably with a small text diagram.
+- Important edge cases and failure behavior.
+- Security-sensitive assumptions, including what an attacker can control and what signal must not be hidden.
+- Required comments when the code needs to preserve a non-obvious constraint.
+- Concrete tests to add or update, including integration / BPF / Kubernetes smoke tests when relevant.
+
+Implementation Notes should not force a line-by-line plan. They should make ownership, boundaries, and invariants clear enough that the implementation can be written without re-litigating the design.
+
+## cicd-sensor-specific checks
+
+When relevant, explicitly answer these project-specific questions:
+
+- **Job boundary**: what identifies the CI/CD Job, and which cgroup / container / runner signal is authoritative?
+- **Scope ownership**: does the change preserve Host scope and Project scope isolation, including separate rules, outputs, and manager config ownership?
+- **Kernel boundary**: what belongs in eBPF maps or hooks, and what belongs in userspace `KernelTracker` state?
+- **Kernel support**: when touching eBPF, state the required kernel versions, configs, attach points, helpers / kfuncs, and fallback or unsupported behavior.
+- **Hot path behavior**: can the change increase event volume, queue pressure, memory use, or drop risk, and how is that visible?
+- **Socket and caller trust**: which socket / endpoint is exposed to which process, how is the caller identified, and is the failure mode fail-open or fail-closed?
+- **Kubernetes runtime**: if NRI, ARC hooks, containerd, or cgroups are involved, state the node requirements, timing constraints, and same-node assumptions.
+- **Rule and event schema**: does the change alter CEL fields, RuleSet behavior, baseline rules, or user-facing event semantics?
+- **Evidence outputs**: which Summary, Detection, Runtime Event, report, or attestation outputs change?
+- **Deployment surface**: which runner environments are affected: GitHub-hosted, installed machine runner, GitHub ARC, GitLab Runner, or Kubernetes executor?
+
+## Working Rules
+
+- Keep facts and measurements separate from decisions.
+- Prefer concrete names over placeholders when the component or API is already known.
+- Do not hide tradeoffs. If a rejected option is tempting, write why it is rejected.
+- Update the progress checklist as work advances.

--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,9 @@ book/
 /feedback.md
 /prompt.md
 
+# Local working docs and investigation notes
+/work_docs/
+
 # Editor/IDE
 .idea/
 .vscode/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,8 @@ AI agents should first investigate the code, docs, runtime behavior, and tradeof
 
 Before changing external state such as creating, closing, reopening, or merging GitHub Issues / PRs, pushing branches, or publishing releases, show the exact target and proposed content, then wait for explicit approval.
 
+Use ignored `work_docs/` for local temporary design drafts, progress notes, investigation logs, and result reports. Do not place local-only working notes at the repository root.
+
 ## What to read first
 
 - `docs/index.md` — project goal and supported platforms
@@ -32,6 +34,7 @@ The files below add detail that only applies when touching specific paths. **The
 | `.claude/rules/20-testing.md` | Writing or reviewing tests. Required test-case table and coverage-perspective table. |
 | `.claude/rules/30-cel-rules.md` | Touching `rules/**`, `internal/rule/**`. RuleSet / RuleModifier schema, CEL surface, event-type sources. |
 | `.claude/rules/40-supply-chain.md` | Touching `.github/**`, `.gitlab-ci.yml`, Dependabot, or Renovate config. SHA pinning and cooldown. |
+| `.claude/rules/50-design-docs.md` | Writing or updating local Design Docs for large feature additions or substantial behavior changes. |
 
 ## Build and test
 
@@ -64,9 +67,11 @@ The Agent is built from several components, each owning a different boundary. Be
 
 | Component | Owns |
 | --- | --- |
-| `Agent` | Top-level process-wide orchestrator. Owns the control socket, provider selection, runner type, host manager connection / client, and shutdown lifecycle. |
-| `Listener` | Unix-socket entrypoint for `host start`, `project start`, and dockerd proxy staging. Provider routes and peer credentials. |
-| `JobRegistry` | Active jobs catalog and KernelTracker binding. Host-start methods receive the host manager client as a parameter; it is not held here. |
+| `Agent` | Top-level process orchestrator. Owns provider/runner selection, socket lifecycles, manager clients, host config cache startup, and shutdown. |
+| `Listener` | Unix-socket HTTP entrypoint. Owns provider routes, peer credentials, request trust checks, and dispatch into JobRegistry. |
+| `NRI observer` | Separate `cicd-sensor nri` process. Observes containerd NRI events and sends Kubernetes staging requests to the Agent. |
+| `ManagerClient / host config cache` | Manager config fetch boundary and cached host config for Kubernetes host paths. Does not own Jobs or KernelTracker state. |
+| `JobRegistry` | Active jobs catalog and KernelTracker binding. Creates scope state, composes tracking primitives, and finalizes Jobs. |
 | `Job` | One CI/CD job's lifecycle, identity, and event worker. |
 | `JobScopeState` | Per-scope state for one Job — one host instance and / or one project instance per Job. Holds the Job's `RuleSets`, `RuleModifiers`, `OutputSettings`, and scope-local manager output config. |
 | `Host scope` | The configuration surface owned by the runner host operator (the platform team installing cicd-sensor on the runner). It arrives via `host start` from a runner hook, and is used when the host enforces a baseline across every job on the runner — typically on self-hosted runners. |
@@ -74,6 +79,7 @@ The Agent is built from several components, each owning a different boundary. Be
 | `KernelTracker` | Userspace cgroup / process tracking, decoded sample domain, and EventRecord attribution. |
 | `KernelIO` | BPF object load, attach, ringbuf read, and map operations. |
 | `Docker proxy` | Mediates dockerd API and stages container cgroup basenames so jobs can track containers created through the host Docker socket. |
+| `GitHub Kubernetes hooks` | Runner-side integration, not Agent-owned state. Supplies GitHub job identity to the Agent and, in ARC Kubernetes mode, to workflow Pods for NRI staging. |
 | `Outputs` | Per-scope runtime summaries used for job logs, project results, reports, and attestations. |
 
 A single Job may carry one scope or both. Each scope owns its own rules, evaluation state, and outputs, and the two are isolated: neither operator can read or override the other's rules, and their outputs are emitted separately. This is the security boundary of the agent — see `docs/developer-guide/agent.md` for the conceptual model and `docs/developer-guide/agent-ownership-boundaries.md` for the implementation ownership rules. For the kernel-side model, see `docs/developer-guide/ebpf-runtime.md`.
@@ -90,5 +96,6 @@ Host scope and project scope are internal Agent implementation boundaries. User-
 ## Large changes
 
 For large feature additions or substantial behavior changes, write a Markdown Design Doc before implementation.
+Use `.claude/rules/50-design-docs.md` for the recommended format.
 Use it mainly as a local working document to keep the direction stable and track progress.
 If communication needs it, copy or summarize the relevant parts into GitHub Issues.


### PR DESCRIPTION
### What
- Add local Design Doc guidance for AI agents.
- Add cicd-sensor-specific checks for job attribution, scope ownership, kernel support, runtime pressure, sockets, Kubernetes runtime, rule schema, and evidence outputs.
- Document `work_docs/` as the ignored location for local investigation and design notes.

### Why
Large behavior changes in this repo need stable design notes before implementation, especially when they touch eBPF, runner identity, sockets, Kubernetes, or rule semantics. This keeps local planning explicit without turning the process into ceremony.

### Validation
- `git diff --cached --check` before commit