### PR TITLE
fix: move GitLab staging lazy start into listener

### DIFF
--- a/cmd/cicd-sensor/host.go
+++ b/cmd/cicd-sensor/host.go
@@ -18,8 +18,8 @@ const (
 // runHostStart is the explicit host-side Job registration path for GitHub
 // self-hosted runners: the wrapper calls it at Job start so the agent can bind
 // the runner cgroup immediately. GitLab Container Executor does not use this
-// CLI path; its dockerd proxy creates Jobs through /v1/gitlab/host/start when
-// it first sees a container for an unregistered GitLab Job.
+// CLI path; its dockerd proxy creates missing Jobs through /v1/gitlab/staging/put
+// when it first sees a container for an unregistered GitLab Job.
 func runHostSubcommand(args []string) {
 	if len(args) < 1 {
 		fmt.Fprintln(os.Stderr, hostUsage)

--- a/docs/developer-guide/agent.md
+++ b/docs/developer-guide/agent.md
@@ -118,7 +118,7 @@ For implementation ownership boundaries, see [Agent Ownership Boundaries](agent-
 | --- | --- | --- | --- |
 | GitHub Actions | GitHub-hosted runner | `/v1/github/project/start` | cgroup of the project start peer PID |
 | GitHub Actions | Self-hosted runner on a machine | `/v1/github/host/start` | cgroup of the hook peer PID |
-| GitLab CI/CD | GitLab Runner Docker executor | `/v1/gitlab/staging/put` -> lazy `/v1/gitlab/host/start` | Docker label evidence and staging promote |
+| GitLab CI/CD | GitLab Runner Docker executor | `/v1/gitlab/staging/put` | Docker label evidence and staging promote |
 | GitHub Actions | ARC default / dind mode | `/v1/github/k8s/start` | cgroup of the job hook peer PID; dind also binds the Pod cgroup tree |
 | GitHub Actions | ARC Kubernetes mode | `/v1/github/k8s/start` + `/v1/github/k8s/staging/put` | job hook peer PID plus NRI-provided container cgroup basenames |
 | GitLab CI/CD | GitLab Runner Kubernetes executor | `/v1/gitlab/k8s/staging/put` | GitLab Pod metadata and NRI-provided container cgroup basenames |
@@ -142,13 +142,12 @@ The normal agent control socket exposes the provider route family selected at ag
 | GitHub | `/v1/github/project/result` | project action | Read project result data for reports and attestations. |
 | GitHub | `/v1/github/staging/put` | Docker proxy | Stage Docker-created container cgroup basenames by peer PID. |
 | GitHub | `/v1/github/k8s/staging/put` | host-side NRI observer | Stage Kubernetes-created container cgroup basenames by injected GitHub identity. |
-| GitLab | `/v1/gitlab/host/start` | Docker proxy lazy start | Create GitLab host Job state from runner metadata. |
-| GitLab | `/v1/gitlab/staging/put` | Docker proxy | Stage Docker-created container cgroup basenames by peer PID. |
+| GitLab | `/v1/gitlab/host/start` | explicit host start caller | Create GitLab host Job state from runner metadata. |
+| GitLab | `/v1/gitlab/staging/put` | Docker proxy | Create missing GitLab Jobs from runner labels, then stage Docker-created container cgroup basenames. |
 | GitLab | `/v1/gitlab/k8s/staging/put` | host-side NRI observer | Create missing GitLab Kubernetes Jobs from cached host config, then stage container cgroup basenames. |
 
-GitLab Kubernetes staging intentionally differs from the Docker proxy flow.
-The Docker proxy uses separate `staging -> /v1/gitlab/host/start -> staging` requests, while the Kubernetes/NRI endpoint performs lazy Job creation inside `/v1/gitlab/k8s/staging/put` so the NRI callback does not make multiple agent calls.
-Moving the Docker proxy to the same listener-owned lazy creation model is a follow-up cleanup, not part of the Kubernetes runtime change.
+GitLab Docker proxy and Kubernetes/NRI staging both perform lazy Job creation inside their staging endpoint.
+This keeps container lifecycle callers to one local agent request and leaves Job creation ownership with the Listener.
 
 GitHub ARC also uses a separate runner socket mounted into the runner container:
 

--- a/internal/agent/listener/gitlab.go
+++ b/internal/agent/listener/gitlab.go
@@ -46,8 +46,9 @@ func (l *Listener) handleGitLabHostStart(w http.ResponseWriter, r *http.Request)
 }
 
 // handleGitLabStagingPut stages Docker proxy-discovered containers. The proxy
-// can identify an existing Job by peer PID, or use the 404 response to
-// lazy-create the Job and retry when it has GitLab runner metadata.
+// can identify an existing Job by peer PID; if peer lookup misses but trusted
+// GitLab runner labels are present, this handler creates the host Job and
+// stages the cgroup basename in the same request.
 func (l *Listener) handleGitLabStagingPut(w http.ResponseWriter, r *http.Request) {
 	if !l.requireRequestPeerUIDMatchesAgentOwner(w, r) {
 		return
@@ -111,7 +112,7 @@ func (l *Listener) handleGitLabStagingPut(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	status, ok := l.stageGitLabBasename(w, r, req.Basename, labelsIdentity)
+	status, ok := l.stageGitLabBasename(w, r, req.Basename, labelsIdentity, req.Metadata)
 	if !ok {
 		return
 	}
@@ -126,10 +127,8 @@ func (l *Listener) handleGitLabStagingPut(w http.ResponseWriter, r *http.Request
 }
 
 // handleGitLabK8sStagingPut records NRI-discovered Kubernetes containers.
-// Unlike the Docker proxy socket flow, Kubernetes/NRI does not do
-// staging -> host/start -> staging across separate requests. NRI runs in
-// containerd's callback path, so this local handler owns lazy Job creation and
-// must not force NRI through an extra host/start round trip.
+// NRI runs in containerd's callback path, so this local handler owns lazy Job
+// creation and must not force NRI through an extra host/start round trip.
 func (l *Listener) handleGitLabK8sStagingPut(w http.ResponseWriter, r *http.Request) {
 	if !l.requireRequestPeerUIDMatchesAgentOwner(w, r) {
 		return
@@ -194,10 +193,24 @@ func (l *Listener) stageGitLabK8sBasename(w http.ResponseWriter, r *http.Request
 	return "staged", true
 }
 
-func (l *Listener) stageGitLabBasename(w http.ResponseWriter, r *http.Request, basename string, identity jobcontext.JobIdentity) (status string, ok bool) {
+func (l *Listener) stageGitLabBasename(w http.ResponseWriter, r *http.Request, basename string, identity jobcontext.JobIdentity, metadata jobcontext.JobMetadata) (status string, ok bool) {
+	if err := l.jobRegistry.StageCgroupBasenameForJob(r.Context(), basename, identity); err == nil {
+		return "staged", true
+	} else if !errors.Is(err, jobregistry.ErrJobNotFound) {
+		l.logger.ErrorContext(r.Context(), "gitlab_staging_put_failed", "error", err)
+		l.writeError(w, r, http.StatusInternalServerError, "internal error")
+		return "", false
+	}
+
+	// GitLab Docker proxy sends labels identity and cgroup basename in one
+	// staging request. If the Job is not registered yet, create the host Job
+	// locally, then retry staging before returning to the proxy.
+	if _, err := l.jobRegistry.ApplyGitLabHostStart(r.Context(), identity, metadata, l.runnerType, l.hostManagerConn, l.hostManagerClient); err != nil {
+		l.writeStartError(w, r, "gitlab_staging_host_start_failed", err)
+		return "", false
+	}
 	if err := l.jobRegistry.StageCgroupBasenameForJob(r.Context(), basename, identity); err != nil {
 		if errors.Is(err, jobregistry.ErrJobNotFound) {
-			// The GitLab proxy uses 404 to lazy-create the Job and retry.
 			l.writeError(w, r, http.StatusNotFound, "job_not_found")
 			return "", false
 		}

--- a/internal/agent/listener/gitlab_test.go
+++ b/internal/agent/listener/gitlab_test.go
@@ -418,13 +418,11 @@ func TestGitLabStagingPut_IgnoresPeerMissWithoutIdentity(t *testing.T) {
 	}
 }
 
-// 404 is the discriminable signal the GitLab proxy uses to lazy-create
-// a Job (call /v1/gitlab/host/start) and retry the staging put.
-func TestGitLabStagingPut_ReturnsJobNotFoundWhenJobMissing(t *testing.T) {
+func TestGitLabStagingPut_CreatesMissingJobAndStages(t *testing.T) {
 	requireLinuxPeerPIDLookup(t)
 	matchAgentOwnerUIDToPeerCred(t)
 
-	client, _, cleanup := setupGitLabListener(t)
+	client, registry, cleanup := setupGitLabListener(t)
 	defer cleanup()
 
 	identity := jobcontext.JobIdentity{
@@ -436,6 +434,7 @@ func TestGitLabStagingPut_ReturnsJobNotFoundWhenJobMissing(t *testing.T) {
 	body := mustMarshal(t, jobcontext.GitLabStagingPutRequest{
 		Basename:    "docker-cafef00d.scope",
 		JobIdentity: &identity,
+		Metadata:    jobcontext.JobMetadata{CommitSHA: "abc123"},
 	})
 
 	resp, err := client.Post("http://cicd-sensor/v1/gitlab/staging/put", "application/json", bytes.NewReader(body))
@@ -444,13 +443,28 @@ func TestGitLabStagingPut_ReturnsJobNotFoundWhenJobMissing(t *testing.T) {
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusNotFound {
+	if resp.StatusCode != http.StatusOK {
 		dump, _ := io.ReadAll(resp.Body)
-		t.Fatalf("status: got %d, want %d (body=%s)", resp.StatusCode, http.StatusNotFound, dump)
+		t.Fatalf("status: got %d, want %d (body=%s)", resp.StatusCode, http.StatusOK, dump)
 	}
-	dump, _ := io.ReadAll(resp.Body)
-	if !bytes.Contains(dump, []byte("job_not_found")) {
-		t.Fatalf("body should contain job_not_found, got %s", dump)
+	var got struct {
+		Status string `json:"status"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.Status != "staged" {
+		t.Fatalf("status: got %q, want %q", got.Status, "staged")
+	}
+	job := gitlabRegisteredJob(registry, identity)
+	if job == nil {
+		t.Fatal("expected job to be registered")
+	}
+	if job.HostScope() == nil {
+		t.Fatal("expected host scope to be set")
+	}
+	if job.Metadata().CommitSHA != "abc123" {
+		t.Fatalf("metadata commit_sha: got %q, want abc123", job.Metadata().CommitSHA)
 	}
 }
 
@@ -506,12 +520,10 @@ func TestGitLabStagingPut_RejectsBadBody(t *testing.T) {
 	}
 }
 
-// Concurrent lazy-create: the GitLab proxy issues host_start
-// opportunistically per container after a 404 from staging/put;
-// multiple containers in one Job race the lookup. The handler must
-// serialize so no caller can observe a Job that has been published
-// to the registry but not yet had its host scope attached.
-func TestGitLabHostStart_ConcurrentLazyCreate(t *testing.T) {
+// Concurrent explicit host starts for one GitLab Job must serialize so no
+// caller can observe a Job that has been published to the registry but not yet
+// had its host scope attached.
+func TestGitLabHostStart_ConcurrentStarts(t *testing.T) {
 	matchAgentOwnerUIDToPeerCred(t)
 
 	client, registry, cleanup := setupGitLabListener(t)

--- a/internal/agent/proxy/dockerd/dockerd.go
+++ b/internal/agent/proxy/dockerd/dockerd.go
@@ -25,9 +25,9 @@ const (
 	// GitHub staging is on the docker create response path, so keep the
 	// agent wait bounded and fail open if the agent is wedged.
 	agentPostTimeout = 1 * time.Second
-	// GitLab lazy create may fetch a project baseline image before the
-	// first staging retry, so it needs a larger bounded fail-open budget.
-	agentLazyCreateTimeout = 5 * time.Second
+	// GitLab staging may create a missing Job behind the listener route, so it
+	// needs a larger bounded fail-open budget than GitHub's staging-only path.
+	agentGitLabStagingTimeout = 5 * time.Second
 )
 
 // Options carries the proxy runtime configuration.

--- a/internal/agent/proxy/dockerd/dockerd_test.go
+++ b/internal/agent/proxy/dockerd/dockerd_test.go
@@ -373,8 +373,7 @@ func TestProxy_AgentFailureFallsThrough(t *testing.T) {
 // On a successful container_create with non-spoofable gitlab-runner labels
 // the proxy must (1) pass the request and response through unchanged and
 // (2) POST a basename + identity pair derived from the labels to
-// /v1/gitlab/staging/put. host_start must NOT be invoked when staging
-// returns 200 directly.
+// /v1/gitlab/staging/put. host_start must NOT be invoked by the proxy.
 func TestProxy_GitLab_StagingHappyPath(t *testing.T) {
 	t.Parallel()
 
@@ -594,7 +593,7 @@ func TestProxy_GitLab_StagingServerErrorDoesNotHostStart(t *testing.T) {
 	assertAgentCalls(t, got, []string{"/v1/gitlab/staging/put"})
 }
 
-func TestProxy_GitLab_HostStartFailureFallsThrough(t *testing.T) {
+func TestProxy_GitLab_StagingNotFoundWithIdentityFallsThrough(t *testing.T) {
 	t.Parallel()
 
 	const containerID = "3333333333333333333333333333333333333333333333333333333333333333"
@@ -618,7 +617,8 @@ func TestProxy_GitLab_HostStartFailureFallsThrough(t *testing.T) {
 		case "/v1/gitlab/staging/put":
 			writeJSON(t, w, http.StatusNotFound, map[string]string{"error": "job_not_found"})
 		case "/v1/gitlab/host/start":
-			http.Error(w, "host start failed", http.StatusInternalServerError)
+			t.Errorf("host_start must not be called; GitLab staging endpoint owns lazy start")
+			writeJSON(t, w, http.StatusOK, map[string]string{"status": "ok"})
 		default:
 			t.Errorf("unexpected agent path: %q", r.URL.Path)
 		}
@@ -634,7 +634,7 @@ func TestProxy_GitLab_HostStartFailureFallsThrough(t *testing.T) {
 		t.Fatalf("status: got %d, want %d", resp.StatusCode, http.StatusCreated)
 	}
 
-	assertAgentCalls(t, got, []string{"/v1/gitlab/staging/put", "/v1/gitlab/host/start"})
+	assertAgentCalls(t, got, []string{"/v1/gitlab/staging/put"})
 }
 
 func TestProxy_GitLab_InvalidCreateResponseFallsThroughWithoutStaging(t *testing.T) {
@@ -689,11 +689,10 @@ func TestProxy_GitLab_InvalidCreateResponseFallsThroughWithoutStaging(t *testing
 	}
 }
 
-// When the agent has no Job for the identity yet (staging returns 404), the
-// proxy must lazily POST host/start with the same identity and retry the
-// staging put. The 3-call sequence (staging, host_start, staging) must
-// occur in order on the same docker create.
-func TestProxy_GitLab_LazyCreate(t *testing.T) {
+// GitLab Job creation belongs to /v1/gitlab/staging/put. The proxy sends one
+// request carrying peer PID plus labels identity; the listener creates a
+// missing Job and stages the basename behind that route.
+func TestProxy_GitLab_StagingCarriesIdentityForListenerLazyStart(t *testing.T) {
 	t.Parallel()
 
 	const containerID = "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
@@ -712,19 +711,14 @@ func TestProxy_GitLab_LazyCreate(t *testing.T) {
 		body []byte
 	}
 	calls := make(chan agentCall, 4)
-	stagingSeen := 0
 	agentSocket := startUnixServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, _ := io.ReadAll(r.Body)
 		calls <- agentCall{path: r.URL.Path, body: body}
 		switch r.URL.Path {
 		case "/v1/gitlab/staging/put":
-			stagingSeen++
-			if stagingSeen == 1 {
-				writeJSON(t, w, http.StatusNotFound, map[string]string{"error": "job_not_found"})
-				return
-			}
 			writeJSON(t, w, http.StatusOK, map[string]string{"status": "staged"})
 		case "/v1/gitlab/host/start":
+			t.Errorf("host_start must not be called; GitLab staging endpoint owns lazy start")
 			writeJSON(t, w, http.StatusOK, map[string]string{"status": "ok"})
 		default:
 			t.Errorf("unexpected agent path: %q", r.URL.Path)
@@ -746,40 +740,34 @@ func TestProxy_GitLab_LazyCreate(t *testing.T) {
 		t.Fatalf("status: got %d, want %d", resp.StatusCode, http.StatusCreated)
 	}
 
-	wantOrder := []string{
-		"/v1/gitlab/staging/put",
-		"/v1/gitlab/host/start",
-		"/v1/gitlab/staging/put",
-	}
-	for i, want := range wantOrder {
-		select {
-		case call := <-calls:
-			if call.path != want {
-				t.Fatalf("call %d: got %q, want %q", i, call.path, want)
-			}
-			if call.path == "/v1/gitlab/host/start" {
-				var req jobcontext.GitLabHostStartRequest
-				if err := json.Unmarshal(call.body, &req); err != nil {
-					t.Fatalf("decode host_start body: %v", err)
-				}
-				if req.JobIdentity != jobcontext.GitLabJobIdentity("gitlab.com", "cicd-sensor/cicd-sensor-testing", "777") {
-					t.Fatalf("host_start identity: got %+v", req.JobIdentity)
-				}
-			}
-		case <-time.After(2 * time.Second):
-			t.Fatalf("call %d (%s) not seen within 2s", i, want)
+	select {
+	case call := <-calls:
+		if call.path != "/v1/gitlab/staging/put" {
+			t.Fatalf("agent path: got %q, want /v1/gitlab/staging/put", call.path)
 		}
+		var req jobcontext.GitLabStagingPutRequest
+		if err := json.Unmarshal(call.body, &req); err != nil {
+			t.Fatalf("decode staging body: %v", err)
+		}
+		if req.JobIdentity == nil {
+			t.Fatal("staging request missing job_identity")
+		}
+		if *req.JobIdentity != jobcontext.GitLabJobIdentity("gitlab.com", "cicd-sensor/cicd-sensor-testing", "777") {
+			t.Fatalf("staging identity: got %+v", *req.JobIdentity)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("staging call not seen within 2s")
 	}
 	select {
 	case extra := <-calls:
-		t.Fatalf("unexpected fourth agent call: %s", extra.path)
+		t.Fatalf("unexpected extra agent call: %s", extra.path)
 	case <-time.After(150 * time.Millisecond):
 	}
 }
 
-// host_start receives metadata from labels (trusted) and env (best-effort),
-// with first-wins on env discarding `.gitlab-ci.yml variables:` spoof attempts.
-func TestProxy_GitLab_LazyCreate_PropagatesMetadata(t *testing.T) {
+// staging receives metadata from labels (trusted) and env (best-effort), with
+// first-wins on env discarding `.gitlab-ci.yml variables:` spoof attempts.
+func TestProxy_GitLab_StagingPropagatesMetadata(t *testing.T) {
 	t.Parallel()
 
 	const containerID = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
@@ -796,7 +784,7 @@ func TestProxy_GitLab_LazyCreate_PropagatesMetadata(t *testing.T) {
 		"CI_JOB_NAME=jirojiro-smoke",
 		"GITLAB_USER_LOGIN=rung",
 		// User-spoofed .gitlab-ci.yml `variables:` overrides (come later).
-		// host_start metadata must NOT pick these up (first-wins).
+		// staging metadata must NOT pick these up (first-wins).
 		"CI_PIPELINE_SOURCE=web",
 		"GITLAB_USER_LOGIN=attacker",
 	}
@@ -805,24 +793,19 @@ func TestProxy_GitLab_LazyCreate_PropagatesMetadata(t *testing.T) {
 		writeJSON(t, w, http.StatusCreated, containerCreateResponse{ID: containerID})
 	}))
 
-	hostStartReq := make(chan jobcontext.GitLabHostStartRequest, 1)
-	stagingSeen := 0
+	stagingReq := make(chan jobcontext.GitLabStagingPutRequest, 1)
 	agentSocket := startUnixServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/v1/gitlab/staging/put":
-			stagingSeen++
-			if stagingSeen == 1 {
-				writeJSON(t, w, http.StatusNotFound, map[string]string{"error": "job_not_found"})
-				return
+			body, _ := io.ReadAll(r.Body)
+			var req jobcontext.GitLabStagingPutRequest
+			if err := json.Unmarshal(body, &req); err != nil {
+				t.Errorf("decode staging body: %v", err)
 			}
+			stagingReq <- req
 			writeJSON(t, w, http.StatusOK, map[string]string{"status": "staged"})
 		case "/v1/gitlab/host/start":
-			body, _ := io.ReadAll(r.Body)
-			var req jobcontext.GitLabHostStartRequest
-			if err := json.Unmarshal(body, &req); err != nil {
-				t.Errorf("decode host_start body: %v", err)
-			}
-			hostStartReq <- req
+			t.Errorf("host_start must not be called; GitLab staging endpoint owns lazy start")
 			writeJSON(t, w, http.StatusOK, map[string]string{"status": "ok"})
 		default:
 			t.Errorf("unexpected agent path: %q", r.URL.Path)
@@ -841,10 +824,13 @@ func TestProxy_GitLab_LazyCreate_PropagatesMetadata(t *testing.T) {
 	resp.Body.Close()
 
 	select {
-	case got := <-hostStartReq:
+	case got := <-stagingReq:
 		wantIdentity := jobcontext.GitLabJobIdentity("gitlab.com", "rung/girogiro-testing", "14499483701")
-		if got.JobIdentity != wantIdentity {
-			t.Fatalf("identity: got %+v, want %+v", got.JobIdentity, wantIdentity)
+		if got.JobIdentity == nil {
+			t.Fatal("staging request missing job_identity")
+		}
+		if *got.JobIdentity != wantIdentity {
+			t.Fatalf("identity: got %+v, want %+v", *got.JobIdentity, wantIdentity)
 		}
 		wantMetadata := jobcontext.JobMetadata{
 			CommitSHA:     "c4c41b82483929ffab3abae20b60dd9f793400ba",
@@ -857,12 +843,12 @@ func TestProxy_GitLab_LazyCreate_PropagatesMetadata(t *testing.T) {
 			t.Fatalf("metadata: got %+v, want %+v", got.Metadata, wantMetadata)
 		}
 	case <-time.After(2 * time.Second):
-		t.Fatalf("host_start not seen within 2s")
+		t.Fatalf("staging request not seen within 2s")
 	}
 }
 
-// cache-init carries labels but no env; the proxy must defer Job creation
-// to predefined/build so env-sourced metadata makes it into host_start.
+// cache-init carries labels but no env; the proxy must defer Job creation to
+// predefined/build so env-sourced metadata makes it into the staging request.
 func TestProxy_GitLab_CacheInitSkipped(t *testing.T) {
 	t.Parallel()
 
@@ -915,17 +901,10 @@ func TestProxy_GitLab_CacheInitSkipped(t *testing.T) {
 	}
 }
 
-// Multiple concurrent containers/create for the same identity must each
-// complete the lazy-create flow successfully. The agent fake here simulates
-// the JobRegistry per-identity barrier: staging/put returns 404 until
-// host/start has been received, host/start can be invoked multiple times
-// (idempotent EnsureJob), and a tiny artificial delay on host/start widens
-// the race window so multiple goroutines hit the 404 → host/start path
-// concurrently. Without proxy-side de-dup or agent-side serialisation,
-// some staging retries would observe stale 404s; this test asserts that
-// at least one host/start completes and every concurrent docker create
-// receives a 201 with no errors propagated.
-func TestProxy_GitLab_ConcurrentLazyCreates(t *testing.T) {
+// Multiple concurrent containers/create for the same identity must still make
+// one staging request per container. The listener owns the per-identity lazy
+// start barrier; the proxy must not add its own host/start sequence.
+func TestProxy_GitLab_ConcurrentStagingRequests(t *testing.T) {
 	t.Parallel()
 
 	const N = 4
@@ -943,28 +922,14 @@ func TestProxy_GitLab_ConcurrentLazyCreates(t *testing.T) {
 		writeJSON(t, w, http.StatusCreated, containerCreateResponse{ID: cid})
 	}))
 
-	var (
-		jobRegistered  atomic.Bool
-		hostStartCalls atomic.Int32
-		stagingCalls   atomic.Int32
-		stagingSuccess atomic.Int32
-	)
+	var stagingCalls atomic.Int32
 	agentSocket := startUnixServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/v1/gitlab/staging/put":
 			stagingCalls.Add(1)
-			if !jobRegistered.Load() {
-				writeJSON(t, w, http.StatusNotFound, map[string]string{"error": "job_not_found"})
-				return
-			}
-			stagingSuccess.Add(1)
 			writeJSON(t, w, http.StatusOK, map[string]string{"status": "staged"})
 		case "/v1/gitlab/host/start":
-			hostStartCalls.Add(1)
-			// Hold the slot briefly so other goroutines stack up on the
-			// 404 → host/start transition.
-			time.Sleep(10 * time.Millisecond)
-			jobRegistered.Store(true)
+			t.Errorf("host_start must not be called; GitLab staging endpoint owns lazy start")
 			writeJSON(t, w, http.StatusOK, map[string]string{"status": "ok"})
 		default:
 			t.Errorf("unexpected agent path: %q", r.URL.Path)
@@ -1003,12 +968,8 @@ func TestProxy_GitLab_ConcurrentLazyCreates(t *testing.T) {
 			t.Errorf("goroutine %d: %v", i, e)
 		}
 	}
-	if hostStartCalls.Load() == 0 {
-		t.Errorf("host_start never invoked")
-	}
-	if stagingSuccess.Load() != N {
-		t.Errorf("expected %d staging successes, got %d (total staging calls: %d)",
-			N, stagingSuccess.Load(), stagingCalls.Load())
+	if stagingCalls.Load() != N {
+		t.Errorf("expected %d staging calls, got %d", N, stagingCalls.Load())
 	}
 }
 
@@ -1033,7 +994,7 @@ func TestPostStagingErrorsIncludeResponseBody(t *testing.T) {
 	}
 
 	identity := jobcontext.GitLabJobIdentity("gitlab.com", "group/project", "42")
-	if err := postGitLabStaging(context.Background(), agentSocket, "docker-deadbeef.scope", int32(os.Getpid()), &identity); err == nil || !strings.Contains(err.Error(), "agent boom") {
+	if err := postGitLabStaging(context.Background(), agentSocket, "docker-deadbeef.scope", int32(os.Getpid()), &identity, jobcontext.JobMetadata{}); err == nil || !strings.Contains(err.Error(), "agent boom") {
 		t.Fatalf("postGitLabStaging error = %v, want body included", err)
 	}
 }

--- a/internal/agent/proxy/dockerd/gitlab.go
+++ b/internal/agent/proxy/dockerd/gitlab.go
@@ -40,9 +40,6 @@ type gitlabRequestState struct {
 	metadata jobcontext.JobMetadata
 }
 
-// errGitLabJobNotFound triggers host/start before one staging retry.
-var errGitLabJobNotFound = errors.New("gitlab job not found at agent")
-
 // proxyHandlerGitLab stages docker-<cid>.scope with peer PID and optional
 // GitLab runner label identity; the agent chooses which evidence to use.
 func proxyHandlerGitLab(logger *slog.Logger, upstreamSocket, agentSocket string) http.Handler {
@@ -129,9 +126,9 @@ func proxyHandlerGitLab(logger *slog.Logger, upstreamSocket, agentSocket string)
 			}
 
 			basename := fmt.Sprintf("docker-%s.scope", parsed.ID)
-			ctx, cancel := context.WithTimeout(resp.Request.Context(), agentLazyCreateTimeout)
+			ctx, cancel := context.WithTimeout(resp.Request.Context(), agentGitLabStagingTimeout)
 			defer cancel()
-			if err := stageGitLabWithLazyCreate(ctx, agentSocket, basename, peerPID, identityPtr, state.metadata); err != nil {
+			if err := postGitLabStaging(ctx, agentSocket, basename, peerPID, identityPtr, state.metadata); err != nil {
 				logger.WarnContext(resp.Request.Context(), "staging_put_failed",
 					"error", err,
 					"basename", basename,
@@ -153,32 +150,12 @@ func proxyHandlerGitLab(logger *slog.Logger, upstreamSocket, agentSocket string)
 	return rev
 }
 
-// stageGitLabWithLazyCreate keeps GitLab Job creation on host/start. Staging
-// first preserves the cheap existing-Job path; 404 is the lazy-start signal.
-func stageGitLabWithLazyCreate(ctx context.Context, agentSocket, basename string, peerPID int32, identity *jobcontext.JobIdentity, metadata jobcontext.JobMetadata) error {
-	err := postGitLabStaging(ctx, agentSocket, basename, peerPID, identity)
-	if err == nil {
-		return nil
-	}
-	if !errors.Is(err, errGitLabJobNotFound) {
-		return err
-	}
-	if identity == nil {
-		return err
-	}
-	// The agent deduplicates concurrent host/start calls for the same identity.
-	if err := postGitLabHostStart(ctx, agentSocket, *identity, metadata); err != nil {
-		return fmt.Errorf("host_start: %w", err)
-	}
-	return postGitLabStaging(ctx, agentSocket, basename, peerPID, identity)
-}
-
-// postGitLabStaging maps 404 to errGitLabJobNotFound for lazy create.
-func postGitLabStaging(ctx context.Context, agentSocket, basename string, peerPID int32, identity *jobcontext.JobIdentity) error {
+func postGitLabStaging(ctx context.Context, agentSocket, basename string, peerPID int32, identity *jobcontext.JobIdentity, metadata jobcontext.JobMetadata) error {
 	body, err := json.Marshal(jobcontext.GitLabStagingPutRequest{
 		Basename:    basename,
 		PeerPID:     peerPID,
 		JobIdentity: identity,
+		Metadata:    metadata,
 	})
 	if err != nil {
 		return fmt.Errorf("marshal gitlab staging request: %w", err)
@@ -190,30 +167,9 @@ func postGitLabStaging(ctx context.Context, agentSocket, basename string, peerPI
 	switch status {
 	case http.StatusOK:
 		return nil
-	case http.StatusNotFound:
-		return errGitLabJobNotFound
 	default:
 		return fmt.Errorf("agent /v1/gitlab/staging/put returned %d: %s", status, respBody)
 	}
-}
-
-// postGitLabHostStart issues the agent's idempotent EnsureJob request.
-func postGitLabHostStart(ctx context.Context, agentSocket string, identity jobcontext.JobIdentity, metadata jobcontext.JobMetadata) error {
-	body, err := json.Marshal(jobcontext.GitLabHostStartRequest{
-		JobIdentity: identity,
-		Metadata:    metadata,
-	})
-	if err != nil {
-		return fmt.Errorf("marshal gitlab host_start request: %w", err)
-	}
-	status, respBody, err := postAgent(ctx, agentSocket, "/v1/gitlab/host/start", body)
-	if err != nil {
-		return err
-	}
-	if status != http.StatusOK {
-		return fmt.Errorf("agent /v1/gitlab/host/start returned %d: %s", status, respBody)
-	}
-	return nil
 }
 
 // jobMetadataFromGitLabContainer derives metadata from runner labels (trust

--- a/internal/jobcontext/agent_requests.go
+++ b/internal/jobcontext/agent_requests.go
@@ -14,11 +14,13 @@ type GitHubK8sStagingPutRequest struct {
 }
 
 // GitLabStagingPutRequest lets the proxy send both evidence sources; the agent
-// chooses peer PID first, then labels identity when needed.
+// chooses peer PID first, then labels identity when it needs to create a
+// missing GitLab host Job.
 type GitLabStagingPutRequest struct {
 	Basename    string       `json:"basename"`
 	PeerPID     int32        `json:"peer_pid,omitempty"`
 	JobIdentity *JobIdentity `json:"job_identity,omitempty"`
+	Metadata    JobMetadata  `json:"metadata,omitempty"`
 }
 
 // GitLabK8sStagingPutRequest is sent by the host-side NRI observer. The
@@ -29,7 +31,7 @@ type GitLabK8sStagingPutRequest struct {
 	Metadata    JobMetadata `json:"metadata,omitempty"`
 }
 
-// GitLabHostStartRequest is the proxy lazy-create payload.
+// GitLabHostStartRequest is the explicit GitLab host-start payload.
 type GitLabHostStartRequest struct {
 	JobIdentity
 	Metadata JobMetadata `json:"metadata,omitempty"`


### PR DESCRIPTION
## What

- Move GitLab Docker proxy lazy Job creation into `/v1/gitlab/staging/put`.
- Make the proxy send `job_identity` and `metadata` on the staging request, then stop calling `/v1/gitlab/host/start` itself.
- Update listener tests and proxy tests so the new ownership is explicit:
  - proxy sends one staging request
  - listener creates a missing GitLab host Job when identity is present
  - proxy fail-open behavior is preserved
- Update developer docs to describe listener-owned lazy creation for GitLab staging.

## Why

GitLab Docker proxy had a multi-request lazy start flow:

1. staging
2. `404 job_not_found`
3. host start
4. staging retry

That made the proxy own part of Job lifecycle behavior and duplicated the model already used by Kubernetes/NRI staging. The listener is the better boundary for this because it already owns Job registration, staging, validation, and host manager config handling.

With this change, container lifecycle callers only make one local agent request, while the listener decides whether to stage an existing Job or create the missing GitLab host Job first.

Fixes #57.

## Validation

- `go test ./cmd/cicd-sensor ./internal/agent/listener ./internal/agent/proxy/dockerd ./internal/jobcontext`
- `go test ./internal/agent/...`
- `git diff --check`
