### PR TITLE
Tune BPF ring buffer sizing

### DIFF
--- a/docs/developer-guide/ebpf-runtime.md
+++ b/docs/developer-guide/ebpf-runtime.md
@@ -122,6 +122,9 @@ The FIFO order is stored as a fixed-size ring buffer, so inserts remain O(1) aft
 KernelTracker records delivery diagnostics internally (`attempted`, `delivered`, `dropped`, `suppressed_duplicates`, and `max_queue_depth`) and logs a summary when a Job is removed if drops or suppression occurred.
 Manager `runtime_event` output uses the same 64k queue capacity so the post-evaluation log path does not immediately become the next bottleneck; detection and summary outputs keep the smaller manager-output queue because they are not raw event streams.
 
+The BPF `events` ring buffer is a node-level ingress buffer before KernelTracker can attribute samples to Jobs.
+KernelIO sizes it from node CPU count, so larger runner nodes get a larger kernel-to-userspace buffer before per-Job delivery begins.
+
 ## Implementation layout
 
 | Path | Content |

--- a/internal/agent/bpf/maps.bpf.h
+++ b/internal/agent/bpf/maps.bpf.h
@@ -30,6 +30,7 @@ const volatile struct staging_value *unused_staging_value;
 struct {
     // Ringbuf requires 5.8+; our 5.15+ baseline guarantees it.
     __uint(type, BPF_MAP_TYPE_RINGBUF);
+    // Userspace sets the real cap from node CPU count before load.
     __uint(max_entries, 1 << 20);
 } events SEC(".maps");
 

--- a/internal/agent/kerneltracker/kernelio/kernel_io_loop_linux.go
+++ b/internal/agent/kerneltracker/kernelio/kernel_io_loop_linux.go
@@ -78,7 +78,7 @@ func (kernelIO *LinuxKernelIO) watchRingbufDrops(ctx context.Context) {
 
 	// Ringbuf drops happen before samples can be attributed to a Job. Keep
 	// them as agent-wide audit signals; do not fold them into Job events_dropped.
-	var lastTotal uint64
+	var dropWarnings ringbufDropWarnState
 	for {
 		select {
 		case <-ctx.Done():
@@ -91,16 +91,42 @@ func (kernelIO *LinuxKernelIO) watchRingbufDrops(ctx context.Context) {
 			kernelIO.logger.WarnContext(ctx, "bpf_ringbuf_drop_count_read_failed", "error", err)
 			continue
 		}
-		if total <= lastTotal {
+		dropped, ok := dropWarnings.shouldWarn(total)
+		if !ok {
 			continue
 		}
 
 		kernelIO.logger.WarnContext(ctx, "bpf_ringbuf_drop",
-			"dropped", total-lastTotal,
+			"dropped", dropped,
 			"total", total,
 		)
-		lastTotal = total
 	}
+}
+
+type ringbufDropWarnState struct {
+	lastWarnTotal uint64
+	nextWarnTotal uint64
+}
+
+func (state *ringbufDropWarnState) shouldWarn(total uint64) (uint64, bool) {
+	if total == 0 || total <= state.lastWarnTotal {
+		return 0, false
+	}
+	if state.nextWarnTotal != 0 && total < state.nextWarnTotal {
+		return 0, false
+	}
+
+	dropped := total - state.lastWarnTotal
+	state.lastWarnTotal = total
+	state.nextWarnTotal = nextRingbufDropWarnTotal(total)
+	return dropped, true
+}
+
+func nextRingbufDropWarnTotal(total uint64) uint64 {
+	if total == ^uint64(0) {
+		return total
+	}
+	return roundUpToPowerOfTwo(total + 1)
 }
 
 func (kernelIO *LinuxKernelIO) readRingbufDropCount() (uint64, error) {

--- a/internal/agent/kerneltracker/kernelio/kernel_io_loop_linux_test.go
+++ b/internal/agent/kerneltracker/kernelio/kernel_io_loop_linux_test.go
@@ -47,3 +47,73 @@ func TestReadRingbufDropCountRequiresMap(t *testing.T) {
 		t.Fatalf("expected missing ringbuf drop count map error")
 	}
 }
+
+func TestRingbufDropWarnState(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		totals []uint64
+		want   []ringbufDropWarnDecision
+	}{
+		{
+			name:   "unchanged zero never warns",
+			totals: []uint64{0, 0},
+			want:   []ringbufDropWarnDecision{{}, {}},
+		},
+		{
+			name:   "first observed drop warns",
+			totals: []uint64{1},
+			want:   []ringbufDropWarnDecision{{dropped: 1, warn: true}},
+		},
+		{
+			name:   "same bucket increase stays quiet",
+			totals: []uint64{2, 3},
+			want:   []ringbufDropWarnDecision{{dropped: 2, warn: true}, {}},
+		},
+		{
+			name:   "crossing power of two warns",
+			totals: []uint64{2, 3, 4},
+			want:   []ringbufDropWarnDecision{{dropped: 2, warn: true}, {}, {dropped: 2, warn: true}},
+		},
+		{
+			name:   "large one-poll jump waits for the next threshold",
+			totals: []uint64{0, 100, 100, 127, 128},
+			want: []ringbufDropWarnDecision{
+				{},
+				{dropped: 100, warn: true},
+				{},
+				{},
+				{dropped: 28, warn: true},
+			},
+		},
+		{
+			name:   "large jump warns once with full delta",
+			totals: []uint64{1, 10},
+			want:   []ringbufDropWarnDecision{{dropped: 1, warn: true}, {dropped: 9, warn: true}},
+		},
+		{
+			name:   "counter rollback stays quiet until previous warning total is exceeded",
+			totals: []uint64{8, 4, 8, 16},
+			want:   []ringbufDropWarnDecision{{dropped: 8, warn: true}, {}, {}, {dropped: 8, warn: true}},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var state ringbufDropWarnState
+			for i, total := range tc.totals {
+				dropped, warn := state.shouldWarn(total)
+				if warn != tc.want[i].warn || dropped != tc.want[i].dropped {
+					t.Fatalf("step %d total %d: got dropped=%d warn=%v, want dropped=%d warn=%v",
+						i, total, dropped, warn, tc.want[i].dropped, tc.want[i].warn)
+				}
+			}
+		})
+	}
+}
+
+type ringbufDropWarnDecision struct {
+	dropped uint64
+	warn    bool
+}

--- a/internal/agent/kerneltracker/kernelio/program_spec.go
+++ b/internal/agent/kerneltracker/kernelio/program_spec.go
@@ -2,16 +2,60 @@ package kernelio
 
 import (
 	"fmt"
+	"math"
+	"math/bits"
+	"runtime"
 
 	"github.com/cilium/ebpf"
 )
 
+const (
+	eventsMapName = "events"
+	// Keep at least 8 MiB for small CI/CD runner nodes.
+	minEventsRingbufMaxEntries = 8 << 20
+	// Add 4 MiB per CPU so larger runner nodes get more ingress capacity.
+	eventsRingbufMaxBytesPerCPU = 4 << 20
+)
+
 // configureBPFProgramSpec applies userspace-owned map settings before load.
 func configureBPFProgramSpec(spec *ebpf.CollectionSpec) error {
+	eventsMap := spec.Maps[eventsMapName]
+	if eventsMap == nil {
+		return fmt.Errorf("bpf map %q not found", eventsMapName)
+	}
+	eventsMaxEntries, err := eventsRingbufMaxEntries(runtime.NumCPU())
+	if err != nil {
+		return err
+	}
+	eventsMap.MaxEntries = eventsMaxEntries
+
 	stagingMap := spec.Maps[StagingMapName]
 	if stagingMap == nil {
 		return fmt.Errorf("bpf map %q not found", StagingMapName)
 	}
 	stagingMap.MaxEntries = StagingMaxEntries
 	return nil
+}
+
+func eventsRingbufMaxEntries(cpuCount int) (uint32, error) {
+	if cpuCount <= 0 {
+		return 0, fmt.Errorf("cpu count must be positive, got %d", cpuCount)
+	}
+
+	size := uint64(cpuCount) * eventsRingbufMaxBytesPerCPU
+	size = max(size, minEventsRingbufMaxEntries)
+
+	// BPF_MAP_TYPE_RINGBUF requires max_entries to be a power of two.
+	rounded := roundUpToPowerOfTwo(size)
+	if rounded > math.MaxUint32 {
+		return 0, fmt.Errorf("events ringbuf max entries %d exceed uint32", rounded)
+	}
+	return uint32(rounded), nil
+}
+
+func roundUpToPowerOfTwo(value uint64) uint64 {
+	if value <= 1 {
+		return 1
+	}
+	return 1 << bits.Len64(value-1)
 }

--- a/internal/agent/kerneltracker/kernelio/program_spec_test.go
+++ b/internal/agent/kerneltracker/kernelio/program_spec_test.go
@@ -1,6 +1,7 @@
 package kernelio
 
 import (
+	"runtime"
 	"testing"
 
 	"github.com/cilium/ebpf"
@@ -20,6 +21,35 @@ func TestConfigureBPFProgramSpecSetsStagingCap(t *testing.T) {
 	}
 }
 
+func TestConfigureBPFProgramSpecSetsEventsRingbufCap(t *testing.T) {
+	t.Parallel()
+
+	spec := fakeProgramSpec()
+
+	if err := configureBPFProgramSpec(spec); err != nil {
+		t.Fatalf("configureBPFProgramSpec returned error: %v", err)
+	}
+
+	want, err := eventsRingbufMaxEntries(runtime.NumCPU())
+	if err != nil {
+		t.Fatalf("eventsRingbufMaxEntries returned error: %v", err)
+	}
+	if got := spec.Maps[eventsMapName].MaxEntries; got != want {
+		t.Fatalf("events ringbuf max entries: got %d, want %d", got, want)
+	}
+}
+
+func TestConfigureBPFProgramSpecErrorsOnMissingEventsMap(t *testing.T) {
+	t.Parallel()
+
+	spec := fakeProgramSpec()
+	delete(spec.Maps, eventsMapName)
+
+	if err := configureBPFProgramSpec(spec); err == nil {
+		t.Fatalf("expected missing events map error")
+	}
+}
+
 func TestConfigureBPFProgramSpecErrorsOnMissingStagingMap(t *testing.T) {
 	t.Parallel()
 
@@ -31,9 +61,47 @@ func TestConfigureBPFProgramSpecErrorsOnMissingStagingMap(t *testing.T) {
 	}
 }
 
+func TestEventsRingbufMaxEntries(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		cpus     int
+		expected uint32
+		wantErr  bool
+	}{
+		{name: "minimum for one CPU", cpus: 1, expected: 8 << 20},
+		{name: "minimum for two CPUs", cpus: 2, expected: 8 << 20},
+		{name: "linear for four CPUs", cpus: 4, expected: 16 << 20},
+		{name: "rounds six CPUs up to next power of two", cpus: 6, expected: 32 << 20},
+		{name: "linear for eight CPUs", cpus: 8, expected: 32 << 20},
+		{name: "rejects zero CPUs", cpus: 0, wantErr: true},
+		{name: "rejects rounded size beyond uint32", cpus: 1024, wantErr: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := eventsRingbufMaxEntries(tc.cpus)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("eventsRingbufMaxEntries returned error: %v", err)
+			}
+			if got != tc.expected {
+				t.Fatalf("eventsRingbufMaxEntries: got %d, want %d", got, tc.expected)
+			}
+		})
+	}
+}
+
 func fakeProgramSpec() *ebpf.CollectionSpec {
 	return &ebpf.CollectionSpec{
 		Maps: map[string]*ebpf.MapSpec{
+			eventsMapName:  {},
 			StagingMapName: {},
 		},
 	}


### PR DESCRIPTION
## What

- Size the KernelIO BPF `events` ring buffer from node CPU count instead of keeping the BPF C default.
  - Formula: `round_up_to_power_of_two(max(8 MiB, runtime.NumCPU() * 4 MiB))`
  - The C-side `1 MiB` value remains only as the generated spec default before userspace overrides it.
- Throttle `bpf_ringbuf_drop` warnings.
  - First observed drop logs immediately.
  - Later warnings are emitted only when cumulative drops cross the next power-of-two threshold.
  - A large one-poll jump, such as `0 -> 100`, logs once and does not repeat until the next threshold.

## Why

The BPF ring buffer is the node-level ingress point before KernelTracker can attribute samples to Jobs. If it drops samples, per-Job queue sizing and `file_open` duplicate suppression cannot recover them.

This keeps the default simple while giving larger runner nodes proportionally more kernel-to-userspace buffer capacity, and keeps drop warnings useful without spamming logs during sustained pressure.

Refs #84
