### PR TITLE
fix: avoid nil-pointer panic when kernel tracker attach fails

### DIFF
--- a/internal/agent/kerneltracker/kernelio/kernel_io_linux.go
+++ b/internal/agent/kerneltracker/kernelio/kernel_io_linux.go
@@ -56,12 +56,15 @@ func NewLinux(logger *slog.Logger, config Config) (kernelIO *LinuxKernelIO, err 
 
 	// NewLinux fails fast on any attach/open error, but earlier steps may
 	// already have loaded objects or attached links. Roll those back here
-	// because no caller-owned LinuxKernelIO exists on failure.
+	// because no caller-owned LinuxKernelIO exists on failure. The error
+	// paths `return nil, err`, which nils the named return value, so hold a
+	// stable handle rather than closing kernelIO directly.
+	rollback := kernelIO
 	defer func() {
 		if err == nil {
 			return
 		}
-		_ = kernelIO.Close()
+		_ = rollback.Close()
 	}()
 
 	// fentry/security_file_open is used instead of BPF LSM so deployments do

--- a/internal/agent/kerneltracker/kernelio/kernel_io_loop_linux.go
+++ b/internal/agent/kerneltracker/kernelio/kernel_io_loop_linux.go
@@ -148,6 +148,10 @@ func (kernelIO *LinuxKernelIO) readRingbufDropCount() (uint64, error) {
 
 // Close releases the ring buffer reader, tracing links, and loaded objects.
 func (kernelIO *LinuxKernelIO) Close() error {
+	if kernelIO == nil {
+		return nil
+	}
+
 	var firstErr error
 
 	if kernelIO.cancelLoop != nil {

--- a/internal/agent/kerneltracker/kernelio/kernel_io_loop_linux_test.go
+++ b/internal/agent/kerneltracker/kernelio/kernel_io_loop_linux_test.go
@@ -39,6 +39,15 @@ func TestCloseZeroValueKernelIO(t *testing.T) {
 	}
 }
 
+func TestCloseNilReceiver(t *testing.T) {
+	t.Parallel()
+
+	var kernelIO *LinuxKernelIO
+	if err := kernelIO.Close(); err != nil {
+		t.Fatalf("Close returned error: %v", err)
+	}
+}
+
 func TestReadRingbufDropCountRequiresMap(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

`NewLinux` (agent kernel tracker) panics with a nil-pointer dereference when attaching its tracing programs fails, instead of returning the underlying attach error.

`NewLinux` uses named return values and rolls back on error with a deferred `kernelIO.Close()`. The error paths use `return nil, err`, which sets the named return `kernelIO` to nil before the defer runs. The rollback (`NewLinux.func1`) then calls `Close()` on a nil receiver, which segfaults (SIGSEGV) and hides the real error. Captured panic (v0.0.39, lower frames trimmed):

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x158 pc=0x70dd60]

goroutine 1 [running]:
github.com/cicd-sensor/cicd-sensor/internal/agent/kerneltracker/kernelio.(*LinuxKernelIO).Close(0x0)
	github.com/cicd-sensor/cicd-sensor/internal/agent/kerneltracker/kernelio/kernel_io_loop_linux.go:153 +0x20
github.com/cicd-sensor/cicd-sensor/internal/agent/kerneltracker/kernelio.NewLinux.func1()
	github.com/cicd-sensor/cicd-sensor/internal/agent/kerneltracker/kernelio/kernel_io_linux.go:64 +0x2c
github.com/cicd-sensor/cicd-sensor/internal/agent/kerneltracker/kernelio.NewLinux(0x0?, {{0x77f393aa54dd?, 0x101a578?}})
	github.com/cicd-sensor/cicd-sensor/internal/agent/kerneltracker/kernelio/kernel_io_linux.go:94 +0x5b4
[... kerneltracker.New -> agent.(*Agent).Run -> main.runAgentStart -> main.main]
```

This is independent of why the attach fails. I hit it on an arm64 host whose kernel lacks ftrace direct-call support: attaching fentry programs needs `CONFIG_DYNAMIC_FTRACE_WITH_DIRECT_CALLS` (`DYNAMIC_FTRACE_WITH_CALL_OPS` on arm64), so `link.AttachTracing` returned `ENOTSUPP` on Amazon Linux 2023's default 6.1 kernel on Graviton (it works on 6.12). Instead of reporting that attach error, the agent panicked.

Changes:
- `NewLinux`: capture a stable handle for the deferred rollback so it closes the partially built instance instead of the nil named return value.
- `Close`: tolerate a nil receiver.
- add a regression test for `Close` on a nil receiver.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / cleanup
- [ ] Docs
- [ ] CI / tooling
- [ ] Other:

## Test plan

Static checks:
- `gofmt -l` clean; `GOOS=linux GOARCH=arm64 go build` and `go vet ./...` clean (developing on macOS, cross-compiled to the linux/arm64 target).
- Added `TestCloseNilReceiver`. The package is `//go:build linux`, so its tests run in CI, not on my dev machine; the BPF integration test additionally needs a privileged Linux host.

Verified on Amazon Linux 2023 kernel 6.1.175 (aarch64), running both binaries on the same host with `CICD_SENSOR_MANAGER_TOKEN` set so the agent reaches the attach:

- Released `v0.0.39`: logs `agent_started`, then crashes with the nil-pointer panic above (exit 2).
- Patched build: logs `agent_started`, then exits non-zero (exit 1) with a normal error instead of panicking:
  ```
  ERROR agent_failed error="new kernel tracker: new kernel io: attach cgroup_attach_task tracing program: create raw tracepoint: not supported"
  ```

`strace` on `v0.0.39` shows the underlying failure as `bpf(BPF_RAW_TRACEPOINT_OPEN, {name=NULL, ...}) = -1 ENOTSUPP`. For reference, on kernel 6.12 (which has `CONFIG_DYNAMIC_FTRACE_WITH_CALL_OPS=y`) the agent runs cleanly (active, 0 restarts), so the failing attach path is not exercised there.

## Checklist

- [ ] `go test ./...` passes locally (not run: the package is `//go:build linux` and the BPF integration test needs a privileged Linux host; covered by CI)
- [x] `gofmt -l` and `go vet ./...` are clean
- [x] Docs and rule samples are updated if behavior changed (N/A: the change makes the attach failure return an error instead of panicking; no doc or rule behavior change)
- [x] No secrets, credentials, or unrelated changes included
