### PR TITLE
feat(rules): add Mastra npm compromise C2 IP IOC

### DIFF
--- a/rules/ioc.yaml
+++ b/rules/ioc.yaml
@@ -20,3 +20,23 @@ rule_sets:
           mitre_tactic: command-and-control
           ioc_date: "2026-05-19"
           source_url: https://www.chainguard.dev/unchained/mini-shai-hulud-npm-attack-antv-ecosystem-compromise-may-2026
+
+      - rule_id: mastra_npm_compromise_c2_ip
+        rule_name: "IOC: Mastra npm package compromise C2 IP"
+        description: |
+          What:
+            Outbound C2 connections from the @mastra/* npm package compromise.
+          Why:
+            Active-compromise IOC. Compromised @mastra packages beacon to these IPs.
+        event_type: network_connect
+        condition: |
+          family == "ipv4" &&
+          (
+            remote_ip == "23.254.164.92" ||
+            remote_ip == "23.254.164.123"
+          )
+        action: terminate
+        tags:
+          mitre_tactic: command-and-control
+          ioc_date: "2026-06-17"
+          source_url: https://x.com/lmt_swallow/status/2067082668458786967


### PR DESCRIPTION
## What

Adds a high-confidence IOC rule for the **@mastra/\* npm package compromise** (campaign began ~2026-06-17).

The rule terminates outbound IPv4 connections to the reported C2 hosts:

- `23.254.164.92`
- `23.254.164.123`

## Why

These are confirmed active-compromise indicators. Compromised `@mastra/<pkg>` packages beacon to these IPs from CI, so matching the C2 destination is the lowest-false-positive signal available.

## Notes

- Exact-IP match (not `/24`) because both IPs sit in shared hosting space (`23.254.164.0/24`); matching the two confirmed IPs avoids hitting unrelated tenants.
- `action: terminate`, consistent with the existing C2 IOC in this file.
- Source: https://x.com/lmt_swallow/status/2067082668458786967

`make rules-validate` passes (`OK: 6 file(s) bundled and validated`).