### PR TITLE
Reduce file_open delivery pressure

### DIFF
--- a/docs/developer-guide/agent.md
+++ b/docs/developer-guide/agent.md
@@ -195,6 +195,8 @@ Job tracking is expressed by JobRegistry composing KernelTracker primitives.
 GitHub can resolve the cgroup from the peer PID at start time, so it uses `RegisterJob + BindProcessCgroupToJob`.
 GitLab Docker executor registers a job from label identity evidence and waits for a later staging promote.
 
+The per-job event channel is bounded. KernelTracker owns delivery-pressure handling before events reach Job rule evaluation, including repeated `file_open` suppression and delivery diagnostics. See [EventRecord delivery pressure](ebpf-runtime.md#eventrecord-delivery-pressure).
+
 ## Design Notes
 
 - Job membership is determined by cgroup tracking. Process context is a fat node snapshot with `exec_path` / `argv` / `ancestors`; it is not used as the job boundary.

--- a/docs/developer-guide/ebpf-runtime.md
+++ b/docs/developer-guide/ebpf-runtime.md
@@ -87,6 +87,40 @@ BPF map state is intentionally small. The kernel side only needs to answer two q
 | `stagingByJob` | Cleans up staging entries for a job when the job ends |
 | `processesByJob` / `processNode` | Holds process fat nodes and attaches `exec_path`, `argv`, and `ancestors` to EventRecord |
 
+### EventRecord delivery pressure
+
+KernelTracker owns the boundary between decoded kernel samples and each Job's event worker.
+Each Job has a bounded `EventRecord` channel; the default capacity is 64k records.
+The bound is intentional: a slow or blocked Job worker must not create unbounded memory growth in the agent.
+
+`file_open` can be much higher volume than process, network, or domain events.
+Repeated reads of the same file by the same process are common during package install, build, and runtime startup.
+If those repeated records fill the per-Job channel, later `process_exec` or unique credential-like file reads can be dropped before rule evaluation sees them.
+
+To protect the delivery path, KernelTracker suppresses repeated same-key `file_open` records before enqueueing them into the Job channel.
+This is a delivery-pressure optimization, not a rule semantic change:
+
+- the first successfully enqueued event for a key is preserved;
+- unique paths are not collapsed;
+- truncated, malformed, or incomplete `file_open` records are not suppressed;
+- non-`file_open` event types are never deduplicated by this path.
+
+The dedup key is explicit rather than a generic payload hash:
+
+| Key field | Reason |
+| --- | --- |
+| process PID + start boottime | Distinguishes process lifetimes even when PIDs are reused |
+| process executable path | Keeps same PID/start context readable when exec context changes |
+| file path | Keeps unique file enumeration visible |
+| read/write mode | Keeps read and write behavior separate |
+| open flags | Keeps rule-visible open-flag differences separate |
+
+The dedup state is per Job, loop-local to KernelTracker, and bounded.
+It keeps up to 4096 file-open keys per Job; this is separate from the 64k per-Job EventRecord channel capacity.
+It uses FIFO eviction rather than LRU so a hot repeated key does not refresh itself forever and evict newer unique keys.
+The FIFO order is stored as a fixed-size ring buffer, so inserts remain O(1) after the per-Job key limit is reached.
+KernelTracker records delivery diagnostics internally (`attempted`, `delivered`, `dropped`, `suppressed_duplicates`, and `max_queue_depth`) and logs a summary when a Job is removed if drops or suppression occurred.
+
 ## Implementation layout
 
 | Path | Content |

--- a/docs/developer-guide/ebpf-runtime.md
+++ b/docs/developer-guide/ebpf-runtime.md
@@ -120,6 +120,7 @@ It keeps up to 4096 file-open keys per Job; this is separate from the 64k per-Jo
 It uses FIFO eviction rather than LRU so a hot repeated key does not refresh itself forever and evict newer unique keys.
 The FIFO order is stored as a fixed-size ring buffer, so inserts remain O(1) after the per-Job key limit is reached.
 KernelTracker records delivery diagnostics internally (`attempted`, `delivered`, `dropped`, `suppressed_duplicates`, and `max_queue_depth`) and logs a summary when a Job is removed if drops or suppression occurred.
+Manager `runtime_event` output uses the same 64k queue capacity so the post-evaluation log path does not immediately become the next bottleneck; detection and summary outputs keep the smaller manager-output queue because they are not raw event streams.
 
 ## Implementation layout
 

--- a/internal/agent/joblogs/manager_job_logs.go
+++ b/internal/agent/joblogs/manager_job_logs.go
@@ -89,6 +89,7 @@ func (o *ManagerJobLogs) start(identity jobcontext.JobIdentity, scopeType jobcon
 			scopeType,
 			managerv1beta1.LogType_LOG_TYPE_DETECTION,
 			detection,
+			managerOutputChannelCap,
 		)
 	}
 	if runtimeEvent.GetEnabled() {
@@ -99,6 +100,7 @@ func (o *ManagerJobLogs) start(identity jobcontext.JobIdentity, scopeType jobcon
 			scopeType,
 			managerv1beta1.LogType_LOG_TYPE_RUNTIME_EVENT,
 			runtimeEvent,
+			runtimeEventManagerOutputChannelCap,
 		)
 	}
 	if summary.GetEnabled() {
@@ -109,6 +111,7 @@ func (o *ManagerJobLogs) start(identity jobcontext.JobIdentity, scopeType jobcon
 			scopeType,
 			managerv1beta1.LogType_LOG_TYPE_SUMMARY,
 			summary,
+			managerOutputChannelCap,
 		)
 	}
 }

--- a/internal/agent/joblogs/manager_job_logs_test.go
+++ b/internal/agent/joblogs/manager_job_logs_test.go
@@ -149,6 +149,15 @@ func TestStartJobLogsUsesOneWorkerPerType(t *testing.T) {
 	if conn.detection.requests == conn.summaryLog.requests {
 		t.Fatal("detection and summary must use separate workers")
 	}
+	if got := cap(conn.runtimeEvent.requests); got != runtimeEventManagerOutputChannelCap {
+		t.Fatalf("runtime event output channel cap: got %d, want %d", got, runtimeEventManagerOutputChannelCap)
+	}
+	if got := cap(conn.detection.requests); got != managerOutputChannelCap {
+		t.Fatalf("detection output channel cap: got %d, want %d", got, managerOutputChannelCap)
+	}
+	if got := cap(conn.summaryLog.requests); got != managerOutputChannelCap {
+		t.Fatalf("summary output channel cap: got %d, want %d", got, managerOutputChannelCap)
+	}
 }
 
 func TestManagerJobLogsEmitAndCloseSummaryLog(t *testing.T) {

--- a/internal/agent/joblogs/manager_output.go
+++ b/internal/agent/joblogs/manager_output.go
@@ -29,6 +29,7 @@ func newManagerOutput(
 	scope jobcontext.ScopeType,
 	logType managerv1beta1.LogType,
 	setting *managerv1beta1.OutputSetting,
+	channelCap int,
 ) *managerOutput {
 	if sendBatch == nil {
 		return nil
@@ -43,7 +44,7 @@ func newManagerOutput(
 		now:       time.Now,
 	})
 	out := &managerOutput{
-		requests: make(chan managerOutputRequest, managerOutputChannelCap),
+		requests: make(chan managerOutputRequest, channelCap),
 		done:     make(chan struct{}),
 	}
 	go worker.run(out.requests, out.done)

--- a/internal/agent/joblogs/manager_output_test.go
+++ b/internal/agent/joblogs/manager_output_test.go
@@ -267,6 +267,7 @@ func testManagerOutput(sendBatch func(context.Context, managerclient.LogBatch) e
 		jobcontext.ScopeTypeHost,
 		managerv1beta1.LogType_LOG_TYPE_DETECTION,
 		setting,
+		managerOutputChannelCap,
 	)
 }
 

--- a/internal/agent/joblogs/manager_worker.go
+++ b/internal/agent/joblogs/manager_worker.go
@@ -11,7 +11,10 @@ import (
 	managerv1beta1 "github.com/cicd-sensor/cicd-sensor/internal/proto/cicd_sensor/manager/v1beta1"
 )
 
-const managerOutputChannelCap = 10_000
+const (
+	managerOutputChannelCap             = 10_000
+	runtimeEventManagerOutputChannelCap = 65_536
+)
 
 type managerWorkerConfig struct {
 	logger    *slog.Logger

--- a/internal/agent/joblogs/testing.go
+++ b/internal/agent/joblogs/testing.go
@@ -28,5 +28,5 @@ func (o *ManagerJobLogs) AttachSummaryRecorderForTesting(identity jobcontext.Job
 }
 
 func (o *ManagerJobLogs) attachRecorderForTesting(identity jobcontext.JobIdentity, scope jobcontext.ScopeType, logType managerv1beta1.LogType, sendBatch func(context.Context, managerclient.LogBatch) error, assign func(*managerOutput)) {
-	assign(newManagerOutput(o.logger, sendBatch, identity, scope, logType, &managerv1beta1.OutputSetting{Enabled: true, FlushThresholdBytes: 1}))
+	assign(newManagerOutput(o.logger, sendBatch, identity, scope, logType, &managerv1beta1.OutputSetting{Enabled: true, FlushThresholdBytes: 1}, managerOutputChannelCap))
 }

--- a/internal/agent/kerneltracker/engine.go
+++ b/internal/agent/kerneltracker/engine.go
@@ -12,7 +12,7 @@ import (
 
 const (
 	defaultEngineInputBufferSize = 16384
-	defaultEventRecordBufferSize = 16384
+	defaultEventRecordBufferSize = 65536
 )
 
 type KernelTracker struct {

--- a/internal/agent/kerneltracker/engine_effect.go
+++ b/internal/agent/kerneltracker/engine_effect.go
@@ -102,18 +102,41 @@ func (engine *KernelTracker) runEngineEffects(ctx context.Context, effects []eng
 			if !ok {
 				continue
 			}
+
+			// Keep delivery pressure stats separately from suppression so job
+			// removal can report what reached, skipped, or overflowed the queue.
+			stats := engine.jobTracking.deliveryStatsFor(value.JobID, value.Record.EventType)
+			stats.Attempted++
+			stats.observeQueueDepth(len(channel))
+
+			var fileOpenDedup *fileOpenDedupState
+			var fileOpenKey fileOpenDedupKey
+			if value.Record.EventType == jobevent.FileOpen {
+				// Collapse repeated file_open records before they consume the
+				// per-Job EventRecord channel. Other event types are never
+				// deduplicated here.
+				dedupKey, canDedupFileOpen := fileOpenDedupKeyForRecord(value.Record)
+				if canDedupFileOpen {
+					dedupState := engine.jobTracking.fileOpenDedupByJob[value.JobID]
+					if dedupState.contains(dedupKey) {
+						stats.SuppressedDuplicates++
+						continue
+					}
+					fileOpenDedup = dedupState
+					fileOpenKey = dedupKey
+				}
+			}
+
 			select {
 			case channel <- value.Record:
-			default:
-				engine.jobTracking.jobEventDropCounts[value.JobID]++
-				dropped := engine.jobTracking.jobEventDropCounts[value.JobID]
-				if shouldLogEventDrop(dropped) {
-					engine.logger.WarnContext(ctx, "bpf_event_channel_drop",
-						"job_id", value.JobID,
-						"count", dropped,
-						"event_type", value.Record.EventType,
-					)
+				stats.Delivered++
+				// Remember only delivered records, so every suppressible key has
+				// one visible EventRecord for rule evaluation.
+				if fileOpenDedup != nil {
+					fileOpenDedup.remember(fileOpenKey)
 				}
+			default:
+				stats.Dropped++
 			}
 		case notifyJobEnded:
 			if engine.jobEndNotifier != nil {
@@ -134,6 +157,7 @@ func (engine *KernelTracker) runEngineEffects(ctx context.Context, effects []eng
 		case removeJobFromKernel:
 			err := engine.deleteJobKernelMapEntries(ctx, value.Cgroups, value.Staging)
 			if err == nil {
+				engine.logEventDeliverySummary(ctx, value.JobID)
 				channel := engine.jobTracking.removeJob(value.JobID)
 				if channel != nil {
 					close(channel)
@@ -159,6 +183,23 @@ func (engine *KernelTracker) runEngineEffects(ctx context.Context, effects []eng
 				close(value.Channel)
 			}
 		}
+	}
+}
+
+func (engine *KernelTracker) logEventDeliverySummary(ctx context.Context, jobID jobcontext.JobIdentity) {
+	for eventType, stats := range engine.jobTracking.jobEventDeliveryStats[jobID] {
+		if stats.Dropped == 0 && stats.SuppressedDuplicates == 0 {
+			continue
+		}
+		engine.logger.InfoContext(ctx, "kernel_event_delivery_summary",
+			"job_id", jobID,
+			"event_type", eventType,
+			"attempted", stats.Attempted,
+			"delivered", stats.Delivered,
+			"dropped", stats.Dropped,
+			"suppressed_duplicates", stats.SuppressedDuplicates,
+			"max_queue_depth", stats.MaxQueueDepth,
+		)
 	}
 }
 

--- a/internal/agent/kerneltracker/engine_effect_test.go
+++ b/internal/agent/kerneltracker/engine_effect_test.go
@@ -79,11 +79,343 @@ func TestRunEngineEffects_RecordsDroppedEvents(t *testing.T) {
 		},
 	}})
 
-	if got := engine.jobTracking.jobEventDropCounts[jobID]; got != 1 {
-		t.Fatalf("event drop count for %q = %d, want 1", jobID, got)
-	}
 	if got := len(channel); got != 1 {
 		t.Fatalf("channel len = %d, want 1", got)
+	}
+	stats := engine.jobTracking.jobEventDeliveryStats[jobID][jobevent.ProcessExec]
+	if stats == nil {
+		t.Fatal("process_exec delivery stats missing")
+	}
+	if stats.Attempted != 1 || stats.Delivered != 0 || stats.Dropped != 1 || stats.SuppressedDuplicates != 0 || stats.MaxQueueDepth != 1 {
+		t.Fatalf("process_exec stats = %#v, want attempted=1 delivered=0 dropped=1 suppressed=0 max_queue_depth=1", stats)
+	}
+}
+
+func TestRunEngineEffects_SuppressesRepeatedFileOpenAfterFirstDelivery(t *testing.T) {
+	t.Parallel()
+
+	jobID := jobcontext.GitLabJobIdentity("gitlab.com", "group/project", "123")
+	state := newJobTrackingState()
+	state.registerJob(jobID, 4)
+	engine := &KernelTracker{
+		logger:      slog.New(slog.NewTextHandler(io.Discard, nil)),
+		jobTracking: state,
+	}
+	record := testFileOpenEventRecord("/workspace/secret.txt")
+
+	engine.runEngineEffects(context.Background(), []engineEffect{
+		emitEventRecord{JobID: jobID, Record: record},
+		emitEventRecord{JobID: jobID, Record: record},
+	})
+
+	channel := state.jobEventChannels[jobID]
+	if got := len(channel); got != 1 {
+		t.Fatalf("channel len = %d, want 1", got)
+	}
+	stats := state.jobEventDeliveryStats[jobID][jobevent.FileOpen]
+	if stats == nil {
+		t.Fatal("file_open delivery stats missing")
+	}
+	if stats.Attempted != 2 || stats.Delivered != 1 || stats.Dropped != 0 || stats.SuppressedDuplicates != 1 {
+		t.Fatalf("file_open stats = %#v, want attempted=2 delivered=1 dropped=0 suppressed=1", stats)
+	}
+}
+
+func TestRunEngineEffects_DoesNotRememberFileOpenKeyWhenEnqueueFails(t *testing.T) {
+	t.Parallel()
+
+	jobID := jobcontext.GitLabJobIdentity("gitlab.com", "group/project", "123")
+	state := newJobTrackingState()
+	state.registerJob(jobID, 1)
+	channel := state.jobEventChannels[jobID]
+	channel <- jobevent.EventRecord{EventType: jobevent.ProcessExec}
+	engine := &KernelTracker{
+		logger:      slog.New(slog.NewTextHandler(io.Discard, nil)),
+		jobTracking: state,
+	}
+	record := testFileOpenEventRecord("/workspace/secret.txt")
+
+	engine.runEngineEffects(context.Background(), []engineEffect{
+		emitEventRecord{JobID: jobID, Record: record},
+	})
+	<-channel
+	engine.runEngineEffects(context.Background(), []engineEffect{
+		emitEventRecord{JobID: jobID, Record: record},
+	})
+
+	if got := len(channel); got != 1 {
+		t.Fatalf("channel len = %d, want 1", got)
+	}
+	got := <-channel
+	if got.EventType != jobevent.FileOpen {
+		t.Fatalf("delivered event type = %q, want %q", got.EventType, jobevent.FileOpen)
+	}
+	stats := state.jobEventDeliveryStats[jobID][jobevent.FileOpen]
+	if stats == nil {
+		t.Fatal("file_open delivery stats missing")
+	}
+	if stats.Attempted != 2 || stats.Delivered != 1 || stats.Dropped != 1 || stats.SuppressedDuplicates != 0 {
+		t.Fatalf("file_open stats = %#v, want attempted=2 delivered=1 dropped=1 suppressed=0", stats)
+	}
+}
+
+func TestRunEngineEffects_DeliversUniqueFileOpenEvents(t *testing.T) {
+	t.Parallel()
+
+	jobID := jobcontext.GitLabJobIdentity("gitlab.com", "group/project", "123")
+	state := newJobTrackingState()
+	state.registerJob(jobID, 4)
+	engine := &KernelTracker{
+		logger:      slog.New(slog.NewTextHandler(io.Discard, nil)),
+		jobTracking: state,
+	}
+
+	engine.runEngineEffects(context.Background(), []engineEffect{
+		emitEventRecord{JobID: jobID, Record: testFileOpenEventRecord("/workspace/a.txt")},
+		emitEventRecord{JobID: jobID, Record: testFileOpenEventRecord("/workspace/b.txt")},
+	})
+
+	channel := state.jobEventChannels[jobID]
+	if got := len(channel); got != 2 {
+		t.Fatalf("channel len = %d, want 2", got)
+	}
+	stats := state.jobEventDeliveryStats[jobID][jobevent.FileOpen]
+	if stats == nil {
+		t.Fatal("file_open delivery stats missing")
+	}
+	if stats.Attempted != 2 || stats.Delivered != 2 || stats.Dropped != 0 || stats.SuppressedDuplicates != 0 {
+		t.Fatalf("file_open stats = %#v, want attempted=2 delivered=2 dropped=0 suppressed=0", stats)
+	}
+}
+
+func TestRunEngineEffects_DeliversFileOpenEventsWithDifferentFlags(t *testing.T) {
+	t.Parallel()
+
+	jobID := jobcontext.GitLabJobIdentity("gitlab.com", "group/project", "123")
+	state := newJobTrackingState()
+	state.registerJob(jobID, 4)
+	engine := &KernelTracker{
+		logger:      slog.New(slog.NewTextHandler(io.Discard, nil)),
+		jobTracking: state,
+	}
+
+	first := testFileOpenEventRecord("/workspace/secret.txt")
+	second := testFileOpenEventRecord("/workspace/secret.txt")
+	second.Payload[fileOpenPayloadFlags] = 0x241
+	engine.runEngineEffects(context.Background(), []engineEffect{
+		emitEventRecord{JobID: jobID, Record: first},
+		emitEventRecord{JobID: jobID, Record: second},
+	})
+
+	channel := state.jobEventChannels[jobID]
+	if got := len(channel); got != 2 {
+		t.Fatalf("channel len = %d, want 2", got)
+	}
+	stats := state.jobEventDeliveryStats[jobID][jobevent.FileOpen]
+	if stats == nil {
+		t.Fatal("file_open delivery stats missing")
+	}
+	if stats.Attempted != 2 || stats.Delivered != 2 || stats.Dropped != 0 || stats.SuppressedDuplicates != 0 {
+		t.Fatalf("file_open stats = %#v, want attempted=2 delivered=2 dropped=0 suppressed=0", stats)
+	}
+}
+
+func TestRunEngineEffects_DeliversReadAfterRepeatedWriteFileOpen(t *testing.T) {
+	t.Parallel()
+
+	jobID := jobcontext.GitLabJobIdentity("gitlab.com", "group/project", "123")
+	state := newJobTrackingState()
+	state.registerJob(jobID, 4)
+	engine := &KernelTracker{
+		logger:      slog.New(slog.NewTextHandler(io.Discard, nil)),
+		jobTracking: state,
+	}
+
+	writeRecord := testFileOpenEventRecord("/workspace/secret.txt")
+	writeRecord.Payload[fileOpenPayloadIsRead] = false
+	writeRecord.Payload[fileOpenPayloadIsWrite] = true
+	writeRecord.Payload[fileOpenPayloadFlags] = 0x1
+	readRecord := testFileOpenEventRecord("/workspace/secret.txt")
+	engine.runEngineEffects(context.Background(), []engineEffect{
+		emitEventRecord{JobID: jobID, Record: writeRecord},
+		emitEventRecord{JobID: jobID, Record: writeRecord},
+		emitEventRecord{JobID: jobID, Record: readRecord},
+	})
+
+	channel := state.jobEventChannels[jobID]
+	if got := len(channel); got != 2 {
+		t.Fatalf("channel len = %d, want 2", got)
+	}
+	first := <-channel
+	second := <-channel
+	if first.Payload[fileOpenPayloadIsWrite] != true || second.Payload[fileOpenPayloadIsRead] != true {
+		t.Fatalf("delivered payloads = %#v, %#v; want write then read", first.Payload, second.Payload)
+	}
+	stats := state.jobEventDeliveryStats[jobID][jobevent.FileOpen]
+	if stats == nil {
+		t.Fatal("file_open delivery stats missing")
+	}
+	if stats.Attempted != 3 || stats.Delivered != 2 || stats.Dropped != 0 || stats.SuppressedDuplicates != 1 {
+		t.Fatalf("file_open stats = %#v, want attempted=3 delivered=2 dropped=0 suppressed=1", stats)
+	}
+}
+
+func TestRunEngineEffects_DeliversRepeatedTruncatedFileOpenEvents(t *testing.T) {
+	t.Parallel()
+
+	jobID := jobcontext.GitLabJobIdentity("gitlab.com", "group/project", "123")
+	state := newJobTrackingState()
+	state.registerJob(jobID, 4)
+	engine := &KernelTracker{
+		logger:      slog.New(slog.NewTextHandler(io.Discard, nil)),
+		jobTracking: state,
+	}
+	record := testFileOpenEventRecord("/workspace/truncated.txt")
+	record.Tags = map[string]string{"truncated": "path"}
+
+	engine.runEngineEffects(context.Background(), []engineEffect{
+		emitEventRecord{JobID: jobID, Record: record},
+		emitEventRecord{JobID: jobID, Record: record},
+	})
+
+	channel := state.jobEventChannels[jobID]
+	if got := len(channel); got != 2 {
+		t.Fatalf("channel len = %d, want 2", got)
+	}
+	stats := state.jobEventDeliveryStats[jobID][jobevent.FileOpen]
+	if stats == nil {
+		t.Fatal("file_open delivery stats missing")
+	}
+	if stats.Attempted != 2 || stats.Delivered != 2 || stats.Dropped != 0 || stats.SuppressedDuplicates != 0 {
+		t.Fatalf("file_open stats = %#v, want attempted=2 delivered=2 dropped=0 suppressed=0", stats)
+	}
+}
+
+func TestRunEngineEffects_FileOpenDedupIsPerJob(t *testing.T) {
+	t.Parallel()
+
+	firstJob := jobcontext.GitLabJobIdentity("gitlab.com", "group/project", "123")
+	secondJob := jobcontext.GitLabJobIdentity("gitlab.com", "group/project", "456")
+	state := newJobTrackingState()
+	state.registerJob(firstJob, 4)
+	state.registerJob(secondJob, 4)
+	engine := &KernelTracker{
+		logger:      slog.New(slog.NewTextHandler(io.Discard, nil)),
+		jobTracking: state,
+	}
+	record := testFileOpenEventRecord("/workspace/shared.txt")
+
+	engine.runEngineEffects(context.Background(), []engineEffect{
+		emitEventRecord{JobID: firstJob, Record: record},
+		emitEventRecord{JobID: secondJob, Record: record},
+		emitEventRecord{JobID: firstJob, Record: record},
+		emitEventRecord{JobID: secondJob, Record: record},
+	})
+
+	firstChannel := state.jobEventChannels[firstJob]
+	secondChannel := state.jobEventChannels[secondJob]
+	if got := len(firstChannel); got != 1 {
+		t.Fatalf("first job channel len = %d, want 1", got)
+	}
+	if got := len(secondChannel); got != 1 {
+		t.Fatalf("second job channel len = %d, want 1", got)
+	}
+	firstStats := state.jobEventDeliveryStats[firstJob][jobevent.FileOpen]
+	if firstStats == nil {
+		t.Fatal("first job file_open delivery stats missing")
+	}
+	if firstStats.Attempted != 2 || firstStats.Delivered != 1 || firstStats.Dropped != 0 || firstStats.SuppressedDuplicates != 1 {
+		t.Fatalf("first job file_open stats = %#v, want attempted=2 delivered=1 dropped=0 suppressed=1", firstStats)
+	}
+	secondStats := state.jobEventDeliveryStats[secondJob][jobevent.FileOpen]
+	if secondStats == nil {
+		t.Fatal("second job file_open delivery stats missing")
+	}
+	if secondStats.Attempted != 2 || secondStats.Delivered != 1 || secondStats.Dropped != 0 || secondStats.SuppressedDuplicates != 1 {
+		t.Fatalf("second job file_open stats = %#v, want attempted=2 delivered=1 dropped=0 suppressed=1", secondStats)
+	}
+}
+
+func TestRunEngineEffects_DeliversProcessExecAfterRepeatedFileOpen(t *testing.T) {
+	t.Parallel()
+
+	jobID := jobcontext.GitLabJobIdentity("gitlab.com", "group/project", "123")
+	state := newJobTrackingState()
+	state.registerJob(jobID, 2)
+	engine := &KernelTracker{
+		logger:      slog.New(slog.NewTextHandler(io.Discard, nil)),
+		jobTracking: state,
+	}
+
+	effects := make([]engineEffect, 0, 101)
+	for range 100 {
+		effects = append(effects, emitEventRecord{JobID: jobID, Record: testFileOpenEventRecord("/workspace/secret.txt")})
+	}
+	effects = append(effects, emitEventRecord{JobID: jobID, Record: jobevent.EventRecord{EventType: jobevent.ProcessExec}})
+
+	engine.runEngineEffects(context.Background(), effects)
+
+	channel := state.jobEventChannels[jobID]
+	if got := len(channel); got != 2 {
+		t.Fatalf("channel len = %d, want 2", got)
+	}
+	first := <-channel
+	second := <-channel
+	if first.EventType != jobevent.FileOpen || second.EventType != jobevent.ProcessExec {
+		t.Fatalf("delivered event types = %q, %q; want file_open, process_exec", first.EventType, second.EventType)
+	}
+	fileStats := state.jobEventDeliveryStats[jobID][jobevent.FileOpen]
+	if fileStats == nil {
+		t.Fatal("file_open delivery stats missing")
+	}
+	if fileStats.Attempted != 100 || fileStats.Delivered != 1 || fileStats.SuppressedDuplicates != 99 || fileStats.Dropped != 0 {
+		t.Fatalf("file_open stats = %#v, want attempted=100 delivered=1 suppressed=99 dropped=0", fileStats)
+	}
+	processStats := state.jobEventDeliveryStats[jobID][jobevent.ProcessExec]
+	if processStats == nil {
+		t.Fatal("process_exec delivery stats missing")
+	}
+	if processStats.Attempted != 1 || processStats.Delivered != 1 || processStats.Dropped != 0 || processStats.SuppressedDuplicates != 0 {
+		t.Fatalf("process_exec stats = %#v, want attempted=1 delivered=1 dropped=0 suppressed=0", processStats)
+	}
+}
+
+func TestRunEngineEffects_RemoveJobLogsDeliverySummary(t *testing.T) {
+	t.Parallel()
+
+	jobID := jobcontext.GitLabJobIdentity("gitlab.com", "group/project", "123")
+	state := newJobTrackingState()
+	state.registerJob(jobID, 1)
+	state.jobEventDeliveryStats[jobID] = map[jobevent.Type]*eventDeliveryStats{
+		jobevent.FileOpen: {
+			Attempted:            3,
+			Delivered:            1,
+			SuppressedDuplicates: 2,
+			MaxQueueDepth:        1,
+		},
+		jobevent.ProcessExec: {
+			Attempted: 1,
+			Delivered: 1,
+		},
+	}
+	var logs bytes.Buffer
+	engine := &KernelTracker{
+		logger:      slog.New(slog.NewJSONHandler(&logs, nil)),
+		kernelIO:    noopKernelIO{},
+		jobTracking: state,
+	}
+
+	engine.runEngineEffects(context.Background(), []engineEffect{removeJobFromKernel{JobID: jobID}})
+
+	got := logs.String()
+	if !strings.Contains(got, "kernel_event_delivery_summary") {
+		t.Fatalf("delivery summary was not logged: %s", got)
+	}
+	if !strings.Contains(got, `"event_type":"file_open"`) {
+		t.Fatalf("delivery summary did not include file_open: %s", got)
+	}
+	if strings.Contains(got, `"event_type":"process_exec"`) {
+		t.Fatalf("delivery summary should skip event types without drop or suppression: %s", got)
 	}
 }
 
@@ -127,5 +459,22 @@ func TestDeleteJobKernelMapEntries_StagingDeleteFailure(t *testing.T) {
 	}
 	if !strings.Contains(logs.String(), "bpf_staging_entries_delete_failed") {
 		t.Fatalf("staging delete failure was not logged: %s", logs.String())
+	}
+}
+
+func testFileOpenEventRecord(path string) jobevent.EventRecord {
+	return jobevent.EventRecord{
+		EventType: jobevent.FileOpen,
+		Process: jobevent.ProcessSummary{
+			PID:           123,
+			StartBoottime: 456,
+			ExecPath:      "/usr/bin/cat",
+		},
+		Payload: map[string]any{
+			fileOpenPayloadPath:    path,
+			fileOpenPayloadIsRead:  true,
+			fileOpenPayloadIsWrite: false,
+			fileOpenPayloadFlags:   0,
+		},
 	}
 }

--- a/internal/agent/kerneltracker/job_tracking_file_open_dedup.go
+++ b/internal/agent/kerneltracker/job_tracking_file_open_dedup.go
@@ -1,0 +1,78 @@
+package kerneltracker
+
+import "github.com/cicd-sensor/cicd-sensor/internal/jobevent"
+
+const defaultFileOpenDedupKeyLimit = 4096
+
+type fileOpenDedupKey struct {
+	pid           int32
+	startBoottime uint64
+	execPath      string
+	payload       fileOpenRecordPayload
+}
+
+func fileOpenDedupKeyForRecord(record jobevent.EventRecord) (fileOpenDedupKey, bool) {
+	if record.Process.PID == 0 || record.Process.StartBoottime == 0 {
+		return fileOpenDedupKey{}, false
+	}
+	if record.Tags["truncated"] == "path" {
+		return fileOpenDedupKey{}, false
+	}
+	payload, ok := fileOpenPayloadFromRecord(record)
+	if !ok {
+		return fileOpenDedupKey{}, false
+	}
+
+	// The key includes rule-visible file_open payload fields. Timestamp and
+	// event ID are intentionally excluded because they differ for every sample.
+	return fileOpenDedupKey{
+		pid:           record.Process.PID,
+		startBoottime: record.Process.StartBoottime,
+		execPath:      record.Process.ExecPath,
+		payload:       payload,
+	}, true
+}
+
+type fileOpenDedupState struct {
+	limit int
+	seen  map[fileOpenDedupKey]struct{}
+	order []fileOpenDedupKey
+	next  int
+}
+
+func newFileOpenDedupState(limit int) *fileOpenDedupState {
+	return &fileOpenDedupState{
+		limit: limit,
+		seen:  make(map[fileOpenDedupKey]struct{}),
+	}
+}
+
+func (s *fileOpenDedupState) contains(key fileOpenDedupKey) bool {
+	if s == nil {
+		return false
+	}
+	_, ok := s.seen[key]
+	return ok
+}
+
+func (s *fileOpenDedupState) remember(key fileOpenDedupKey) {
+	if s == nil || s.limit <= 0 {
+		return
+	}
+	// This is FIFO, not LRU: a hot repeated key should not refresh itself and
+	// keep evicting newer unique file_open keys.
+	if _, ok := s.seen[key]; ok {
+		return
+	}
+	// order is a fixed-size FIFO ring. Once full, next points at the oldest
+	// slot; replacing that slot keeps membership bounded with O(1) work.
+	if len(s.order) < s.limit {
+		s.order = append(s.order, key)
+	} else {
+		oldest := s.order[s.next]
+		delete(s.seen, oldest)
+		s.order[s.next] = key
+		s.next = (s.next + 1) % s.limit
+	}
+	s.seen[key] = struct{}{}
+}

--- a/internal/agent/kerneltracker/job_tracking_file_open_dedup_test.go
+++ b/internal/agent/kerneltracker/job_tracking_file_open_dedup_test.go
@@ -1,0 +1,425 @@
+package kerneltracker
+
+import (
+	"testing"
+
+	"github.com/cicd-sensor/cicd-sensor/internal/jobevent"
+)
+
+func TestFileOpenPayloadFromRecord(t *testing.T) {
+	t.Parallel()
+
+	baseRecord := func() jobevent.EventRecord {
+		return jobevent.EventRecord{
+			EventType: jobevent.FileOpen,
+			Payload: map[string]any{
+				fileOpenPayloadPath:    "/workspace/secret.txt",
+				fileOpenPayloadIsRead:  true,
+				fileOpenPayloadIsWrite: false,
+				fileOpenPayloadFlags:   0x241,
+			},
+		}
+	}
+
+	cases := []struct {
+		name   string
+		mutate func(jobevent.EventRecord) jobevent.EventRecord
+		wantOK bool
+		want   fileOpenRecordPayload
+	}{
+		{
+			name:   "valid payload",
+			wantOK: true,
+			want: fileOpenRecordPayload{
+				Path:    "/workspace/secret.txt",
+				IsRead:  true,
+				IsWrite: false,
+				Flags:   0x241,
+			},
+		},
+		{
+			name: "non file open",
+			mutate: func(record jobevent.EventRecord) jobevent.EventRecord {
+				record.EventType = jobevent.ProcessExec
+				return record
+			},
+		},
+		{
+			name: "missing path",
+			mutate: func(record jobevent.EventRecord) jobevent.EventRecord {
+				delete(record.Payload, fileOpenPayloadPath)
+				return record
+			},
+		},
+		{
+			name: "wrong path type",
+			mutate: func(record jobevent.EventRecord) jobevent.EventRecord {
+				record.Payload[fileOpenPayloadPath] = 42
+				return record
+			},
+		},
+		{
+			name: "missing read mode",
+			mutate: func(record jobevent.EventRecord) jobevent.EventRecord {
+				delete(record.Payload, fileOpenPayloadIsRead)
+				return record
+			},
+		},
+		{
+			name: "wrong read mode type",
+			mutate: func(record jobevent.EventRecord) jobevent.EventRecord {
+				record.Payload[fileOpenPayloadIsRead] = "true"
+				return record
+			},
+		},
+		{
+			name: "missing write mode",
+			mutate: func(record jobevent.EventRecord) jobevent.EventRecord {
+				delete(record.Payload, fileOpenPayloadIsWrite)
+				return record
+			},
+		},
+		{
+			name: "wrong write mode type",
+			mutate: func(record jobevent.EventRecord) jobevent.EventRecord {
+				record.Payload[fileOpenPayloadIsWrite] = "false"
+				return record
+			},
+		},
+		{
+			name: "missing flags",
+			mutate: func(record jobevent.EventRecord) jobevent.EventRecord {
+				delete(record.Payload, fileOpenPayloadFlags)
+				return record
+			},
+		},
+		{
+			name: "wrong flags type",
+			mutate: func(record jobevent.EventRecord) jobevent.EventRecord {
+				record.Payload[fileOpenPayloadFlags] = int32(0x241)
+				return record
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			record := baseRecord()
+			if tc.mutate != nil {
+				record = tc.mutate(record)
+			}
+
+			got, ok := fileOpenPayloadFromRecord(record)
+			if ok != tc.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tc.wantOK)
+			}
+			if got != tc.want {
+				t.Fatalf("payload = %#v, want %#v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestFileOpenDedupKeyForRecord(t *testing.T) {
+	t.Parallel()
+
+	baseRecord := func() jobevent.EventRecord {
+		return jobevent.EventRecord{
+			EventType: jobevent.FileOpen,
+			Process: jobevent.ProcessSummary{
+				PID:           123,
+				StartBoottime: 456,
+				ExecPath:      "/usr/bin/cat",
+			},
+			Payload: map[string]any{
+				fileOpenPayloadPath:    "/workspace/secret.txt",
+				fileOpenPayloadIsRead:  true,
+				fileOpenPayloadIsWrite: false,
+				fileOpenPayloadFlags:   0,
+			},
+		}
+	}
+	wantKey := func(payload fileOpenRecordPayload) fileOpenDedupKey {
+		return fileOpenDedupKey{
+			pid:           123,
+			startBoottime: 456,
+			execPath:      "/usr/bin/cat",
+			payload:       payload,
+		}
+	}
+	basePayload := fileOpenRecordPayload{
+		Path:    "/workspace/secret.txt",
+		IsRead:  true,
+		IsWrite: false,
+		Flags:   0,
+	}
+
+	cases := []struct {
+		name   string
+		mutate func(jobevent.EventRecord) jobevent.EventRecord
+		wantOK bool
+		want   fileOpenDedupKey
+	}{
+		{
+			name:   "valid read key",
+			wantOK: true,
+			want:   wantKey(basePayload),
+		},
+		{
+			name: "path difference changes key",
+			mutate: func(record jobevent.EventRecord) jobevent.EventRecord {
+				record.Payload[fileOpenPayloadPath] = "/workspace/other.txt"
+				return record
+			},
+			wantOK: true,
+			want:   wantKey(fileOpenRecordPayload{Path: "/workspace/other.txt", IsRead: true, IsWrite: false, Flags: 0}),
+		},
+		{
+			name: "process pid difference changes key",
+			mutate: func(record jobevent.EventRecord) jobevent.EventRecord {
+				record.Process.PID = 124
+				return record
+			},
+			wantOK: true,
+			want: fileOpenDedupKey{
+				pid:           124,
+				startBoottime: 456,
+				execPath:      "/usr/bin/cat",
+				payload:       basePayload,
+			},
+		},
+		{
+			name: "process start time difference changes key",
+			mutate: func(record jobevent.EventRecord) jobevent.EventRecord {
+				record.Process.StartBoottime = 789
+				return record
+			},
+			wantOK: true,
+			want: fileOpenDedupKey{
+				pid:           123,
+				startBoottime: 789,
+				execPath:      "/usr/bin/cat",
+				payload:       basePayload,
+			},
+		},
+		{
+			name: "exec path difference changes key",
+			mutate: func(record jobevent.EventRecord) jobevent.EventRecord {
+				record.Process.ExecPath = "/usr/bin/tar"
+				return record
+			},
+			wantOK: true,
+			want: fileOpenDedupKey{
+				pid:           123,
+				startBoottime: 456,
+				execPath:      "/usr/bin/tar",
+				payload:       basePayload,
+			},
+		},
+		{
+			name: "read write mode difference changes key",
+			mutate: func(record jobevent.EventRecord) jobevent.EventRecord {
+				record.Payload[fileOpenPayloadIsRead] = false
+				record.Payload[fileOpenPayloadIsWrite] = true
+				return record
+			},
+			wantOK: true,
+			want:   wantKey(fileOpenRecordPayload{Path: "/workspace/secret.txt", IsRead: false, IsWrite: true, Flags: 0}),
+		},
+		{
+			name: "flags difference changes key",
+			mutate: func(record jobevent.EventRecord) jobevent.EventRecord {
+				record.Payload[fileOpenPayloadFlags] = 0x241
+				return record
+			},
+			wantOK: true,
+			want:   wantKey(fileOpenRecordPayload{Path: "/workspace/secret.txt", IsRead: true, IsWrite: false, Flags: 0x241}),
+		},
+		{
+			name: "non file open is not eligible",
+			mutate: func(record jobevent.EventRecord) jobevent.EventRecord {
+				record.EventType = jobevent.ProcessExec
+				return record
+			},
+		},
+		{
+			name: "truncated path is not eligible",
+			mutate: func(record jobevent.EventRecord) jobevent.EventRecord {
+				record.Tags = map[string]string{"truncated": "path"}
+				return record
+			},
+		},
+		{
+			name: "empty path is not eligible",
+			mutate: func(record jobevent.EventRecord) jobevent.EventRecord {
+				record.Payload[fileOpenPayloadPath] = ""
+				return record
+			},
+		},
+		{
+			name: "missing process pid is not eligible",
+			mutate: func(record jobevent.EventRecord) jobevent.EventRecord {
+				record.Process.PID = 0
+				return record
+			},
+		},
+		{
+			name: "missing process start time is not eligible",
+			mutate: func(record jobevent.EventRecord) jobevent.EventRecord {
+				record.Process.StartBoottime = 0
+				return record
+			},
+		},
+		{
+			name: "missing read mode is not eligible",
+			mutate: func(record jobevent.EventRecord) jobevent.EventRecord {
+				delete(record.Payload, fileOpenPayloadIsRead)
+				return record
+			},
+		},
+		{
+			name: "malformed write mode is not eligible",
+			mutate: func(record jobevent.EventRecord) jobevent.EventRecord {
+				record.Payload[fileOpenPayloadIsWrite] = "false"
+				return record
+			},
+		},
+		{
+			name: "missing flags is not eligible",
+			mutate: func(record jobevent.EventRecord) jobevent.EventRecord {
+				delete(record.Payload, fileOpenPayloadFlags)
+				return record
+			},
+		},
+		{
+			name: "malformed flags is not eligible",
+			mutate: func(record jobevent.EventRecord) jobevent.EventRecord {
+				record.Payload[fileOpenPayloadFlags] = int32(0)
+				return record
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			record := baseRecord()
+			if tc.mutate != nil {
+				record = tc.mutate(record)
+			}
+
+			got, ok := fileOpenDedupKeyForRecord(record)
+			if ok != tc.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tc.wantOK)
+			}
+			if got != tc.want {
+				t.Fatalf("key = %#v, want %#v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestFileOpenDedupState(t *testing.T) {
+	t.Parallel()
+
+	key := func(path string) fileOpenDedupKey {
+		return fileOpenDedupKey{
+			pid:           123,
+			startBoottime: 456,
+			execPath:      "/usr/bin/cat",
+			payload: fileOpenRecordPayload{
+				Path:   path,
+				IsRead: true,
+				Flags:  0,
+			},
+		}
+	}
+
+	cases := []struct {
+		name string
+		run  func(*testing.T)
+	}{
+		{
+			name: "duplicate hit is visible after remember",
+			run: func(t *testing.T) {
+				state := newFileOpenDedupState(2)
+				first := key("/tmp/a")
+
+				if state.contains(first) {
+					t.Fatal("key must not be present before remember")
+				}
+				state.remember(first)
+				if !state.contains(first) {
+					t.Fatal("key must be present after remember")
+				}
+			},
+		},
+		{
+			name: "duplicate hit does not refresh fifo order",
+			run: func(t *testing.T) {
+				state := newFileOpenDedupState(2)
+				first := key("/tmp/a")
+				second := key("/tmp/b")
+				third := key("/tmp/c")
+
+				state.remember(first)
+				state.remember(second)
+				state.remember(first)
+				state.remember(third)
+
+				if state.contains(first) {
+					t.Fatal("duplicate remember refreshed FIFO order; oldest key survived")
+				}
+				if !state.contains(second) || !state.contains(third) {
+					t.Fatal("newer keys must survive FIFO eviction")
+				}
+			},
+		},
+		{
+			name: "oldest inserted key is evicted at capacity",
+			run: func(t *testing.T) {
+				state := newFileOpenDedupState(2)
+				first := key("/tmp/a")
+				second := key("/tmp/b")
+				third := key("/tmp/c")
+
+				state.remember(first)
+				state.remember(second)
+				state.remember(third)
+
+				if state.contains(first) {
+					t.Fatal("oldest key survived capacity eviction")
+				}
+				if !state.contains(second) || !state.contains(third) {
+					t.Fatal("newer keys must survive capacity eviction")
+				}
+			},
+		},
+		{
+			name: "table size never exceeds limit",
+			run: func(t *testing.T) {
+				state := newFileOpenDedupState(2)
+				state.remember(key("/tmp/a"))
+				state.remember(key("/tmp/b"))
+				state.remember(key("/tmp/c"))
+
+				if got := len(state.seen); got != 2 {
+					t.Fatalf("seen size = %d, want 2", got)
+				}
+				if got := len(state.order); got != 2 {
+					t.Fatalf("order size = %d, want 2", got)
+				}
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			tc.run(t)
+		})
+	}
+}

--- a/internal/agent/kerneltracker/job_tracking_state.go
+++ b/internal/agent/kerneltracker/job_tracking_state.go
@@ -2,7 +2,6 @@ package kerneltracker
 
 import (
 	"log/slog"
-	"math/bits"
 
 	"github.com/cicd-sensor/cicd-sensor/internal/jobcontext"
 	"github.com/cicd-sensor/cicd-sensor/internal/jobevent"
@@ -10,27 +9,29 @@ import (
 
 // jobTrackingState is the loop-local Job mirror owned by KernelTracker.Run.
 type jobTrackingState struct {
-	logger             *slog.Logger
-	jobs               map[jobcontext.JobIdentity]struct{}
-	jobEventChannels   map[jobcontext.JobIdentity]chan jobevent.EventRecord
-	jobEventDropCounts map[jobcontext.JobIdentity]uint64
-	jobByCgroup        map[uint64]jobcontext.JobIdentity
-	cgroupsByJob       map[jobcontext.JobIdentity]map[uint64]struct{}
-	stagingByBasename  map[string]jobcontext.JobIdentity
-	stagingByJob       map[jobcontext.JobIdentity]map[string]struct{}
-	processesByJob     map[jobcontext.JobIdentity]*jobProcessState
+	logger                *slog.Logger
+	jobs                  map[jobcontext.JobIdentity]struct{}
+	jobEventChannels      map[jobcontext.JobIdentity]chan jobevent.EventRecord
+	jobEventDeliveryStats map[jobcontext.JobIdentity]map[jobevent.Type]*eventDeliveryStats
+	fileOpenDedupByJob    map[jobcontext.JobIdentity]*fileOpenDedupState
+	jobByCgroup           map[uint64]jobcontext.JobIdentity
+	cgroupsByJob          map[jobcontext.JobIdentity]map[uint64]struct{}
+	stagingByBasename     map[string]jobcontext.JobIdentity
+	stagingByJob          map[jobcontext.JobIdentity]map[string]struct{}
+	processesByJob        map[jobcontext.JobIdentity]*jobProcessState
 }
 
 func newJobTrackingState() *jobTrackingState {
 	return &jobTrackingState{
-		jobs:               make(map[jobcontext.JobIdentity]struct{}),
-		jobEventChannels:   make(map[jobcontext.JobIdentity]chan jobevent.EventRecord),
-		jobEventDropCounts: make(map[jobcontext.JobIdentity]uint64),
-		jobByCgroup:        make(map[uint64]jobcontext.JobIdentity),
-		cgroupsByJob:       make(map[jobcontext.JobIdentity]map[uint64]struct{}),
-		stagingByBasename:  make(map[string]jobcontext.JobIdentity),
-		stagingByJob:       make(map[jobcontext.JobIdentity]map[string]struct{}),
-		processesByJob:     make(map[jobcontext.JobIdentity]*jobProcessState),
+		jobs:                  make(map[jobcontext.JobIdentity]struct{}),
+		jobEventChannels:      make(map[jobcontext.JobIdentity]chan jobevent.EventRecord),
+		jobEventDeliveryStats: make(map[jobcontext.JobIdentity]map[jobevent.Type]*eventDeliveryStats),
+		fileOpenDedupByJob:    make(map[jobcontext.JobIdentity]*fileOpenDedupState),
+		jobByCgroup:           make(map[uint64]jobcontext.JobIdentity),
+		cgroupsByJob:          make(map[jobcontext.JobIdentity]map[uint64]struct{}),
+		stagingByBasename:     make(map[string]jobcontext.JobIdentity),
+		stagingByJob:          make(map[jobcontext.JobIdentity]map[string]struct{}),
+		processesByJob:        make(map[jobcontext.JobIdentity]*jobProcessState),
 	}
 }
 
@@ -39,6 +40,9 @@ func (s *jobTrackingState) registerJob(jobID jobcontext.JobIdentity, eventRecord
 
 	if s.processesByJob[jobID] == nil {
 		s.processesByJob[jobID] = newJobProcessState()
+	}
+	if s.fileOpenDedupByJob[jobID] == nil {
+		s.fileOpenDedupByJob[jobID] = newFileOpenDedupState(defaultFileOpenDedupKeyLimit)
 	}
 
 	channel := s.jobEventChannels[jobID]
@@ -50,15 +54,39 @@ func (s *jobTrackingState) registerJob(jobID jobcontext.JobIdentity, eventRecord
 	return channel
 }
 
-// shouldLogEventDrop rate-limits event-drop logs at powers of two.
-func shouldLogEventDrop(dropped uint64) bool {
-	return dropped == 1 || bits.OnesCount64(dropped) == 1
+type eventDeliveryStats struct {
+	Attempted            uint64
+	Delivered            uint64
+	Dropped              uint64
+	SuppressedDuplicates uint64
+	MaxQueueDepth        int
+}
+
+func (s *eventDeliveryStats) observeQueueDepth(depth int) {
+	if depth > s.MaxQueueDepth {
+		s.MaxQueueDepth = depth
+	}
+}
+
+func (s *jobTrackingState) deliveryStatsFor(jobID jobcontext.JobIdentity, eventType jobevent.Type) *eventDeliveryStats {
+	byEventType := s.jobEventDeliveryStats[jobID]
+	if byEventType == nil {
+		byEventType = make(map[jobevent.Type]*eventDeliveryStats)
+		s.jobEventDeliveryStats[jobID] = byEventType
+	}
+	stats := byEventType[eventType]
+	if stats == nil {
+		stats = &eventDeliveryStats{}
+		byEventType[eventType] = stats
+	}
+	return stats
 }
 
 func (s *jobTrackingState) removeJob(jobID jobcontext.JobIdentity) chan jobevent.EventRecord {
 	channel := s.jobEventChannels[jobID]
 	delete(s.jobEventChannels, jobID)
-	delete(s.jobEventDropCounts, jobID)
+	delete(s.jobEventDeliveryStats, jobID)
+	delete(s.fileOpenDedupByJob, jobID)
 	s.removeCgroupAndStaging(jobID)
 	delete(s.jobs, jobID)
 	delete(s.processesByJob, jobID)

--- a/internal/agent/kerneltracker/job_tracking_state_test.go
+++ b/internal/agent/kerneltracker/job_tracking_state_test.go
@@ -1,8 +1,10 @@
 package kerneltracker
 
 import (
-	"github.com/cicd-sensor/cicd-sensor/internal/jobcontext"
 	"testing"
+
+	"github.com/cicd-sensor/cicd-sensor/internal/jobcontext"
+	"github.com/cicd-sensor/cicd-sensor/internal/jobevent"
 )
 
 func TestJobTrackingState_RemoveJobClearsAllJobOwnedState(t *testing.T) {
@@ -15,15 +17,27 @@ func TestJobTrackingState_RemoveJobClearsAllJobOwnedState(t *testing.T) {
 	otherProcess := processIdentity{PID: 20, StartBoottime: 2000}
 
 	s.registerJob(target, 1)
+	if s.fileOpenDedupByJob[target] == nil {
+		t.Fatal("registerJob did not initialize target file open dedup state")
+	}
 	s.bind(target, 42)
 	s.putStaging("docker-target.scope", target)
-	s.jobEventDropCounts[target] = 3
+	s.jobEventDeliveryStats[target] = map[jobevent.Type]*eventDeliveryStats{
+		jobevent.FileOpen: &eventDeliveryStats{Attempted: 3, Delivered: 1, SuppressedDuplicates: 2},
+	}
+	s.fileOpenDedupByJob[target].remember(testFileOpenDedupKey(10, 1000, "/target"))
 	s.recordExec(target, targetProcess, "/bin/target", nil, 0)
 
 	s.registerJob(other, 1)
+	if s.fileOpenDedupByJob[other] == nil {
+		t.Fatal("registerJob did not initialize bystander file open dedup state")
+	}
 	s.bind(other, 84)
 	s.putStaging("docker-other.scope", other)
-	s.jobEventDropCounts[other] = 5
+	s.jobEventDeliveryStats[other] = map[jobevent.Type]*eventDeliveryStats{
+		jobevent.FileOpen: &eventDeliveryStats{Attempted: 5, Delivered: 4, SuppressedDuplicates: 1},
+	}
+	s.fileOpenDedupByJob[other].remember(testFileOpenDedupKey(20, 2000, "/other"))
 	s.recordExec(other, otherProcess, "/bin/other", nil, 0)
 
 	channel := s.removeJob(target)
@@ -37,8 +51,11 @@ func TestJobTrackingState_RemoveJobClearsAllJobOwnedState(t *testing.T) {
 	if _, ok := s.jobEventChannels[target]; ok {
 		t.Fatal("target event channel survived RemoveJob")
 	}
-	if _, ok := s.jobEventDropCounts[target]; ok {
-		t.Fatal("target event drop count survived RemoveJob")
+	if _, ok := s.jobEventDeliveryStats[target]; ok {
+		t.Fatal("target event delivery stats survived RemoveJob")
+	}
+	if _, ok := s.fileOpenDedupByJob[target]; ok {
+		t.Fatal("target file open dedup state survived RemoveJob")
 	}
 	if _, ok := s.jobForCgroup(42); ok {
 		t.Fatal("target cgroup forward index survived RemoveJob")
@@ -62,8 +79,11 @@ func TestJobTrackingState_RemoveJobClearsAllJobOwnedState(t *testing.T) {
 	if _, ok := s.jobEventChannels[other]; !ok {
 		t.Fatal("bystander event channel was removed")
 	}
-	if got := s.jobEventDropCounts[other]; got != 5 {
-		t.Fatalf("bystander event drop count = %d, want 5", got)
+	if got := s.jobEventDeliveryStats[other][jobevent.FileOpen].SuppressedDuplicates; got != 1 {
+		t.Fatalf("bystander suppressed duplicate count = %d, want 1", got)
+	}
+	if state := s.fileOpenDedupByJob[other]; state == nil || !state.contains(testFileOpenDedupKey(20, 2000, "/other")) {
+		t.Fatal("bystander file open dedup state was removed")
 	}
 	if owner, ok := s.jobForCgroup(84); !ok || owner != other {
 		t.Fatalf("bystander cgroup owner = %v ok=%v, want %v true", owner, ok, other)
@@ -145,5 +165,17 @@ func TestJobTrackingState_RemoveJob(t *testing.T) {
 				t.Errorf("bystander staging entry lost: got %v ok=%v", owner, ok)
 			}
 		})
+	}
+}
+
+func testFileOpenDedupKey(pid int32, startBoottime uint64, path string) fileOpenDedupKey {
+	return fileOpenDedupKey{
+		pid:           pid,
+		startBoottime: startBoottime,
+		payload: fileOpenRecordPayload{
+			Path:   path,
+			IsRead: true,
+			Flags:  0,
+		},
 	}
 }

--- a/internal/agent/kerneltracker/kernel_sample_file_handle.go
+++ b/internal/agent/kerneltracker/kernel_sample_file_handle.go
@@ -21,6 +21,51 @@ type fileOpenSample struct {
 func (fileOpenSample) sealedEngineInput()         {}
 func (fileOpenSample) sealedDecodedKernelSample() {}
 
+const (
+	fileOpenPayloadPath    = "path"
+	fileOpenPayloadIsRead  = "is_read"
+	fileOpenPayloadIsWrite = "is_write"
+	fileOpenPayloadFlags   = "flags"
+)
+
+// fileOpenRecordPayload is what file_open dedup reads from EventRecord.Payload.
+// fileOpenDedupKey embeds this type so rule-visible payload changes also change
+// duplicate-suppression identity.
+type fileOpenRecordPayload struct {
+	Path    string
+	IsRead  bool
+	IsWrite bool
+	Flags   int
+}
+
+func fileOpenPayloadFromRecord(record jobevent.EventRecord) (fileOpenRecordPayload, bool) {
+	if record.EventType != jobevent.FileOpen {
+		return fileOpenRecordPayload{}, false
+	}
+	pathValue, ok := record.Payload[fileOpenPayloadPath].(string)
+	if !ok || pathValue == "" {
+		return fileOpenRecordPayload{}, false
+	}
+	isRead, ok := record.Payload[fileOpenPayloadIsRead].(bool)
+	if !ok {
+		return fileOpenRecordPayload{}, false
+	}
+	isWrite, ok := record.Payload[fileOpenPayloadIsWrite].(bool)
+	if !ok {
+		return fileOpenRecordPayload{}, false
+	}
+	flags, ok := record.Payload[fileOpenPayloadFlags].(int)
+	if !ok {
+		return fileOpenRecordPayload{}, false
+	}
+	return fileOpenRecordPayload{
+		Path:    pathValue,
+		IsRead:  isRead,
+		IsWrite: isWrite,
+		Flags:   flags,
+	}, true
+}
+
 type fileRemoveSample struct {
 	Identity      processIdentity
 	CgroupID      uint64
@@ -72,10 +117,10 @@ func handleFileOpenSample(state *jobTrackingState, sample fileOpenSample) []engi
 		Timestamp: bootNsToUTC(sample.TsNs),
 		Process:   state.lookupProcessSummary(jobID, sample.Identity),
 		Payload: map[string]any{
-			"path":     sample.Path,
-			"is_write": sample.IsWrite,
-			"is_read":  sample.IsRead,
-			"flags":    int(sample.Flags),
+			fileOpenPayloadPath:    sample.Path,
+			fileOpenPayloadIsRead:  sample.IsRead,
+			fileOpenPayloadIsWrite: sample.IsWrite,
+			fileOpenPayloadFlags:   int(sample.Flags),
 		},
 		Tags: map[string]string{},
 	}

--- a/internal/agent/kerneltracker/kernel_sample_file_handle_test.go
+++ b/internal/agent/kerneltracker/kernel_sample_file_handle_test.go
@@ -49,6 +49,54 @@ func TestHandleFileOpen_EmitsPayloadAndTruncatedTag(t *testing.T) {
 	if got := emit.Record.Tags["truncated"]; got != "path" {
 		t.Fatalf("truncated tag = %q, want path", got)
 	}
+
+	assertPayloadKeys(t, emit.Record.Payload, fileOpenPayloadPath, fileOpenPayloadFlags, fileOpenPayloadIsWrite, fileOpenPayloadIsRead)
+	payload, ok := fileOpenPayloadFromRecord(emit.Record)
+	if !ok {
+		t.Fatal("fileOpenPayloadFromRecord() ok = false, want true")
+	}
+	if payload != (fileOpenRecordPayload{Path: "/tmp/very-long-path", IsRead: true, IsWrite: true, Flags: 0x241}) {
+		t.Fatalf("fileOpenPayloadFromRecord() = %#v", payload)
+	}
+	if _, ok := fileOpenDedupKeyForRecord(emit.Record); ok {
+		t.Fatal("truncated file_open must not be eligible for dedup")
+	}
+}
+
+func TestHandleFileOpen_PayloadRoundTripsToDedupKey(t *testing.T) {
+	t.Parallel()
+
+	jobID := jobcontext.GitLabJobIdentity("gitlab.com", "group/project", "123")
+	identity := processIdentity{PID: 101, StartBoottime: 2}
+
+	state := destinationTrackedState(jobID, 42)
+	state.recordExec(jobID, identity, "/bin/cat", nil, 0)
+
+	effects := handleEngineInput(state, fileOpenSample{
+		Identity: identity,
+		CgroupID: 42,
+		TsNs:     17,
+		Path:     "/tmp/visible-path",
+		Flags:    0x241,
+		IsWrite:  true,
+		IsRead:   true,
+	})
+
+	emit, ok := singleEmitEventRecordEffect(effects)
+	if !ok {
+		t.Fatalf("effects = %#v, want single emitEventRecord", effects)
+	}
+	assertPayloadKeys(t, emit.Record.Payload, fileOpenPayloadPath, fileOpenPayloadFlags, fileOpenPayloadIsWrite, fileOpenPayloadIsRead)
+	payload, ok := fileOpenPayloadFromRecord(emit.Record)
+	if !ok {
+		t.Fatal("fileOpenPayloadFromRecord() ok = false, want true")
+	}
+	if payload != (fileOpenRecordPayload{Path: "/tmp/visible-path", IsRead: true, IsWrite: true, Flags: 0x241}) {
+		t.Fatalf("fileOpenPayloadFromRecord() = %#v", payload)
+	}
+	if _, ok := fileOpenDedupKeyForRecord(emit.Record); !ok {
+		t.Fatal("fileOpenDedupKeyForRecord() ok = false, want true")
+	}
 }
 
 func TestHandleFileRemove_EmitsPayload(t *testing.T) {
@@ -226,5 +274,18 @@ func TestHandleFileLink_SymlinkRelativeResolved(t *testing.T) {
 				t.Fatalf("payload[is_symlink] = false, want true")
 			}
 		})
+	}
+}
+
+func assertPayloadKeys(t *testing.T, payload map[string]any, keys ...string) {
+	t.Helper()
+
+	if len(payload) != len(keys) {
+		t.Fatalf("payload keys = %v, want exactly %v", payload, keys)
+	}
+	for _, key := range keys {
+		if _, ok := payload[key]; !ok {
+			t.Fatalf("payload missing key %q in %v", key, payload)
+		}
 	}
 }

--- a/internal/agent/kerneltracker/kernel_sample_file_integration_linux_test.go
+++ b/internal/agent/kerneltracker/kernel_sample_file_integration_linux_test.go
@@ -82,9 +82,13 @@ func TestLinuxKernelSampleFileOpenEndToEnd(t *testing.T) {
 		return true
 	})
 
-	appendReadFile, err := os.OpenFile(path, os.O_RDONLY|syscall.O_APPEND, 0)
+	appendReadPath := filepath.Join(tempDir, "append-read.txt")
+	if err := os.WriteFile(appendReadPath, []byte("test"), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q): %v", appendReadPath, err)
+	}
+	appendReadFile, err := os.OpenFile(appendReadPath, os.O_RDONLY|syscall.O_APPEND, 0)
 	if err != nil {
-		t.Fatalf("OpenFile(%q, O_RDONLY|O_APPEND): %v", path, err)
+		t.Fatalf("OpenFile(%q, O_RDONLY|O_APPEND): %v", appendReadPath, err)
 	}
 	_ = appendReadFile.Close()
 
@@ -95,7 +99,52 @@ func TestLinuxKernelSampleFileOpenEndToEnd(t *testing.T) {
 		gotPath, _ := record.Payload["path"].(string)
 		isRead, _ := record.Payload["is_read"].(bool)
 		isWrite, _ := record.Payload["is_write"].(bool)
-		return gotPath == path && isRead && !isWrite
+		return gotPath == appendReadPath && isRead && !isWrite
+	})
+}
+
+func TestLinuxKernelSampleFileOpenRepeatedReadIsSuppressedEndToEnd(t *testing.T) {
+	kernelIO, cgroupRoot := newLinuxKernelIO(t)
+	defer kernelIO.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	engine := newTestKernelTracker(nil, nil, kernelIO, cgroupRoot)
+	done := make(chan error, 1)
+	go func() {
+		done <- engine.Run(ctx)
+	}()
+	defer func() {
+		cancel()
+		if err := <-done; err != nil {
+			t.Fatalf("Run error = %v, want nil", err)
+		}
+	}()
+
+	tempDir := t.TempDir()
+	path := filepath.Join(tempDir, "repeated.txt")
+	if err := os.WriteFile(path, []byte("test"), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q): %v", path, err)
+	}
+
+	jobID := jobcontext.GitLabJobIdentity("gitlab.com", "group/project", "file-open-dedup")
+	eventCh, err := engine.RegisterJob(ctx, jobID)
+	if err != nil {
+		t.Fatalf("RegisterJob: %v", err)
+	}
+	if err := engine.BindProcessCgroupToJob(ctx, jobID, int32(os.Getpid())); err != nil {
+		t.Fatalf("BindProcessCgroupToJob: %v", err)
+	}
+
+	openReadOnlyFile(t, path)
+	waitForEventRecord(t, eventCh, 5*time.Second, "first repeated file_open read", func(record jobevent.EventRecord) bool {
+		return isReadFileOpenForPath(record, path)
+	})
+
+	openReadOnlyFile(t, path)
+	assertNoEventRecord(t, eventCh, 500*time.Millisecond, func(record jobevent.EventRecord) bool {
+		return isReadFileOpenForPath(record, path)
 	})
 }
 
@@ -159,6 +208,27 @@ func TestLinuxKernelSampleFileOpenLongPathIsTruncated(t *testing.T) {
 		t.Logf("file_open long path saw path=%q tags=%v", record.Payload["path"], record.Tags)
 		return record.Tags["truncated"] == "path"
 	})
+}
+
+func openReadOnlyFile(t *testing.T, path string) {
+	t.Helper()
+	file, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("Open(%q): %v", path, err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatalf("Close(%q): %v", path, err)
+	}
+}
+
+func isReadFileOpenForPath(record jobevent.EventRecord, path string) bool {
+	if record.EventType != jobevent.FileOpen {
+		return false
+	}
+	gotPath, _ := record.Payload["path"].(string)
+	isRead, _ := record.Payload["is_read"].(bool)
+	isWrite, _ := record.Payload["is_write"].(bool)
+	return gotPath == path && isRead && !isWrite
 }
 
 // TestLinuxKernelSampleFileRemoveEndToEnd exercises the security_inode_unlink and


### PR DESCRIPTION
## What

- Increase the per-Job `EventRecord` channel capacity from 16k to 64k.
- Suppress repeated same-key `file_open` records before they consume the per-Job channel.
- Keep suppression scoped to `file_open` only; all other event types are delivered or dropped normally.
- Add delivery diagnostics for attempted / delivered / dropped / suppressed event records.
- Document the EventRecord delivery-pressure behavior in the Developer Guide.

## Why

Issue #78 showed that high-volume repeated `file_open` events can fill a Job’s bounded event channel and cause later security-relevant events, such as `process_exec` or unique credential-like file reads, to be dropped before rule evaluation.

The fix keeps the first successfully delivered `file_open` for each key, suppresses later duplicates, and preserves unique reads, write/read differences, and open-flag differences. This reduces delivery pressure without changing eBPF attribution, rule evaluation, CEL schema, or manager APIs.

Refs #78
