### PR TITLE
fix: reconcile missed cgroup removals

### DIFF
--- a/docs/developer-guide/ebpf-runtime.md
+++ b/docs/developer-guide/ebpf-runtime.md
@@ -50,6 +50,7 @@ The Docker proxy checks the peer process of the Docker create request and determ
 `cgroup_rmdir` does not immediately delete non-final cgroups from `tracked_cgroups`.
 KernelTracker marks them removed and purges them after the 10-second grace period plus the next purge tick, so in-flight samples that arrive after rmdir can still be attributed to the Job.
 If the removed cgroup is the Job's last active cgroup, KernelTracker ends the Job immediately and lets normal Job finalization clean up kernel and userspace state.
+KernelTracker also periodically scans the cgroup v2 root from userspace and reconciles active tracked cgroups, so a missed `cgroup_rmdir` sample does not leave stale cgroups or Jobs indefinitely.
 
 ## Event coverage
 

--- a/internal/agent/kerneltracker/engine.go
+++ b/internal/agent/kerneltracker/engine.go
@@ -76,7 +76,9 @@ func (engine *KernelTracker) Run(ctx context.Context) error {
 
 	// Start periodic maintenance such as process context GC and lazy cgroup purge.
 	stopTrackingStatePurgeTicker := engine.startTrackingStatePurgeTicker(ctx)
+	stopCgroupLivenessScanner := engine.startCgroupLivenessScanner(ctx)
 	defer engine.closeRemainingChannels()
+	defer stopCgroupLivenessScanner()
 	defer stopTrackingStatePurgeTicker()
 
 	for {

--- a/internal/agent/kerneltracker/engine_handler.go
+++ b/internal/agent/kerneltracker/engine_handler.go
@@ -28,6 +28,8 @@ func handleEngineInput(state *jobTrackingState, input engineInput) []engineEffec
 		return handleExitSample(state, value)
 	case commandPurgeExpiredTrackingState:
 		return handlePurgeTick(state)
+	case commandReconcileCgroupLiveness:
+		return handleCgroupLivenessReconciliation(state, value)
 	case cgroupMkdirSample:
 		return handleCgroupMkdirSample(state, value)
 	case cgroupAttachSample:

--- a/internal/agent/kerneltracker/engine_handler_test.go
+++ b/internal/agent/kerneltracker/engine_handler_test.go
@@ -365,6 +365,157 @@ func TestTransitionInvariants(t *testing.T) {
 			},
 		},
 		{
+			name: "cgroup liveness reconciliation notifies when final active cgroup is missing",
+			run: func(t *testing.T) {
+				state := destinationTrackedState(jobID, 42)
+				var logs bytes.Buffer
+				state.logger = slog.New(slog.NewJSONHandler(&logs, nil))
+				effects := handleEngineInput(state, commandReconcileCgroupLiveness{
+					ScanStartedAt:  time.Now().UTC().Add(time.Second),
+					CheckedAt:      time.Now().UTC().Add(2 * time.Second),
+					LiveCgroupIDs:  map[uint64]struct{}{},
+					StatErrorCount: 1,
+				})
+				if !hasNotifyJobEndedEffect(effects) {
+					t.Fatalf("expected notifyJobEnded when final active cgroup is missing")
+				}
+				assertEffectOrder(t, effects,
+					notifyJobEnded{},
+				)
+				logOutput := logs.String()
+				for _, want := range []string{
+					"cgroup_liveness_reconciled",
+					`"removed_count":1`,
+					`"drained_job_count":1`,
+					`"live_cgroup_count":0`,
+					`"stat_error_count":1`,
+				} {
+					if !strings.Contains(logOutput, want) {
+						t.Fatalf("reconciliation log = %s, want to contain %s", logOutput, want)
+					}
+				}
+			},
+		},
+		{
+			name: "cgroup liveness reconciliation is silent when nothing changes",
+			run: func(t *testing.T) {
+				state := destinationTrackedState(jobID, 42)
+				var logs bytes.Buffer
+				state.logger = slog.New(slog.NewJSONHandler(&logs, nil))
+				effects := handleEngineInput(state, commandReconcileCgroupLiveness{
+					ScanStartedAt: time.Now().UTC().Add(time.Second),
+					CheckedAt:     time.Now().UTC().Add(2 * time.Second),
+					LiveCgroupIDs: map[uint64]struct{}{42: {}},
+				})
+				if len(effects) != 0 {
+					t.Fatalf("live cgroup reconciliation emitted effects: %#v", effects)
+				}
+				if got := logs.String(); got != "" {
+					t.Fatalf("live cgroup reconciliation log = %s, want empty", got)
+				}
+			},
+		},
+		{
+			name: "cgroup rmdir then liveness scan keeps non-final removed cgroup pending",
+			run: func(t *testing.T) {
+				state := destinationTrackedState(jobID, 42, 84)
+				rmdirEffects := handleEngineInput(state, cgroupRmdirSample{CgroupID: 42})
+				if len(rmdirEffects) != 0 {
+					t.Fatalf("non-final rmdir emitted effects: %#v", rmdirEffects)
+				}
+
+				scanEffects := handleEngineInput(state, commandReconcileCgroupLiveness{
+					ScanStartedAt: time.Now().UTC().Add(time.Second),
+					CheckedAt:     time.Now().UTC().Add(2 * time.Second),
+					LiveCgroupIDs: map[uint64]struct{}{84: {}},
+				})
+				if len(scanEffects) != 0 {
+					t.Fatalf("scan after non-final rmdir emitted effects: %#v", scanEffects)
+				}
+				if got := len(state.removedCgroupQueue); got != 1 {
+					t.Fatalf("removed cgroup queue length = %d, want 1", got)
+				}
+				if state.cgroupsByJob[jobID][42].State != trackedCgroupRemoved {
+					t.Fatalf("rmdir cgroup state = %v, want removed", state.cgroupsByJob[jobID][42].State)
+				}
+				if state.cgroupsByJob[jobID][84].State != trackedCgroupActive {
+					t.Fatalf("live cgroup state = %v, want active", state.cgroupsByJob[jobID][84].State)
+				}
+			},
+		},
+		{
+			name: "cgroup rmdir then liveness scan can drain remaining active cgroup",
+			run: func(t *testing.T) {
+				state := destinationTrackedState(jobID, 42, 84)
+				rmdirEffects := handleEngineInput(state, cgroupRmdirSample{CgroupID: 42})
+				if len(rmdirEffects) != 0 {
+					t.Fatalf("non-final rmdir emitted effects: %#v", rmdirEffects)
+				}
+
+				scanEffects := handleEngineInput(state, commandReconcileCgroupLiveness{
+					ScanStartedAt: time.Now().UTC().Add(time.Second),
+					CheckedAt:     time.Now().UTC().Add(2 * time.Second),
+					LiveCgroupIDs: map[uint64]struct{}{},
+				})
+				if !hasNotifyJobEndedEffect(scanEffects) {
+					t.Fatalf("expected scan to notify when remaining active cgroup is missing")
+				}
+				assertEffectOrder(t, scanEffects,
+					notifyJobEnded{},
+				)
+				if got := len(state.removedCgroupQueue); got != 2 {
+					t.Fatalf("removed cgroup queue length = %d, want 2", got)
+				}
+			},
+		},
+		{
+			name: "cgroup liveness scan then rmdir can drain remaining active cgroup",
+			run: func(t *testing.T) {
+				state := destinationTrackedState(jobID, 42, 84)
+				scanEffects := handleEngineInput(state, commandReconcileCgroupLiveness{
+					ScanStartedAt: time.Now().UTC().Add(time.Second),
+					CheckedAt:     time.Now().UTC().Add(2 * time.Second),
+					LiveCgroupIDs: map[uint64]struct{}{84: {}},
+				})
+				if len(scanEffects) != 0 {
+					t.Fatalf("non-final scan emitted effects: %#v", scanEffects)
+				}
+
+				rmdirEffects := handleEngineInput(state, cgroupRmdirSample{CgroupID: 84})
+				if !hasNotifyJobEndedEffect(rmdirEffects) {
+					t.Fatalf("expected rmdir to notify when remaining active cgroup is removed")
+				}
+				assertEffectOrder(t, rmdirEffects,
+					notifyJobEnded{},
+				)
+				if got := len(state.removedCgroupQueue); got != 2 {
+					t.Fatalf("removed cgroup queue length = %d, want 2", got)
+				}
+			},
+		},
+		{
+			name: "cgroup liveness scan after final rmdir does not notify twice",
+			run: func(t *testing.T) {
+				state := destinationTrackedState(jobID, 42)
+				rmdirEffects := handleEngineInput(state, cgroupRmdirSample{CgroupID: 42})
+				if !hasNotifyJobEndedEffect(rmdirEffects) {
+					t.Fatalf("expected rmdir to notify when final active cgroup is removed")
+				}
+
+				scanEffects := handleEngineInput(state, commandReconcileCgroupLiveness{
+					ScanStartedAt: time.Now().UTC().Add(time.Second),
+					CheckedAt:     time.Now().UTC().Add(2 * time.Second),
+					LiveCgroupIDs: map[uint64]struct{}{},
+				})
+				if len(scanEffects) != 0 {
+					t.Fatalf("scan after final rmdir emitted effects: %#v", scanEffects)
+				}
+				if got := len(state.removedCgroupQueue); got != 1 {
+					t.Fatalf("removed cgroup queue length = %d, want 1", got)
+				}
+			},
+		},
+		{
 			name: "exit marks process as logically deleted",
 			run: func(t *testing.T) {
 				state := destinationTrackedState(jobID, 42)

--- a/internal/agent/kerneltracker/engine_input.go
+++ b/internal/agent/kerneltracker/engine_input.go
@@ -1,6 +1,8 @@
 package kerneltracker
 
 import (
+	"time"
+
 	"github.com/cicd-sensor/cicd-sensor/internal/jobcontext"
 	"github.com/cicd-sensor/cicd-sensor/internal/jobevent"
 )
@@ -61,3 +63,12 @@ func (commandFindJobForCgroup) sealedEngineInput() {}
 type commandPurgeExpiredTrackingState struct{}
 
 func (commandPurgeExpiredTrackingState) sealedEngineInput() {}
+
+type commandReconcileCgroupLiveness struct {
+	ScanStartedAt  time.Time
+	CheckedAt      time.Time
+	LiveCgroupIDs  map[uint64]struct{}
+	StatErrorCount int
+}
+
+func (commandReconcileCgroupLiveness) sealedEngineInput() {}

--- a/internal/agent/kerneltracker/job_tracking_cgroup.go
+++ b/internal/agent/kerneltracker/job_tracking_cgroup.go
@@ -16,7 +16,11 @@ const (
 const cgroupRemovalGracePeriod = processExitGracePeriod
 
 type trackedCgroup struct {
-	State     trackedCgroupState
+	State trackedCgroupState
+	// TrackedAt is compared with async liveness scan start time. A cgroup
+	// first tracked after a scan started must not be removed by that scan's
+	// stale live-ID snapshot.
+	TrackedAt time.Time
 	RemovedAt time.Time
 }
 
@@ -44,6 +48,12 @@ type cgroupPurgeCandidate struct {
 // bind mirrors a cgroup -> Job attribution already accepted by KernelIO/eBPF.
 // It is non-overwriting so one cgroup cannot silently move between Jobs.
 func (s *jobTrackingState) bind(jobID jobcontext.JobIdentity, cgroupID uint64) bool {
+	return s.bindAt(jobID, cgroupID, time.Now().UTC())
+}
+
+// bindAt records when this userspace mirror first accepted the cgroup. Tests
+// and async reconciliation pass explicit times to make scan-race behavior clear.
+func (s *jobTrackingState) bindAt(jobID jobcontext.JobIdentity, cgroupID uint64, trackedAt time.Time) bool {
 	if owner, ok := s.jobByCgroup[cgroupID]; ok {
 		// Removed cgroups stay attributable during their grace period, but
 		// rmdir is a one-way lifecycle signal. Do not reactivate them.
@@ -59,6 +69,7 @@ func (s *jobTrackingState) bind(jobID jobcontext.JobIdentity, cgroupID uint64) b
 		s.cgroupsByJob[jobID][cgroupID] = cgroup
 	}
 	cgroup.State = trackedCgroupActive
+	cgroup.TrackedAt = trackedAt
 	cgroup.RemovedAt = time.Time{}
 	return true
 }
@@ -107,14 +118,45 @@ func (s *jobTrackingState) markTrackedCgroupRemoved(cgroupID uint64, now time.Ti
 
 	cgroup.State = trackedCgroupRemoved
 	cgroup.RemovedAt = now
-	// Keep the forward cgroup -> Job mapping until purge so late samples from
-	// the removed cgroup still resolve to the Job.
+	// cgroup_rmdir is the primary deletion signal. Periodic liveness
+	// reconciliation only uses this same path to compensate for a missed
+	// rmdir sample; it does not delete cgroups immediately. Keep the forward
+	// cgroup -> Job mapping until purge so late samples from the removed
+	// cgroup still resolve to the Job.
 	s.removedCgroupQueue = append(s.removedCgroupQueue, cgroupPurgeCandidate{JobID: jobID, CgroupID: cgroupID})
 	return cgroupDetachResult{
 		JobID:      jobID,
 		Found:      true,
 		JobDrained: s.activeCgroupCount(jobID) == 0,
 	}
+}
+
+// reconcileCgroupLiveness applies a filesystem scan result to loop-owned state.
+// The scan is a safety net for missed cgroup_rmdir samples: it detects active
+// tracked cgroups that no longer exist, then moves them into the same
+// removed-pending queue used by the rmdir handler. The scan itself runs outside
+// the engine loop; this method is the only place that interprets the live-ID
+// snapshot and mutates tracked cgroup ownership.
+func (s *jobTrackingState) reconcileCgroupLiveness(liveCgroupIDs map[uint64]struct{}, scanStartedAt time.Time, checkedAt time.Time) []cgroupDetachResult {
+	var removed []cgroupDetachResult
+	for _, cgroups := range s.cgroupsByJob {
+		for cgroupID, cgroup := range cgroups {
+			if cgroup == nil || cgroup.State != trackedCgroupActive {
+				continue
+			}
+			if cgroup.TrackedAt.After(scanStartedAt) {
+				continue
+			}
+			if _, ok := liveCgroupIDs[cgroupID]; ok {
+				continue
+			}
+			result := s.markTrackedCgroupRemoved(cgroupID, checkedAt)
+			if result.Found {
+				removed = append(removed, result)
+			}
+		}
+	}
+	return removed
 }
 
 func (s *jobTrackingState) activeCgroupCount(jobID jobcontext.JobIdentity) int {

--- a/internal/agent/kerneltracker/job_tracking_cgroup_liveness.go
+++ b/internal/agent/kerneltracker/job_tracking_cgroup_liveness.go
@@ -1,0 +1,69 @@
+package kerneltracker
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+const cgroupLivenessScanInterval = time.Minute
+
+// cgroupLivenessSnapshot is produced outside the KernelTracker engine loop.
+// It contains only immutable scan output; ownership decisions stay inside the
+// loop when commandReconcileCgroupLiveness is handled.
+type cgroupLivenessSnapshot struct {
+	LiveCgroupIDs  map[uint64]struct{}
+	DirectoryCount int
+	StatErrorCount int
+}
+
+// startCgroupLivenessScanner runs filesystem work outside the state-owner loop.
+// Scanning /sys/fs/cgroup can block briefly, so the goroutine sends only a
+// completed live-ID snapshot back through inputCh for serialized reconciliation.
+func (engine *KernelTracker) startCgroupLivenessScanner(ctx context.Context) func() {
+	if engine.cgroupV2RootPath == "" {
+		return func() {}
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+
+		ticker := time.NewTicker(cgroupLivenessScanInterval)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				engine.scanAndQueueCgroupLiveness(ctx)
+			}
+		}
+	}()
+	return wg.Wait
+}
+
+// scanAndQueueCgroupLiveness keeps ScanStartedAt from before the walk. The
+// engine loop uses it to ignore cgroups first tracked while this scan was in
+// progress, because those cgroups may legitimately be absent from the snapshot.
+func (engine *KernelTracker) scanAndQueueCgroupLiveness(ctx context.Context) {
+	scanStartedAt := time.Now().UTC()
+	snapshot, err := scanLiveCgroupIDs(engine.cgroupV2RootPath)
+	checkedAt := time.Now().UTC()
+	if err != nil {
+		engine.logger.WarnContext(ctx, "cgroup_liveness_scan_failed", "error", err)
+		return
+	}
+
+	select {
+	case engine.inputCh <- commandReconcileCgroupLiveness{
+		ScanStartedAt:  scanStartedAt,
+		CheckedAt:      checkedAt,
+		LiveCgroupIDs:  snapshot.LiveCgroupIDs,
+		StatErrorCount: snapshot.StatErrorCount,
+	}:
+	case <-ctx.Done():
+	}
+}

--- a/internal/agent/kerneltracker/job_tracking_cgroup_liveness_linux.go
+++ b/internal/agent/kerneltracker/job_tracking_cgroup_liveness_linux.go
@@ -1,0 +1,61 @@
+//go:build linux
+
+package kerneltracker
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+
+	"golang.org/x/sys/unix"
+)
+
+func scanLiveCgroupIDs(cgroupV2RootPath string) (cgroupLivenessSnapshot, error) {
+	return scanLiveCgroupIDsWithWalkDir(cgroupV2RootPath, filepath.WalkDir)
+}
+
+// scanLiveCgroupIDsWithWalkDir collects cgroup v2 directory inode numbers.
+// KernelTracker already treats cgroup IDs as cgroup directory inodes, so the
+// live set can be compared directly with tracked_cgroups userspace state.
+func scanLiveCgroupIDsWithWalkDir(cgroupV2RootPath string, walkDir func(string, fs.WalkDirFunc) error) (cgroupLivenessSnapshot, error) {
+	if cgroupV2RootPath == "" {
+		return cgroupLivenessSnapshot{}, errors.New("cgroup v2 root path is empty")
+	}
+
+	snapshot := cgroupLivenessSnapshot{LiveCgroupIDs: make(map[uint64]struct{})}
+	err := walkDir(cgroupV2RootPath, func(current string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			// Only a child ENOENT is safe to skip: it means the cgroup
+			// disappeared during the scan. Other child errors could hide a
+			// live subtree, so abort instead of falsely reconciling it away.
+			if current != cgroupV2RootPath && errors.Is(walkErr, os.ErrNotExist) {
+				snapshot.StatErrorCount++
+				return nil
+			}
+			return walkErr
+		}
+		if !entry.IsDir() {
+			return nil
+		}
+
+		var stat unix.Stat_t
+		if err := unix.Stat(current, &stat); err != nil {
+			// A child cgroup can disappear while the scan is walking the tree.
+			// Treat that as a missed live entry, not as a failed reconciliation.
+			if current != cgroupV2RootPath && errors.Is(err, os.ErrNotExist) {
+				snapshot.StatErrorCount++
+				return nil
+			}
+			return fmt.Errorf("stat cgroup path %q: %w", current, err)
+		}
+		snapshot.LiveCgroupIDs[stat.Ino] = struct{}{}
+		snapshot.DirectoryCount++
+		return nil
+	})
+	if err != nil {
+		return cgroupLivenessSnapshot{}, fmt.Errorf("walk cgroup v2 root %q: %w", cgroupV2RootPath, err)
+	}
+	return snapshot, nil
+}

--- a/internal/agent/kerneltracker/job_tracking_cgroup_liveness_linux_test.go
+++ b/internal/agent/kerneltracker/job_tracking_cgroup_liveness_linux_test.go
@@ -1,0 +1,121 @@
+//go:build linux
+
+package kerneltracker
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+func TestScanLiveCgroupIDsWithWalkDir(t *testing.T) {
+	t.Parallel()
+
+	t.Run("collects directory inodes", func(t *testing.T) {
+		t.Parallel()
+
+		root := t.TempDir()
+		child := filepath.Join(root, "child")
+		grandchild := filepath.Join(child, "grandchild")
+		if err := os.MkdirAll(grandchild, 0o755); err != nil {
+			t.Fatalf("mkdir cgroup tree: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(root, "cgroup.controllers"), []byte("cpu"), 0o644); err != nil {
+			t.Fatalf("write file: %v", err)
+		}
+
+		snapshot, err := scanLiveCgroupIDs(root)
+		if err != nil {
+			t.Fatalf("scanLiveCgroupIDs: %v", err)
+		}
+		if snapshot.DirectoryCount != 3 {
+			t.Fatalf("directory count = %d, want 3", snapshot.DirectoryCount)
+		}
+		if snapshot.StatErrorCount != 0 {
+			t.Fatalf("stat error count = %d, want 0", snapshot.StatErrorCount)
+		}
+		for _, path := range []string{root, child, grandchild} {
+			var stat unix.Stat_t
+			if err := unix.Stat(path, &stat); err != nil {
+				t.Fatalf("stat %q: %v", path, err)
+			}
+			if _, ok := snapshot.LiveCgroupIDs[stat.Ino]; !ok {
+				t.Fatalf("inode for %q not found in live cgroup IDs", path)
+			}
+		}
+	})
+
+	t.Run("empty root returns error", func(t *testing.T) {
+		t.Parallel()
+
+		if _, err := scanLiveCgroupIDs(""); err == nil {
+			t.Fatal("scanLiveCgroupIDs empty root error = nil, want error")
+		}
+	})
+
+	t.Run("root walk error returns error", func(t *testing.T) {
+		t.Parallel()
+
+		root := t.TempDir()
+		wantErr := errors.New("walk root failed")
+		_, err := scanLiveCgroupIDsWithWalkDir(root, func(path string, fn fs.WalkDirFunc) error {
+			return fn(path, testDirEntry{name: filepath.Base(path), dir: true}, wantErr)
+		})
+		if !errors.Is(err, wantErr) {
+			t.Fatalf("scan error = %v, want %v", err, wantErr)
+		}
+	})
+
+	t.Run("transient non-root disappearance is counted and ignored", func(t *testing.T) {
+		t.Parallel()
+
+		root := t.TempDir()
+		missing := filepath.Join(root, "gone")
+		snapshot, err := scanLiveCgroupIDsWithWalkDir(root, func(path string, fn fs.WalkDirFunc) error {
+			if err := fn(root, testDirEntry{name: filepath.Base(root), dir: true}, nil); err != nil {
+				return err
+			}
+			return fn(missing, nil, os.ErrNotExist)
+		})
+		if err != nil {
+			t.Fatalf("scanLiveCgroupIDsWithWalkDir: %v", err)
+		}
+		if snapshot.DirectoryCount != 1 {
+			t.Fatalf("directory count = %d, want 1", snapshot.DirectoryCount)
+		}
+		if snapshot.StatErrorCount != 1 {
+			t.Fatalf("stat error count = %d, want 1", snapshot.StatErrorCount)
+		}
+	})
+
+	t.Run("non-ENOENT child walk error aborts scan", func(t *testing.T) {
+		t.Parallel()
+
+		root := t.TempDir()
+		child := filepath.Join(root, "child")
+		wantErr := os.ErrPermission
+		_, err := scanLiveCgroupIDsWithWalkDir(root, func(path string, fn fs.WalkDirFunc) error {
+			if err := fn(root, testDirEntry{name: filepath.Base(root), dir: true}, nil); err != nil {
+				return err
+			}
+			return fn(child, nil, wantErr)
+		})
+		if !errors.Is(err, wantErr) {
+			t.Fatalf("scan error = %v, want %v", err, wantErr)
+		}
+	})
+}
+
+type testDirEntry struct {
+	name string
+	dir  bool
+}
+
+func (entry testDirEntry) Name() string               { return entry.name }
+func (entry testDirEntry) IsDir() bool                { return entry.dir }
+func (entry testDirEntry) Type() fs.FileMode          { return 0 }
+func (entry testDirEntry) Info() (fs.FileInfo, error) { return nil, nil }

--- a/internal/agent/kerneltracker/job_tracking_cgroup_liveness_stub.go
+++ b/internal/agent/kerneltracker/job_tracking_cgroup_liveness_stub.go
@@ -1,0 +1,9 @@
+//go:build !linux
+
+package kerneltracker
+
+import "github.com/cicd-sensor/cicd-sensor/internal/agent/kerneltracker/kernelio"
+
+func scanLiveCgroupIDs(string) (cgroupLivenessSnapshot, error) {
+	return cgroupLivenessSnapshot{}, kernelio.ErrNotSupported
+}

--- a/internal/agent/kerneltracker/job_tracking_cgroup_test.go
+++ b/internal/agent/kerneltracker/job_tracking_cgroup_test.go
@@ -12,8 +12,9 @@ func TestJobTrackingState_BindAndJobForCgroup(t *testing.T) {
 
 	s := newJobTrackingState()
 	jobID := newJob("100")
+	trackedAt := time.Unix(100, 0)
 
-	if !s.bind(jobID, 42) {
+	if !s.bindAt(jobID, 42, trackedAt) {
 		t.Fatalf("Bind on empty state must succeed")
 	}
 
@@ -23,6 +24,9 @@ func TestJobTrackingState_BindAndJobForCgroup(t *testing.T) {
 	}
 	if !testHasTrackedCgroups(s, jobID) {
 		t.Fatal("tracked cgroups must be present after Bind")
+	}
+	if got := s.cgroupsByJob[jobID][42].TrackedAt; !got.Equal(trackedAt) {
+		t.Fatalf("tracked at = %v, want %v", got, trackedAt)
 	}
 }
 
@@ -281,6 +285,138 @@ func TestJobTrackingState_BindDoesNotReactivateSameJobRemovedCgroup(t *testing.T
 	if got := len(s.removedCgroupQueue); got != 1 {
 		t.Fatalf("removed cgroup queue length = %d, want 1", got)
 	}
+}
+
+func TestJobTrackingState_ReconcileCgroupLiveness(t *testing.T) {
+	t.Parallel()
+
+	scanStartedAt := time.Unix(200, 0)
+	checkedAt := time.Unix(210, 0)
+
+	t.Run("live active cgroup remains active", func(t *testing.T) {
+		t.Parallel()
+
+		s := newJobTrackingState()
+		jobID := newJob("100")
+		s.bindAt(jobID, 42, scanStartedAt.Add(-time.Second))
+
+		removed := s.reconcileCgroupLiveness(map[uint64]struct{}{42: {}}, scanStartedAt, checkedAt)
+		if len(removed) != 0 {
+			t.Fatalf("removed cgroups = %#v, want none", removed)
+		}
+		if state := s.cgroupsByJob[jobID][42].State; state != trackedCgroupActive {
+			t.Fatalf("cgroup state = %v, want active", state)
+		}
+	})
+
+	t.Run("missing non-final cgroup becomes removed pending", func(t *testing.T) {
+		t.Parallel()
+
+		s := newJobTrackingState()
+		jobID := newJob("100")
+		s.bindAt(jobID, 42, scanStartedAt.Add(-time.Second))
+		s.bindAt(jobID, 84, scanStartedAt.Add(-time.Second))
+
+		removed := s.reconcileCgroupLiveness(map[uint64]struct{}{84: {}}, scanStartedAt, checkedAt)
+		if len(removed) != 1 || removed[0].JobID != jobID || removed[0].JobDrained {
+			t.Fatalf("removed result = %#v, want one non-drained result for %v", removed, jobID)
+		}
+		if state := s.cgroupsByJob[jobID][42].State; state != trackedCgroupRemoved {
+			t.Fatalf("missing cgroup state = %v, want removed", state)
+		}
+		if got := s.cgroupsByJob[jobID][42].RemovedAt; !got.Equal(checkedAt) {
+			t.Fatalf("removed at = %v, want %v", got, checkedAt)
+		}
+		if owner, ok := s.jobForCgroup(42); !ok || owner != jobID {
+			t.Fatalf("removed pending owner = %v ok=%v, want %v true", owner, ok, jobID)
+		}
+	})
+
+	t.Run("missing final active cgroup drains job", func(t *testing.T) {
+		t.Parallel()
+
+		s := newJobTrackingState()
+		jobID := newJob("100")
+		s.bindAt(jobID, 42, scanStartedAt.Add(-time.Second))
+
+		removed := s.reconcileCgroupLiveness(nil, scanStartedAt, checkedAt)
+		if len(removed) != 1 || removed[0].JobID != jobID || !removed[0].JobDrained {
+			t.Fatalf("removed result = %#v, want one drained result for %v", removed, jobID)
+		}
+	})
+
+	t.Run("all active cgroups missing drains once", func(t *testing.T) {
+		t.Parallel()
+
+		s := newJobTrackingState()
+		jobID := newJob("100")
+		s.bindAt(jobID, 42, scanStartedAt.Add(-time.Second))
+		s.bindAt(jobID, 84, scanStartedAt.Add(-time.Second))
+
+		removed := s.reconcileCgroupLiveness(nil, scanStartedAt, checkedAt)
+		if len(removed) != 2 {
+			t.Fatalf("removed result count = %d, want 2: %#v", len(removed), removed)
+		}
+		drained := 0
+		for _, result := range removed {
+			if result.JobID != jobID {
+				t.Fatalf("removed result job = %v, want %v", result.JobID, jobID)
+			}
+			if result.JobDrained {
+				drained++
+			}
+		}
+		if drained != 1 {
+			t.Fatalf("drained result count = %d, want 1: %#v", drained, removed)
+		}
+	})
+
+	t.Run("removed pending cgroup is ignored", func(t *testing.T) {
+		t.Parallel()
+
+		s := newJobTrackingState()
+		jobID := newJob("100")
+		s.bindAt(jobID, 42, scanStartedAt.Add(-time.Second))
+		s.markTrackedCgroupRemoved(42, checkedAt.Add(-time.Second))
+
+		removed := s.reconcileCgroupLiveness(nil, scanStartedAt, checkedAt)
+		if len(removed) != 0 {
+			t.Fatalf("removed result = %#v, want none", removed)
+		}
+		if got := len(s.removedCgroupQueue); got != 1 {
+			t.Fatalf("removed cgroup queue length = %d, want 1", got)
+		}
+	})
+
+	t.Run("cgroup tracked after scan start is skipped", func(t *testing.T) {
+		t.Parallel()
+
+		s := newJobTrackingState()
+		jobID := newJob("100")
+		s.bindAt(jobID, 42, scanStartedAt.Add(time.Second))
+
+		removed := s.reconcileCgroupLiveness(nil, scanStartedAt, checkedAt)
+		if len(removed) != 0 {
+			t.Fatalf("removed result = %#v, want none", removed)
+		}
+		if state := s.cgroupsByJob[jobID][42].State; state != trackedCgroupActive {
+			t.Fatalf("new cgroup state = %v, want active", state)
+		}
+	})
+
+	t.Run("stale scan after remove job is no-op", func(t *testing.T) {
+		t.Parallel()
+
+		s := newJobTrackingState()
+		jobID := newJob("100")
+		s.bindAt(jobID, 42, scanStartedAt.Add(-time.Second))
+		s.removeJob(jobID)
+
+		removed := s.reconcileCgroupLiveness(nil, scanStartedAt, checkedAt)
+		if len(removed) != 0 {
+			t.Fatalf("removed result = %#v, want none", removed)
+		}
+	})
 }
 
 func TestJobTrackingState_StageCgroupBasename_RejectsCrossJobOwner(t *testing.T) {

--- a/internal/agent/kerneltracker/kernel_sample_cgroup_handle.go
+++ b/internal/agent/kerneltracker/kernel_sample_cgroup_handle.go
@@ -100,3 +100,28 @@ func handleCgroupRmdirSample(state *jobTrackingState, sample cgroupRmdirSample) 
 
 	return nil
 }
+
+func handleCgroupLivenessReconciliation(state *jobTrackingState, command commandReconcileCgroupLiveness) []engineEffect {
+	removed := state.reconcileCgroupLiveness(command.LiveCgroupIDs, command.ScanStartedAt, command.CheckedAt)
+	if len(removed) == 0 {
+		return nil
+	}
+
+	var effects []engineEffect
+	drainedJobs := 0
+	for _, result := range removed {
+		if result.JobDrained {
+			drainedJobs++
+			effects = append(effects, notifyJobEnded{JobID: result.JobID, Reason: EndCgroupRmdir})
+		}
+	}
+	if state.logger != nil {
+		state.logger.Info("cgroup_liveness_reconciled",
+			"removed_count", len(removed),
+			"drained_job_count", drainedJobs,
+			"live_cgroup_count", len(command.LiveCgroupIDs),
+			"stat_error_count", command.StatErrorCount,
+		)
+	}
+	return effects
+}

--- a/internal/agent/kerneltracker/kernel_sample_cgroup_integration_linux_test.go
+++ b/internal/agent/kerneltracker/kernel_sample_cgroup_integration_linux_test.go
@@ -297,6 +297,68 @@ func TestLinuxKernelSampleCgroupFinalRmdirRemoveJobCleanup(t *testing.T) {
 	}
 }
 
+func TestLinuxKernelSampleCgroupLivenessReconciliation(t *testing.T) {
+	kernelIO, cgroupRoot := newLinuxKernelIO(t)
+	defer kernelIO.Close()
+
+	parentPID := int32(os.Getpid())
+	parentCgroupPath, err := currentCgroupPath(parentPID)
+	if err != nil {
+		t.Fatalf("currentCgroupPath: %v", err)
+	}
+
+	childName := fmt.Sprintf("cicd-sensor-liveness-%d", time.Now().UnixNano())
+	childPath := filepath.Join(parentCgroupPath, childName)
+	childFullPath := mustCgroupFSPath(t, cgroupRoot, childPath)
+	if err := os.Mkdir(childFullPath, 0o755); err != nil {
+		t.Fatalf("Mkdir(%q): %v", childFullPath, err)
+	}
+	cleanupChild := true
+	t.Cleanup(func() {
+		if cleanupChild {
+			_ = os.Remove(childFullPath)
+		}
+	})
+
+	childCgroupID, err := cgroupIDForPath(cgroupRoot, childPath)
+	if err != nil {
+		t.Fatalf("cgroupIDForPath(%q): %v", childPath, err)
+	}
+	liveSnapshot, err := scanLiveCgroupIDs(cgroupRoot)
+	if err != nil {
+		t.Fatalf("scanLiveCgroupIDs live child: %v", err)
+	}
+	if _, ok := liveSnapshot.LiveCgroupIDs[childCgroupID]; !ok {
+		t.Fatalf("live child cgroup %d was not found by cgroup liveness scan", childCgroupID)
+	}
+
+	scanStartedAt := time.Now().UTC()
+	jobID := jobcontext.GitLabJobIdentity("gitlab.com", "group/project", "123")
+	state := newJobTrackingState()
+	state.registerJob(jobID, defaultEventRecordBufferSize)
+	state.bindAt(jobID, childCgroupID, scanStartedAt.Add(-time.Second))
+
+	if err := os.Remove(childFullPath); err != nil {
+		t.Fatalf("Remove(%q): %v", childFullPath, err)
+	}
+	cleanupChild = false
+
+	missingSnapshot, err := scanLiveCgroupIDs(cgroupRoot)
+	if err != nil {
+		t.Fatalf("scanLiveCgroupIDs missing child: %v", err)
+	}
+	if _, ok := missingSnapshot.LiveCgroupIDs[childCgroupID]; ok {
+		t.Fatalf("removed child cgroup %d was still found by cgroup liveness scan", childCgroupID)
+	}
+
+	effects := handleEngineInput(state, commandReconcileCgroupLiveness{
+		ScanStartedAt: scanStartedAt,
+		CheckedAt:     time.Now().UTC(),
+		LiveCgroupIDs: missingSnapshot.LiveCgroupIDs,
+	})
+	assertEffectOrder(t, effects, notifyJobEnded{})
+}
+
 func TestLinuxKernelSampleCgroupAttachExternal(t *testing.T) {
 	kernelIO, cgroupRoot := newLinuxKernelIO(t)
 	defer kernelIO.Close()


### PR DESCRIPTION
## What

Adds periodic cgroup liveness reconciliation to KernelTracker.

- Scans the cgroup v2 root from userspace every minute.
- Compares live cgroup directory inode numbers with active tracked cgroup IDs.
- Moves missing active cgroups into the same removed-pending path used by `cgroup_rmdir`.
- Ends the Job with the existing `EndCgroupRmdir` reason when the last active cgroup is found missing.
- Keeps scan work outside the KernelTracker owner loop; the loop only receives immutable scan results.
- Logs `cgroup_liveness_reconciled` only when reconciliation actually changes state.

## Why

`cgroup_rmdir` is still the primary deletion signal, but ring buffer drops or other missed samples can leave tracked cgroups and Jobs stale forever.

This change makes scan-based reconciliation a safety net: it does not delete cgroups immediately, and it does not introduce a separate lifecycle path. Instead, it compensates for missed `rmdir` samples by joining the same removed-pending, grace, and purge flow.

GKE Standard / COS scan measurements showed full cgroup v2 scans are small enough for this initial implementation, and the scan runs asynchronously so it does not block sample handling.

## Validation

- `GOCACHE=$PWD/.gocache go test -count=1 ./internal/agent/kerneltracker`
- `GOCACHE=$PWD/.gocache go test -race -count=1 ./internal/agent/kerneltracker`

## Notes

The periodic scan is a fallback for missed `cgroup_rmdir` samples. It does not replace the rmdir path.

When the scan finds a missing active tracked cgroup, the tracker moves it through the same removed-pending path as rmdir. If that was the Job's last active cgroup, the Job is ended immediately with `EndCgroupRmdir`; only the kernel/userspace cleanup is delayed by the existing grace period.