### PR TITLE
fix(gitlab): create Docker jobs from staging

### DIFF
--- a/cmd/cicd-sensor/host.go
+++ b/cmd/cicd-sensor/host.go
@@ -18,8 +18,8 @@ const (
 // runHostStart is the explicit host-side Job registration path for GitHub
 // self-hosted runners: the wrapper calls it at Job start so the agent can bind
 // the runner cgroup immediately. GitLab Container Executor does not use this
-// CLI path; its dockerd proxy creates Jobs through /v1/gitlab/host/start when
-// it first sees a container for an unregistered GitLab Job.
+// CLI path; GitLab Docker staging creates Jobs inside /v1/gitlab/staging/put
+// when it first sees a container for an unregistered GitLab Job.
 func runHostSubcommand(args []string) {
 	if len(args) < 1 {
 		fmt.Fprintln(os.Stderr, hostUsage)

--- a/docs/developer-guide/agent.md
+++ b/docs/developer-guide/agent.md
@@ -118,7 +118,7 @@ For implementation ownership boundaries, see [Agent Ownership Boundaries](agent-
 | --- | --- | --- | --- |
 | GitHub Actions | GitHub-hosted runner | `/v1/github/project/start` | cgroup of the project start peer PID |
 | GitHub Actions | Self-hosted runner on a machine | `/v1/github/host/start` | cgroup of the hook peer PID |
-| GitLab CI/CD | GitLab Runner Docker executor | `/v1/gitlab/staging/put` -> lazy `/v1/gitlab/host/start` | Docker label evidence and staging promote |
+| GitLab CI/CD | GitLab Runner Docker executor | `/v1/gitlab/staging/put` | Docker label evidence and staging promote |
 | GitHub Actions | ARC default / dind mode | `/v1/github/k8s/start` | cgroup of the job hook peer PID; dind also binds the Pod cgroup tree |
 | GitHub Actions | ARC Kubernetes mode | `/v1/github/k8s/start` + `/v1/github/k8s/staging/put` | job hook peer PID plus NRI-provided container cgroup basenames |
 | GitLab CI/CD | GitLab Runner Kubernetes executor | `/v1/gitlab/k8s/staging/put` | GitLab Pod metadata and NRI-provided container cgroup basenames |
@@ -142,13 +142,12 @@ The normal agent control socket exposes the provider route family selected at ag
 | GitHub | `/v1/github/project/result` | project action | Read project result data for reports and attestations. |
 | GitHub | `/v1/github/staging/put` | Docker proxy | Stage Docker-created container cgroup basenames by peer PID. |
 | GitHub | `/v1/github/k8s/staging/put` | host-side NRI observer | Stage Kubernetes-created container cgroup basenames by injected GitHub identity. |
-| GitLab | `/v1/gitlab/host/start` | Docker proxy lazy start | Create GitLab host Job state from runner metadata. |
-| GitLab | `/v1/gitlab/staging/put` | Docker proxy | Stage Docker-created container cgroup basenames by peer PID. |
+| GitLab | `/v1/gitlab/host/start` | Internal compatibility path | Create GitLab host Job state from runner metadata. |
+| GitLab | `/v1/gitlab/staging/put` | Docker proxy | Create missing GitLab Jobs from runner metadata, then stage Docker-created container cgroup basenames. |
 | GitLab | `/v1/gitlab/k8s/staging/put` | host-side NRI observer | Create missing GitLab Kubernetes Jobs from cached host config, then stage container cgroup basenames. |
 
-GitLab Kubernetes staging intentionally differs from the Docker proxy flow.
-The Docker proxy uses separate `staging -> /v1/gitlab/host/start -> staging` requests, while the Kubernetes/NRI endpoint performs lazy Job creation inside `/v1/gitlab/k8s/staging/put` so the NRI callback does not make multiple agent calls.
-Moving the Docker proxy to the same listener-owned lazy creation model is a follow-up cleanup, not part of the Kubernetes runtime change.
+GitLab Docker and Kubernetes staging both perform listener-owned lazy Job creation.
+Docker staging uses runner labels and container metadata from the proxy request, while Kubernetes/NRI staging uses Pod metadata collected on the host.
 
 GitHub ARC also uses a separate runner socket mounted into the runner container:
 

--- a/internal/agent/listener/gitlab.go
+++ b/internal/agent/listener/gitlab.go
@@ -46,8 +46,8 @@ func (l *Listener) handleGitLabHostStart(w http.ResponseWriter, r *http.Request)
 }
 
 // handleGitLabStagingPut stages Docker proxy-discovered containers. The proxy
-// can identify an existing Job by peer PID, or use the 404 response to
-// lazy-create the Job and retry when it has GitLab runner metadata.
+// sends one request with peer PID plus optional trusted GitLab labels, and this
+// handler owns lazy Job creation when the labels identify a missing Job.
 func (l *Listener) handleGitLabStagingPut(w http.ResponseWriter, r *http.Request) {
 	if !l.requireRequestPeerUIDMatchesAgentOwner(w, r) {
 		return
@@ -111,7 +111,7 @@ func (l *Listener) handleGitLabStagingPut(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	status, ok := l.stageGitLabBasename(w, r, req.Basename, labelsIdentity)
+	status, ok := l.stageGitLabBasename(w, r, req.Basename, labelsIdentity, req.Metadata)
 	if !ok {
 		return
 	}
@@ -126,10 +126,9 @@ func (l *Listener) handleGitLabStagingPut(w http.ResponseWriter, r *http.Request
 }
 
 // handleGitLabK8sStagingPut records NRI-discovered Kubernetes containers.
-// Unlike the Docker proxy socket flow, Kubernetes/NRI does not do
-// staging -> host/start -> staging across separate requests. NRI runs in
-// containerd's callback path, so this local handler owns lazy Job creation and
-// must not force NRI through an extra host/start round trip.
+// Like Docker staging, this local handler owns lazy Job creation. NRI runs in
+// containerd's callback path and must not depend on an extra host/start round
+// trip.
 func (l *Listener) handleGitLabK8sStagingPut(w http.ResponseWriter, r *http.Request) {
 	if !l.requireRequestPeerUIDMatchesAgentOwner(w, r) {
 		return
@@ -194,10 +193,21 @@ func (l *Listener) stageGitLabK8sBasename(w http.ResponseWriter, r *http.Request
 	return "staged", true
 }
 
-func (l *Listener) stageGitLabBasename(w http.ResponseWriter, r *http.Request, basename string, identity jobcontext.JobIdentity) (status string, ok bool) {
+func (l *Listener) stageGitLabBasename(w http.ResponseWriter, r *http.Request, basename string, identity jobcontext.JobIdentity, metadata jobcontext.JobMetadata) (status string, ok bool) {
+	if err := l.jobRegistry.StageCgroupBasenameForJob(r.Context(), basename, identity); err == nil {
+		return "staged", true
+	} else if !errors.Is(err, jobregistry.ErrJobNotFound) {
+		l.logger.ErrorContext(r.Context(), "gitlab_staging_put_failed", "error", err)
+		l.writeError(w, r, http.StatusInternalServerError, "internal error")
+		return "", false
+	}
+
+	if _, err := l.jobRegistry.ApplyGitLabHostStart(r.Context(), identity, metadata, l.runnerType, l.hostManagerConn, l.hostManagerClient); err != nil {
+		l.writeStartError(w, r, "gitlab_staging_host_start_failed", err)
+		return "", false
+	}
 	if err := l.jobRegistry.StageCgroupBasenameForJob(r.Context(), basename, identity); err != nil {
 		if errors.Is(err, jobregistry.ErrJobNotFound) {
-			// The GitLab proxy uses 404 to lazy-create the Job and retry.
 			l.writeError(w, r, http.StatusNotFound, "job_not_found")
 			return "", false
 		}

--- a/internal/agent/listener/gitlab_test.go
+++ b/internal/agent/listener/gitlab_test.go
@@ -110,11 +110,10 @@ func TestGitLabHostStart_RequiresManager(t *testing.T) {
 	}
 }
 
-// Idempotency invariant: a duplicate gitlab host_start must succeed
-// silently because the GitLab proxy issues host_start as a lazy create
-// after a 404 from staging/put. Concurrent container creates can race
-// the lookup, so a 409 here would force the proxy to reason about race
-// outcomes — we keep the contract simpler.
+// Idempotency invariant: duplicate gitlab host_start must still succeed
+// silently for compatibility with callers that use the explicit host-start
+// path. Concurrent starts can race the lookup, so a 409 here would force
+// callers to reason about race outcomes.
 func TestGitLabHostStart_DuplicateIsIdempotent(t *testing.T) {
 	matchAgentOwnerUIDToPeerCred(t)
 
@@ -418,13 +417,11 @@ func TestGitLabStagingPut_IgnoresPeerMissWithoutIdentity(t *testing.T) {
 	}
 }
 
-// 404 is the discriminable signal the GitLab proxy uses to lazy-create
-// a Job (call /v1/gitlab/host/start) and retry the staging put.
-func TestGitLabStagingPut_ReturnsJobNotFoundWhenJobMissing(t *testing.T) {
+func TestGitLabStagingPut_CreatesMissingJobAndStages(t *testing.T) {
 	requireLinuxPeerPIDLookup(t)
 	matchAgentOwnerUIDToPeerCred(t)
 
-	client, _, cleanup := setupGitLabListener(t)
+	client, registry, cleanup := setupGitLabListener(t)
 	defer cleanup()
 
 	identity := jobcontext.JobIdentity{
@@ -436,6 +433,7 @@ func TestGitLabStagingPut_ReturnsJobNotFoundWhenJobMissing(t *testing.T) {
 	body := mustMarshal(t, jobcontext.GitLabStagingPutRequest{
 		Basename:    "docker-cafef00d.scope",
 		JobIdentity: &identity,
+		Metadata:    jobcontext.JobMetadata{CommitSHA: "abc123"},
 	})
 
 	resp, err := client.Post("http://cicd-sensor/v1/gitlab/staging/put", "application/json", bytes.NewReader(body))
@@ -444,13 +442,19 @@ func TestGitLabStagingPut_ReturnsJobNotFoundWhenJobMissing(t *testing.T) {
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusNotFound {
+	if resp.StatusCode != http.StatusOK {
 		dump, _ := io.ReadAll(resp.Body)
-		t.Fatalf("status: got %d, want %d (body=%s)", resp.StatusCode, http.StatusNotFound, dump)
+		t.Fatalf("status: got %d, want %d (body=%s)", resp.StatusCode, http.StatusOK, dump)
 	}
-	dump, _ := io.ReadAll(resp.Body)
-	if !bytes.Contains(dump, []byte("job_not_found")) {
-		t.Fatalf("body should contain job_not_found, got %s", dump)
+	job := gitlabRegisteredJob(registry, identity)
+	if job == nil {
+		t.Fatal("expected job to be registered")
+	}
+	if job.HostScope() == nil {
+		t.Fatal("expected host scope to be set")
+	}
+	if job.Metadata().CommitSHA != "abc123" {
+		t.Fatalf("metadata commit_sha: got %q, want abc123", job.Metadata().CommitSHA)
 	}
 }
 
@@ -506,11 +510,9 @@ func TestGitLabStagingPut_RejectsBadBody(t *testing.T) {
 	}
 }
 
-// Concurrent lazy-create: the GitLab proxy issues host_start
-// opportunistically per container after a 404 from staging/put;
-// multiple containers in one Job race the lookup. The handler must
-// serialize so no caller can observe a Job that has been published
-// to the registry but not yet had its host scope attached.
+// Concurrent explicit host_start calls can race the lookup. The handler must
+// serialize so no caller can observe a Job that has been published to the
+// registry but not yet had its host scope attached.
 func TestGitLabHostStart_ConcurrentLazyCreate(t *testing.T) {
 	matchAgentOwnerUIDToPeerCred(t)
 

--- a/internal/agent/proxy/dockerd/dockerd_test.go
+++ b/internal/agent/proxy/dockerd/dockerd_test.go
@@ -594,7 +594,7 @@ func TestProxy_GitLab_StagingServerErrorDoesNotHostStart(t *testing.T) {
 	assertAgentCalls(t, got, []string{"/v1/gitlab/staging/put"})
 }
 
-func TestProxy_GitLab_HostStartFailureFallsThrough(t *testing.T) {
+func TestProxy_GitLab_StagingNotFoundWithIdentityFallsThrough(t *testing.T) {
 	t.Parallel()
 
 	const containerID = "3333333333333333333333333333333333333333333333333333333333333333"
@@ -618,7 +618,8 @@ func TestProxy_GitLab_HostStartFailureFallsThrough(t *testing.T) {
 		case "/v1/gitlab/staging/put":
 			writeJSON(t, w, http.StatusNotFound, map[string]string{"error": "job_not_found"})
 		case "/v1/gitlab/host/start":
-			http.Error(w, "host start failed", http.StatusInternalServerError)
+			t.Errorf("proxy must not call host/start; staging owns lazy job creation")
+			http.Error(w, "host start should not be called", http.StatusInternalServerError)
 		default:
 			t.Errorf("unexpected agent path: %q", r.URL.Path)
 		}
@@ -634,7 +635,7 @@ func TestProxy_GitLab_HostStartFailureFallsThrough(t *testing.T) {
 		t.Fatalf("status: got %d, want %d", resp.StatusCode, http.StatusCreated)
 	}
 
-	assertAgentCalls(t, got, []string{"/v1/gitlab/staging/put", "/v1/gitlab/host/start"})
+	assertAgentCalls(t, got, []string{"/v1/gitlab/staging/put"})
 }
 
 func TestProxy_GitLab_InvalidCreateResponseFallsThroughWithoutStaging(t *testing.T) {
@@ -689,11 +690,7 @@ func TestProxy_GitLab_InvalidCreateResponseFallsThroughWithoutStaging(t *testing
 	}
 }
 
-// When the agent has no Job for the identity yet (staging returns 404), the
-// proxy must lazily POST host/start with the same identity and retry the
-// staging put. The 3-call sequence (staging, host_start, staging) must
-// occur in order on the same docker create.
-func TestProxy_GitLab_LazyCreate(t *testing.T) {
+func TestProxy_GitLab_StagingNotFoundWithIdentityDoesNotHostStart(t *testing.T) {
 	t.Parallel()
 
 	const containerID = "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
@@ -712,20 +709,15 @@ func TestProxy_GitLab_LazyCreate(t *testing.T) {
 		body []byte
 	}
 	calls := make(chan agentCall, 4)
-	stagingSeen := 0
 	agentSocket := startUnixServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, _ := io.ReadAll(r.Body)
 		calls <- agentCall{path: r.URL.Path, body: body}
 		switch r.URL.Path {
 		case "/v1/gitlab/staging/put":
-			stagingSeen++
-			if stagingSeen == 1 {
-				writeJSON(t, w, http.StatusNotFound, map[string]string{"error": "job_not_found"})
-				return
-			}
-			writeJSON(t, w, http.StatusOK, map[string]string{"status": "staged"})
+			writeJSON(t, w, http.StatusNotFound, map[string]string{"error": "job_not_found"})
 		case "/v1/gitlab/host/start":
-			writeJSON(t, w, http.StatusOK, map[string]string{"status": "ok"})
+			t.Errorf("proxy must not call host/start; staging owns lazy job creation")
+			http.Error(w, "host start should not be called", http.StatusInternalServerError)
 		default:
 			t.Errorf("unexpected agent path: %q", r.URL.Path)
 		}
@@ -746,40 +738,25 @@ func TestProxy_GitLab_LazyCreate(t *testing.T) {
 		t.Fatalf("status: got %d, want %d", resp.StatusCode, http.StatusCreated)
 	}
 
-	wantOrder := []string{
-		"/v1/gitlab/staging/put",
-		"/v1/gitlab/host/start",
-		"/v1/gitlab/staging/put",
-	}
-	for i, want := range wantOrder {
-		select {
-		case call := <-calls:
-			if call.path != want {
-				t.Fatalf("call %d: got %q, want %q", i, call.path, want)
-			}
-			if call.path == "/v1/gitlab/host/start" {
-				var req jobcontext.GitLabHostStartRequest
-				if err := json.Unmarshal(call.body, &req); err != nil {
-					t.Fatalf("decode host_start body: %v", err)
-				}
-				if req.JobIdentity != jobcontext.GitLabJobIdentity("gitlab.com", "cicd-sensor/cicd-sensor-testing", "777") {
-					t.Fatalf("host_start identity: got %+v", req.JobIdentity)
-				}
-			}
-		case <-time.After(2 * time.Second):
-			t.Fatalf("call %d (%s) not seen within 2s", i, want)
+	select {
+	case call := <-calls:
+		if call.path != "/v1/gitlab/staging/put" {
+			t.Fatalf("agent path: got %q, want /v1/gitlab/staging/put", call.path)
 		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("staging call not seen within 2s")
 	}
+
 	select {
 	case extra := <-calls:
-		t.Fatalf("unexpected fourth agent call: %s", extra.path)
+		t.Fatalf("unexpected second agent call: %s", extra.path)
 	case <-time.After(150 * time.Millisecond):
 	}
 }
 
-// host_start receives metadata from labels (trusted) and env (best-effort),
-// with first-wins on env discarding `.gitlab-ci.yml variables:` spoof attempts.
-func TestProxy_GitLab_LazyCreate_PropagatesMetadata(t *testing.T) {
+// staging receives metadata from labels (trusted) and env (best-effort), with
+// first-wins on env discarding `.gitlab-ci.yml variables:` spoof attempts.
+func TestProxy_GitLab_StagingPropagatesMetadata(t *testing.T) {
 	t.Parallel()
 
 	const containerID = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
@@ -796,7 +773,7 @@ func TestProxy_GitLab_LazyCreate_PropagatesMetadata(t *testing.T) {
 		"CI_JOB_NAME=jirojiro-smoke",
 		"GITLAB_USER_LOGIN=rung",
 		// User-spoofed .gitlab-ci.yml `variables:` overrides (come later).
-		// host_start metadata must NOT pick these up (first-wins).
+		// staging metadata must NOT pick these up (first-wins).
 		"CI_PIPELINE_SOURCE=web",
 		"GITLAB_USER_LOGIN=attacker",
 	}
@@ -805,25 +782,20 @@ func TestProxy_GitLab_LazyCreate_PropagatesMetadata(t *testing.T) {
 		writeJSON(t, w, http.StatusCreated, containerCreateResponse{ID: containerID})
 	}))
 
-	hostStartReq := make(chan jobcontext.GitLabHostStartRequest, 1)
-	stagingSeen := 0
+	stagingReq := make(chan jobcontext.GitLabStagingPutRequest, 1)
 	agentSocket := startUnixServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/v1/gitlab/staging/put":
-			stagingSeen++
-			if stagingSeen == 1 {
-				writeJSON(t, w, http.StatusNotFound, map[string]string{"error": "job_not_found"})
-				return
+			body, _ := io.ReadAll(r.Body)
+			var req jobcontext.GitLabStagingPutRequest
+			if err := json.Unmarshal(body, &req); err != nil {
+				t.Errorf("decode staging body: %v", err)
 			}
+			stagingReq <- req
 			writeJSON(t, w, http.StatusOK, map[string]string{"status": "staged"})
 		case "/v1/gitlab/host/start":
-			body, _ := io.ReadAll(r.Body)
-			var req jobcontext.GitLabHostStartRequest
-			if err := json.Unmarshal(body, &req); err != nil {
-				t.Errorf("decode host_start body: %v", err)
-			}
-			hostStartReq <- req
-			writeJSON(t, w, http.StatusOK, map[string]string{"status": "ok"})
+			t.Errorf("proxy must not call host/start; staging owns lazy job creation")
+			http.Error(w, "host start should not be called", http.StatusInternalServerError)
 		default:
 			t.Errorf("unexpected agent path: %q", r.URL.Path)
 		}
@@ -841,10 +813,13 @@ func TestProxy_GitLab_LazyCreate_PropagatesMetadata(t *testing.T) {
 	resp.Body.Close()
 
 	select {
-	case got := <-hostStartReq:
+	case got := <-stagingReq:
 		wantIdentity := jobcontext.GitLabJobIdentity("gitlab.com", "rung/girogiro-testing", "14499483701")
-		if got.JobIdentity != wantIdentity {
-			t.Fatalf("identity: got %+v, want %+v", got.JobIdentity, wantIdentity)
+		if got.JobIdentity == nil {
+			t.Fatal("job_identity is nil")
+		}
+		if *got.JobIdentity != wantIdentity {
+			t.Fatalf("identity: got %+v, want %+v", *got.JobIdentity, wantIdentity)
 		}
 		wantMetadata := jobcontext.JobMetadata{
 			CommitSHA:     "c4c41b82483929ffab3abae20b60dd9f793400ba",
@@ -857,12 +832,12 @@ func TestProxy_GitLab_LazyCreate_PropagatesMetadata(t *testing.T) {
 			t.Fatalf("metadata: got %+v, want %+v", got.Metadata, wantMetadata)
 		}
 	case <-time.After(2 * time.Second):
-		t.Fatalf("host_start not seen within 2s")
+		t.Fatalf("staging request not seen within 2s")
 	}
 }
 
-// cache-init carries labels but no env; the proxy must defer Job creation
-// to predefined/build so env-sourced metadata makes it into host_start.
+// cache-init carries labels but no env; the proxy must defer identity metadata
+// to predefined/build so env-sourced metadata makes it into staging.
 func TestProxy_GitLab_CacheInitSkipped(t *testing.T) {
 	t.Parallel()
 
@@ -915,17 +890,9 @@ func TestProxy_GitLab_CacheInitSkipped(t *testing.T) {
 	}
 }
 
-// Multiple concurrent containers/create for the same identity must each
-// complete the lazy-create flow successfully. The agent fake here simulates
-// the JobRegistry per-identity barrier: staging/put returns 404 until
-// host/start has been received, host/start can be invoked multiple times
-// (idempotent EnsureJob), and a tiny artificial delay on host/start widens
-// the race window so multiple goroutines hit the 404 → host/start path
-// concurrently. Without proxy-side de-dup or agent-side serialisation,
-// some staging retries would observe stale 404s; this test asserts that
-// at least one host/start completes and every concurrent docker create
-// receives a 201 with no errors propagated.
-func TestProxy_GitLab_ConcurrentLazyCreates(t *testing.T) {
+// Multiple concurrent containers/create for the same identity must each send a
+// single staging request and leave lazy Job creation to the agent endpoint.
+func TestProxy_GitLab_ConcurrentStagingRequests(t *testing.T) {
 	t.Parallel()
 
 	const N = 4
@@ -944,7 +911,6 @@ func TestProxy_GitLab_ConcurrentLazyCreates(t *testing.T) {
 	}))
 
 	var (
-		jobRegistered  atomic.Bool
 		hostStartCalls atomic.Int32
 		stagingCalls   atomic.Int32
 		stagingSuccess atomic.Int32
@@ -953,19 +919,12 @@ func TestProxy_GitLab_ConcurrentLazyCreates(t *testing.T) {
 		switch r.URL.Path {
 		case "/v1/gitlab/staging/put":
 			stagingCalls.Add(1)
-			if !jobRegistered.Load() {
-				writeJSON(t, w, http.StatusNotFound, map[string]string{"error": "job_not_found"})
-				return
-			}
 			stagingSuccess.Add(1)
 			writeJSON(t, w, http.StatusOK, map[string]string{"status": "staged"})
 		case "/v1/gitlab/host/start":
 			hostStartCalls.Add(1)
-			// Hold the slot briefly so other goroutines stack up on the
-			// 404 → host/start transition.
-			time.Sleep(10 * time.Millisecond)
-			jobRegistered.Store(true)
-			writeJSON(t, w, http.StatusOK, map[string]string{"status": "ok"})
+			t.Errorf("proxy must not call host/start; staging owns lazy job creation")
+			http.Error(w, "host start should not be called", http.StatusInternalServerError)
 		default:
 			t.Errorf("unexpected agent path: %q", r.URL.Path)
 		}
@@ -1003,8 +962,8 @@ func TestProxy_GitLab_ConcurrentLazyCreates(t *testing.T) {
 			t.Errorf("goroutine %d: %v", i, e)
 		}
 	}
-	if hostStartCalls.Load() == 0 {
-		t.Errorf("host_start never invoked")
+	if hostStartCalls.Load() != 0 {
+		t.Errorf("host_start invoked %d times, want 0", hostStartCalls.Load())
 	}
 	if stagingSuccess.Load() != N {
 		t.Errorf("expected %d staging successes, got %d (total staging calls: %d)",
@@ -1033,7 +992,7 @@ func TestPostStagingErrorsIncludeResponseBody(t *testing.T) {
 	}
 
 	identity := jobcontext.GitLabJobIdentity("gitlab.com", "group/project", "42")
-	if err := postGitLabStaging(context.Background(), agentSocket, "docker-deadbeef.scope", int32(os.Getpid()), &identity); err == nil || !strings.Contains(err.Error(), "agent boom") {
+	if err := postGitLabStaging(context.Background(), agentSocket, "docker-deadbeef.scope", int32(os.Getpid()), &identity, jobcontext.JobMetadata{}); err == nil || !strings.Contains(err.Error(), "agent boom") {
 		t.Fatalf("postGitLabStaging error = %v, want body included", err)
 	}
 }

--- a/internal/agent/proxy/dockerd/gitlab.go
+++ b/internal/agent/proxy/dockerd/gitlab.go
@@ -40,9 +40,6 @@ type gitlabRequestState struct {
 	metadata jobcontext.JobMetadata
 }
 
-// errGitLabJobNotFound triggers host/start before one staging retry.
-var errGitLabJobNotFound = errors.New("gitlab job not found at agent")
-
 // proxyHandlerGitLab stages docker-<cid>.scope with peer PID and optional
 // GitLab runner label identity; the agent chooses which evidence to use.
 func proxyHandlerGitLab(logger *slog.Logger, upstreamSocket, agentSocket string) http.Handler {
@@ -131,7 +128,7 @@ func proxyHandlerGitLab(logger *slog.Logger, upstreamSocket, agentSocket string)
 			basename := fmt.Sprintf("docker-%s.scope", parsed.ID)
 			ctx, cancel := context.WithTimeout(resp.Request.Context(), agentLazyCreateTimeout)
 			defer cancel()
-			if err := stageGitLabWithLazyCreate(ctx, agentSocket, basename, peerPID, identityPtr, state.metadata); err != nil {
+			if err := postGitLabStaging(ctx, agentSocket, basename, peerPID, identityPtr, state.metadata); err != nil {
 				logger.WarnContext(resp.Request.Context(), "staging_put_failed",
 					"error", err,
 					"basename", basename,
@@ -153,32 +150,14 @@ func proxyHandlerGitLab(logger *slog.Logger, upstreamSocket, agentSocket string)
 	return rev
 }
 
-// stageGitLabWithLazyCreate keeps GitLab Job creation on host/start. Staging
-// first preserves the cheap existing-Job path; 404 is the lazy-start signal.
-func stageGitLabWithLazyCreate(ctx context.Context, agentSocket, basename string, peerPID int32, identity *jobcontext.JobIdentity, metadata jobcontext.JobMetadata) error {
-	err := postGitLabStaging(ctx, agentSocket, basename, peerPID, identity)
-	if err == nil {
-		return nil
-	}
-	if !errors.Is(err, errGitLabJobNotFound) {
-		return err
-	}
-	if identity == nil {
-		return err
-	}
-	// The agent deduplicates concurrent host/start calls for the same identity.
-	if err := postGitLabHostStart(ctx, agentSocket, *identity, metadata); err != nil {
-		return fmt.Errorf("host_start: %w", err)
-	}
-	return postGitLabStaging(ctx, agentSocket, basename, peerPID, identity)
-}
-
-// postGitLabStaging maps 404 to errGitLabJobNotFound for lazy create.
-func postGitLabStaging(ctx context.Context, agentSocket, basename string, peerPID int32, identity *jobcontext.JobIdentity) error {
+// postGitLabStaging sends all Docker proxy evidence in one request. The agent
+// owns lazy GitLab Job creation inside /v1/gitlab/staging/put.
+func postGitLabStaging(ctx context.Context, agentSocket, basename string, peerPID int32, identity *jobcontext.JobIdentity, metadata jobcontext.JobMetadata) error {
 	body, err := json.Marshal(jobcontext.GitLabStagingPutRequest{
 		Basename:    basename,
 		PeerPID:     peerPID,
 		JobIdentity: identity,
+		Metadata:    metadata,
 	})
 	if err != nil {
 		return fmt.Errorf("marshal gitlab staging request: %w", err)
@@ -190,30 +169,9 @@ func postGitLabStaging(ctx context.Context, agentSocket, basename string, peerPI
 	switch status {
 	case http.StatusOK:
 		return nil
-	case http.StatusNotFound:
-		return errGitLabJobNotFound
 	default:
 		return fmt.Errorf("agent /v1/gitlab/staging/put returned %d: %s", status, respBody)
 	}
-}
-
-// postGitLabHostStart issues the agent's idempotent EnsureJob request.
-func postGitLabHostStart(ctx context.Context, agentSocket string, identity jobcontext.JobIdentity, metadata jobcontext.JobMetadata) error {
-	body, err := json.Marshal(jobcontext.GitLabHostStartRequest{
-		JobIdentity: identity,
-		Metadata:    metadata,
-	})
-	if err != nil {
-		return fmt.Errorf("marshal gitlab host_start request: %w", err)
-	}
-	status, respBody, err := postAgent(ctx, agentSocket, "/v1/gitlab/host/start", body)
-	if err != nil {
-		return err
-	}
-	if status != http.StatusOK {
-		return fmt.Errorf("agent /v1/gitlab/host/start returned %d: %s", status, respBody)
-	}
-	return nil
 }
 
 // jobMetadataFromGitLabContainer derives metadata from runner labels (trust

--- a/internal/jobcontext/agent_requests.go
+++ b/internal/jobcontext/agent_requests.go
@@ -13,12 +13,13 @@ type GitHubK8sStagingPutRequest struct {
 	JobIdentity JobIdentity `json:"job_identity"`
 }
 
-// GitLabStagingPutRequest lets the proxy send both evidence sources; the agent
-// chooses peer PID first, then labels identity when needed.
+// GitLabStagingPutRequest lets the proxy send peer PID, labels identity, and
+// metadata; the agent chooses peer PID first, then labels identity when needed.
 type GitLabStagingPutRequest struct {
 	Basename    string       `json:"basename"`
 	PeerPID     int32        `json:"peer_pid,omitempty"`
 	JobIdentity *JobIdentity `json:"job_identity,omitempty"`
+	Metadata    JobMetadata  `json:"metadata,omitempty"`
 }
 
 // GitLabK8sStagingPutRequest is sent by the host-side NRI observer. The
@@ -29,7 +30,7 @@ type GitLabK8sStagingPutRequest struct {
 	Metadata    JobMetadata `json:"metadata,omitempty"`
 }
 
-// GitLabHostStartRequest is the proxy lazy-create payload.
+// GitLabHostStartRequest is the explicit GitLab host-start compatibility path.
 type GitLabHostStartRequest struct {
 	JobIdentity
 	Metadata JobMetadata `json:"metadata,omitempty"`


### PR DESCRIPTION
## Summary

Moves GitLab Runner Docker executor lazy Job creation into `/v1/gitlab/staging/put`, so the Docker proxy now sends one staging request with peer PID, runner label identity, and metadata. The listener creates a missing GitLab Job inside the staging endpoint before staging the Docker cgroup basename.

This removes the proxy-side `staging -> /v1/gitlab/host/start -> staging` retry flow while keeping `/v1/gitlab/host/start` as an explicit compatibility path.

Fixes #57.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] Refactor / cleanup
- [x] Docs
- [ ] CI / tooling
- [ ] Other:

## Test plan

- [x] `PATH="$(go env GOPATH)/bin:$PATH" make check` with Colima/Docker; passed containerized BPF generation, `go test -mod=vendor -count=1 ./...`, rule validation, `git diff --check`, and `git diff --exit-code`.
- [x] `gofmt -l $(git ls-files '*.go' ':!:vendor/**')` produced no output.
- [x] `go vet -mod=vendor ./...` passed.

## Checklist

- [x] `go test ./...` passes locally
- [x] `gofmt -l` and `go vet ./...` are clean
- [x] Docs and rule samples are updated if behavior changed
- [x] No secrets, credentials, or unrelated changes included
