### PR TITLE
fix(rules): cover file_move/file_link persistence landings (#107)

### DIFF
--- a/internal/rulesource/persistence_bypass_test.go
+++ b/internal/rulesource/persistence_bypass_test.go
@@ -1,0 +1,129 @@
+package rulesource_test
+
+import (
+	"testing"
+
+	"github.com/cicd-sensor/cicd-sensor/internal/jobevent"
+	"github.com/cicd-sensor/cicd-sensor/internal/rule"
+	"github.com/cicd-sensor/cicd-sensor/internal/rule/celengine"
+	"github.com/cicd-sensor/cicd-sensor/internal/rulesource"
+)
+
+// TestPersistenceRulesCoverMoveAndLinkBypass is the regression guard for
+// issue #107: protected-path persistence rules must match across file_open,
+// file_move (mv / rename), and file_link (ln) so that staging a payload and
+// then renaming or linking it into a protected location is not a detection
+// blind spot. It loads the actually shipped baseline ruleset and evaluates
+// the real rule conditions, so it fails if a rule is removed or narrowed.
+func TestPersistenceRulesCoverMoveAndLinkBypass(t *testing.T) {
+	t.Parallel()
+
+	loaded, err := rulesource.LoadRulesFile("../../rules/generic-persistence.yaml")
+	if err != nil {
+		t.Fatalf("load persistence rules: %v", err)
+	}
+	if len(loaded.RuleSets) != 1 {
+		t.Fatalf("expected 1 ruleset, got %d", len(loaded.RuleSets))
+	}
+	set := loaded.RuleSets[0]
+
+	byID := make(map[string]rule.Rule, len(set.Rules))
+	for _, r := range set.Rules {
+		byID[r.RuleID] = r
+	}
+
+	env, err := celengine.NewEnv()
+	if err != nil {
+		t.Fatalf("new env: %v", err)
+	}
+
+	cases := []struct {
+		ruleID    string
+		input     celengine.CELInputEvent
+		wantMatch bool
+	}{
+		// Cron: write, rename, and link into /etc/cron.d all detect.
+		{"cron_write", celengine.CELInputEvent{Path: "/etc/cron.d/evil", IsWrite: true}, true},
+		{"cron_write", celengine.CELInputEvent{Path: "/etc/crontab", IsWrite: true}, true},
+		{"cron_write", celengine.CELInputEvent{Path: "/etc/cron.d/evil", IsWrite: false}, false},
+		{"cron_move", celengine.CELInputEvent{FromPath: "/tmp/job", ToPath: "/etc/cron.d/evil"}, true},
+		{"cron_move", celengine.CELInputEvent{FromPath: "/tmp/a", ToPath: "/tmp/b"}, false},
+		{"cron_link", celengine.CELInputEvent{CreatedPath: "/etc/cron.d/evil", ExistingPath: "/tmp/job", IsSymlink: true}, true},
+
+		// Shell startup files.
+		{"shell_rc_write", celengine.CELInputEvent{Path: "/home/runner/.bashrc", IsWrite: true}, true},
+		{"shell_rc_write", celengine.CELInputEvent{Path: "/etc/profile.d/evil.sh", IsWrite: true}, true},
+		{"shell_rc_move", celengine.CELInputEvent{FromPath: "/tmp/rc", ToPath: "/home/runner/.bashrc"}, true},
+		{"shell_rc_link", celengine.CELInputEvent{CreatedPath: "/home/runner/.zshrc", ExistingPath: "/tmp/rc", IsSymlink: true}, true},
+
+		// Dynamic linker preload.
+		{"ld_so_preload_write", celengine.CELInputEvent{Path: "/etc/ld.so.preload", IsWrite: true}, true},
+		{"ld_so_preload_move", celengine.CELInputEvent{FromPath: "/tmp/p", ToPath: "/etc/ld.so.preload"}, true},
+		{"ld_so_preload_link", celengine.CELInputEvent{CreatedPath: "/etc/ld.so.conf.d/evil.conf", ExistingPath: "/tmp/p", IsHardlink: true}, true},
+
+		// User systemd service unit (same move/link gap closed).
+		{"user_systemd_service_move", celengine.CELInputEvent{FromPath: "/tmp/x.service", ToPath: "/home/runner/.config/systemd/user/x.service"}, true},
+		{"user_systemd_service_link", celengine.CELInputEvent{CreatedPath: "/home/runner/.config/systemd/user/x.service", ExistingPath: "/tmp/x.service", IsSymlink: true}, true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.ruleID+"/"+caseLabel(tc.input), func(t *testing.T) {
+			t.Parallel()
+
+			r, ok := byID[tc.ruleID]
+			if !ok {
+				t.Fatalf("rule %q not present in shipped ruleset", tc.ruleID)
+			}
+
+			prog, err := env.Compile(r.RuleID, r.EventType, r.Condition, set.Lists)
+			if err != nil {
+				t.Fatalf("compile %s: %v", r.RuleID, err)
+			}
+			staticActivation, err := celengine.NewListActivation(rule.NormalizePredefinedLists(set.Lists))
+			if err != nil {
+				t.Fatalf("list activation: %v", err)
+			}
+			matched, err := prog.EvalActivation(celengine.NewEventActivation(tc.input).WithParent(staticActivation))
+			if err != nil {
+				t.Fatalf("eval %s: %v", r.RuleID, err)
+			}
+			if matched != tc.wantMatch {
+				t.Fatalf("rule %s matched=%v, want %v", r.RuleID, matched, tc.wantMatch)
+			}
+		})
+	}
+
+	// Guard the event-type coverage explicitly: each persistence category
+	// must ship a rule for every primitive an attacker can reach it through.
+	for _, ids := range [][3]string{
+		{"cron_write", "cron_move", "cron_link"},
+		{"shell_rc_write", "shell_rc_move", "shell_rc_link"},
+		{"ld_so_preload_write", "ld_so_preload_move", "ld_so_preload_link"},
+	} {
+		wantType := map[string]jobevent.Type{
+			ids[0]: jobevent.FileOpen,
+			ids[1]: jobevent.FileMove,
+			ids[2]: jobevent.FileLink,
+		}
+		for id, want := range wantType {
+			r, ok := byID[id]
+			if !ok {
+				t.Fatalf("expected rule %q to be shipped", id)
+			}
+			if r.EventType != want {
+				t.Fatalf("rule %q event_type=%q, want %q", id, r.EventType, want)
+			}
+		}
+	}
+}
+
+func caseLabel(in celengine.CELInputEvent) string {
+	switch {
+	case in.ToPath != "":
+		return "to=" + in.ToPath
+	case in.CreatedPath != "":
+		return "link=" + in.CreatedPath
+	default:
+		return "path=" + in.Path
+	}
+}

--- a/rules/generic-persistence.yaml
+++ b/rules/generic-persistence.yaml
@@ -18,6 +18,53 @@ rule_sets:
         - "restart"
         - "start"
 
+      # Cron persistence locations. Matched with contains() so that any file
+      # created, renamed, or linked inside these directories is covered.
+      cron_persistence_dirs:
+        - "/etc/cron.d/"
+        - "/etc/cron.hourly/"
+        - "/etc/cron.daily/"
+        - "/etc/cron.weekly/"
+        - "/etc/cron.monthly/"
+        - "/var/spool/cron/"
+
+      cron_persistence_files:
+        - "/etc/crontab"
+
+      # Shell startup files (system-wide and per-user). System directories use
+      # contains(); per-user dotfiles use endsWith() against the home path.
+      shell_rc_dirs:
+        - "/etc/profile.d/"
+
+      shell_rc_files:
+        - "/etc/profile"
+        - "/etc/bashrc"
+        - "/etc/bash.bashrc"
+        - "/etc/zshrc"
+        - "/etc/zshenv"
+        - "/etc/zsh/zshrc"
+        - "/etc/zsh/zshenv"
+        - "/etc/zsh/zprofile"
+
+      shell_rc_suffixes:
+        - "/.bashrc"
+        - "/.bash_profile"
+        - "/.bash_login"
+        - "/.bash_logout"
+        - "/.profile"
+        - "/.zshrc"
+        - "/.zshenv"
+        - "/.zprofile"
+        - "/.zlogin"
+
+      # Dynamic-linker preload / config locations.
+      ld_preload_dirs:
+        - "/etc/ld.so.conf.d/"
+
+      ld_preload_files:
+        - "/etc/ld.so.preload"
+        - "/etc/ld.so.conf"
+
     rules:
       - rule_id: systemctl_user_persistence_operation
         rule_name: "Supply-chain: user systemd persistence operation"
@@ -98,6 +145,216 @@ rule_sets:
           process.ancestors.exists(a,
             list.python_suffixes.exists(p, a.exec_path.endsWith(p))
           )
+        action: detect
+        tags:
+          mitre_tactic: persistence
+
+      # --- Cron persistence -------------------------------------------------
+      # cron_write/_move/_link cover the three ways a payload reaches a
+      # protected cron location: writing it open(O_WRONLY), renaming a file
+      # already staged elsewhere (mv), or linking it in (ln). A rule bound to
+      # file_open alone is bypassed by the move/link primitives, so each
+      # protected location is monitored across all three event types.
+      - rule_id: cron_write
+        rule_name: "Supply-chain: cron persistence file write"
+        description: |
+          What:
+            Detects writes to system cron locations (/etc/cron.*, /etc/crontab, /var/spool/cron).
+          Why:
+            Dropping a job into a cron directory persists payload execution outside the CI job lineage.
+          Notes:
+            Package installs (dpkg/rpm) can legitimately write /etc/cron.d entries; correlate with payload download or unexpected ancestry.
+        event_type: file_open
+        condition: |
+          is_write &&
+          (
+            list.cron_persistence_dirs.exists(d, path.contains(d)) ||
+            list.cron_persistence_files.exists(f, path == f)
+          )
+        action: detect
+        tags:
+          mitre_tactic: persistence
+
+      - rule_id: cron_move
+        rule_name: "Supply-chain: cron persistence file move (rename bypass)"
+        description: |
+          What:
+            Detects a rename whose destination is a system cron location.
+          Why:
+            Renaming a staged file into /etc/cron.d (mv) reaches the same persistence as a direct write but emits file_move instead of file_open, evading write-only rules.
+          Notes:
+            Inspect the source path and the moved content; package tooling rarely renames into cron directories.
+        event_type: file_move
+        condition: |
+          list.cron_persistence_dirs.exists(d, to_path.contains(d)) ||
+          list.cron_persistence_files.exists(f, to_path == f)
+        action: detect
+        tags:
+          mitre_tactic: persistence
+
+      - rule_id: cron_link
+        rule_name: "Supply-chain: cron persistence file link (link bypass)"
+        description: |
+          What:
+            Detects a hardlink or symlink created inside a system cron location.
+          Why:
+            Linking a file into /etc/cron.d (ln) installs cron persistence without a write to the protected path, evading write-only rules.
+          Notes:
+            Review the link target; legitimate workflows seldom link into cron directories.
+        event_type: file_link
+        condition: |
+          list.cron_persistence_dirs.exists(d, created_path.contains(d)) ||
+          list.cron_persistence_files.exists(f, created_path == f)
+        action: detect
+        tags:
+          mitre_tactic: persistence
+
+      # --- Shell startup persistence ---------------------------------------
+      - rule_id: shell_rc_write
+        rule_name: "Supply-chain: shell startup file write"
+        description: |
+          What:
+            Detects writes to shell startup files (/etc/profile, /etc/profile.d, *.bashrc, *.zshrc, *.profile, ...).
+          Why:
+            Shell rc files execute on every interactive/login shell, persisting a payload across sessions and jobs.
+          Notes:
+            Toolchain installers (nvm, rustup, conda, pyenv) commonly append to ~/.bashrc or ~/.profile; tune with an exception for the specific installer if needed.
+        event_type: file_open
+        condition: |
+          is_write &&
+          (
+            list.shell_rc_dirs.exists(d, path.contains(d)) ||
+            list.shell_rc_files.exists(f, path == f) ||
+            list.shell_rc_suffixes.exists(s, path.endsWith(s))
+          )
+        action: detect
+        tags:
+          mitre_tactic: persistence
+
+      - rule_id: shell_rc_move
+        rule_name: "Supply-chain: shell startup file move (rename bypass)"
+        description: |
+          What:
+            Detects a rename whose destination is a shell startup file.
+          Why:
+            Renaming a staged file over ~/.bashrc or into /etc/profile.d reaches shell-rc persistence while emitting file_move instead of file_open.
+          Notes:
+            Inspect the source path and content; correlate with unexpected ancestry.
+        event_type: file_move
+        condition: |
+          list.shell_rc_dirs.exists(d, to_path.contains(d)) ||
+          list.shell_rc_files.exists(f, to_path == f) ||
+          list.shell_rc_suffixes.exists(s, to_path.endsWith(s))
+        action: detect
+        tags:
+          mitre_tactic: persistence
+
+      - rule_id: shell_rc_link
+        rule_name: "Supply-chain: shell startup file link (link bypass)"
+        description: |
+          What:
+            Detects a hardlink or symlink created at a shell startup file path.
+          Why:
+            Linking a payload into a shell rc path installs persistence without writing the protected path, evading write-only rules.
+          Notes:
+            Review the link target before treating it as benign.
+        event_type: file_link
+        condition: |
+          list.shell_rc_dirs.exists(d, created_path.contains(d)) ||
+          list.shell_rc_files.exists(f, created_path == f) ||
+          list.shell_rc_suffixes.exists(s, created_path.endsWith(s))
+        action: detect
+        tags:
+          mitre_tactic: persistence
+
+      # --- Dynamic linker preload (defense evasion) ------------------------
+      - rule_id: ld_so_preload_write
+        rule_name: "Supply-chain: dynamic linker preload write"
+        description: |
+          What:
+            Detects writes to /etc/ld.so.preload, /etc/ld.so.conf, or /etc/ld.so.conf.d.
+          Why:
+            ld.so.preload forces a shared object into every dynamically linked process — a classic library-injection persistence and defense-evasion primitive.
+          Notes:
+            These files are almost never written during normal CI; investigate any match.
+        event_type: file_open
+        condition: |
+          is_write &&
+          (
+            list.ld_preload_files.exists(f, path == f) ||
+            list.ld_preload_dirs.exists(d, path.contains(d))
+          )
+        action: detect
+        tags:
+          mitre_tactic: defense-evasion,persistence
+
+      - rule_id: ld_so_preload_move
+        rule_name: "Supply-chain: dynamic linker preload move (rename bypass)"
+        description: |
+          What:
+            Detects a rename whose destination is an ld.so preload/config path.
+          Why:
+            Renaming a staged file over /etc/ld.so.preload reaches the same injection primitive while emitting file_move instead of file_open.
+          Notes:
+            Investigate any match; legitimate tooling does not rename into these paths.
+        event_type: file_move
+        condition: |
+          list.ld_preload_files.exists(f, to_path == f) ||
+          list.ld_preload_dirs.exists(d, to_path.contains(d))
+        action: detect
+        tags:
+          mitre_tactic: defense-evasion,persistence
+
+      - rule_id: ld_so_preload_link
+        rule_name: "Supply-chain: dynamic linker preload link (link bypass)"
+        description: |
+          What:
+            Detects a hardlink or symlink created at an ld.so preload/config path.
+          Why:
+            Linking a controlled file into /etc/ld.so.preload installs library injection without writing the protected path, evading write-only rules.
+          Notes:
+            Investigate any match.
+        event_type: file_link
+        condition: |
+          list.ld_preload_files.exists(f, created_path == f) ||
+          list.ld_preload_dirs.exists(d, created_path.contains(d))
+        action: detect
+        tags:
+          mitre_tactic: defense-evasion,persistence
+
+      # --- User systemd service (close the same move/link gap) -------------
+      # user_systemd_service_write (above) is file_open-only and is bypassed
+      # by the same rename/link primitives; these cover the gap.
+      - rule_id: user_systemd_service_move
+        rule_name: "Supply-chain: user systemd service move (rename bypass)"
+        description: |
+          What:
+            Detects a rename whose destination is a user systemd service unit.
+          Why:
+            Renaming a staged .service into ~/.config/systemd/user persists payload execution while emitting file_move instead of file_open.
+          Notes:
+            Inspect the unit content and the writing process ancestry.
+        event_type: file_move
+        condition: |
+          to_path.endsWith(".service") &&
+          list.user_systemd_fragments.exists(p, to_path.contains(p))
+        action: detect
+        tags:
+          mitre_tactic: persistence
+
+      - rule_id: user_systemd_service_link
+        rule_name: "Supply-chain: user systemd service link (link bypass)"
+        description: |
+          What:
+            Detects a hardlink or symlink created at a user systemd service unit path.
+          Why:
+            Linking a .service into ~/.config/systemd/user installs persistence without writing the protected path, evading write-only rules.
+          Notes:
+            Inspect the link target and unit content.
+        event_type: file_link
+        condition: |
+          created_path.endsWith(".service") &&
+          list.user_systemd_fragments.exists(p, created_path.contains(p))
         action: detect
         tags:
           mitre_tactic: persistence


### PR DESCRIPTION
Narrowed from the original #48 proposal to just the rule-coverage half (#107), per the direction in #108. The eBPF/mount-observability side (#108) is left to a separate PR.

**Problem:** persistence/tamper rules matched only `file_open && is_write` on a path string, so a payload renamed (`mv` → `file_move`) or linked (`ln` → `file_link`) into a protected location was not detected. Both events are already observed and CEL-exposed; no rule consumed them.

**Fix (rule layer only, no new observability):** protected-path lists plus `_write`/`_move`/`_link` triplets for cron, shell rc, and `ld.so.preload`, plus `user_systemd_service_move`/`_link`. `_write` matches `path`, `_move` matches `to_path`, `_link` matches `created_path`.

**Dropped from this PR (now #108, maintainer-owned):** `resolved_path` on `file_open` and the write-time dentry walk that filled it, the proto/CEL surface, and the bind-mount integration test.

**Testing:** `internal/rulesource/persistence_bypass_test.go` loads the shipped ruleset and asserts write/move/link matches incl. negatives, plus an event-type coverage guard. `make rules-validate` / `rules-bundle-validate` pass.
