### PR TITLE
feat(manager): add use_path_style option for S3-compatible sinks

### DIFF
--- a/docs/user-guide/manager.md
+++ b/docs/user-guide/manager.md
@@ -216,11 +216,11 @@ Use this mapping to choose patterns such as storing all logs in one GCS destinat
 
 ### Sink settings
 
-| Sink type | Required settings | Notes |
-| --- | --- | --- |
-| `aws_s3` | `uri`, `region` | `uri` is an `s3://...` object-storage URI. Include any desired object key path in the URI. |
-| `google_storage` | `uri` | `uri` is a `gs://...` object-storage URI. Include any desired object key path in the URI. |
-| `google_pubsub` | `project_id`, `topic` | Publishes one plain JSON record per message. |
+| Sink type | Required settings | Optional settings | Notes |
+| --- | --- | --- | --- |
+| `aws_s3` | `uri`, `region` | `use_path_style` | `uri` is an `s3://...` object-storage URI. Include any desired object key path in the URI. Set `use_path_style: true` to use path-style addressing (`endpoint/bucket`) instead of virtual-hosted-style (`bucket.endpoint`). |
+| `google_storage` | `uri` | | `uri` is a `gs://...` object-storage URI. Include any desired object key path in the URI. |
+| `google_pubsub` | `project_id`, `topic` | | Publishes one plain JSON record per message. |
 
 Store logs in GCS:
 

--- a/internal/manager/output_router.go
+++ b/internal/manager/output_router.go
@@ -91,7 +91,7 @@ func BuildOutputs(ctx context.Context, logger *slog.Logger, sinks SinksConfig, l
 func buildNamedSink(ctx context.Context, logger *slog.Logger, sc SinkConfig) (sink.Sink, error) {
 	switch sc.Type {
 	case "aws_s3":
-		return sink.NewS3(ctx, sc.URI, sc.Region)
+		return sink.NewS3(ctx, sc.URI, sc.Region, sc.UsePathStyle)
 	case "google_storage":
 		return sink.NewGCS(ctx, sc.URI)
 	case "google_pubsub":

--- a/internal/manager/sink/s3.go
+++ b/internal/manager/sink/s3.go
@@ -36,7 +36,9 @@ const (
 
 // NewS3 creates an S3-backed Sink using the AWS default credential chain.
 // uri must be an s3:// URI; any path component becomes the object key prefix.
-func NewS3(ctx context.Context, uri, region string) (Sink, error) {
+// When usePathStyle is true the client uses path-style addressing
+// (e.g. endpoint/bucket) instead of virtual-hosted-style (bucket.endpoint).
+func NewS3(ctx context.Context, uri, region string, usePathStyle bool) (Sink, error) {
 	bucket, prefix, err := parseObjectURI("s3", uri)
 	if err != nil {
 		return nil, fmt.Errorf("invalid s3 uri: %w", err)
@@ -49,8 +51,14 @@ func NewS3(ctx context.Context, uri, region string) (Sink, error) {
 	if err != nil {
 		return nil, fmt.Errorf("load AWS config: %w", err)
 	}
+	var s3Opts []func(*s3.Options)
+	if usePathStyle {
+		s3Opts = append(s3Opts, func(o *s3.Options) {
+			o.UsePathStyle = true
+		})
+	}
 	return &s3Sink{
-		client: s3.NewFromConfig(cfg),
+		client: s3.NewFromConfig(cfg, s3Opts...),
 		bucket: bucket,
 		prefix: prefix,
 	}, nil

--- a/internal/manager/startup_config.go
+++ b/internal/manager/startup_config.go
@@ -40,11 +40,12 @@ type SinksConfig map[string]SinkConfig
 
 // SinkConfig describes one physical manager output destination.
 type SinkConfig struct {
-	Type      string `yaml:"type"`
-	URI       string `yaml:"uri,omitempty"`
-	Region    string `yaml:"region,omitempty"`
-	ProjectID string `yaml:"project_id,omitempty"`
-	Topic     string `yaml:"topic,omitempty"`
+	Type         string `yaml:"type"`
+	URI          string `yaml:"uri,omitempty"`
+	Region       string `yaml:"region,omitempty"`
+	UsePathStyle bool   `yaml:"use_path_style,omitempty"`
+	ProjectID    string `yaml:"project_id,omitempty"`
+	Topic        string `yaml:"topic,omitempty"`
 }
 
 // LogsConfig maps a log type to one sink name.
@@ -149,6 +150,9 @@ func validateGCSSink(name string, sc SinkConfig) error {
 	if sc.Region != "" || sc.ProjectID != "" || sc.Topic != "" {
 		return fmt.Errorf("sinks.%s: region, project_id, and topic are not valid for google_storage", name)
 	}
+	if sc.UsePathStyle {
+		return fmt.Errorf("sinks.%s: use_path_style is only valid for aws_s3", name)
+	}
 	return nil
 }
 
@@ -161,6 +165,9 @@ func validatePubSubSink(name string, sc SinkConfig) error {
 	}
 	if sc.Region != "" || sc.URI != "" {
 		return fmt.Errorf("sinks.%s: region and uri are not valid for google_pubsub", name)
+	}
+	if sc.UsePathStyle {
+		return fmt.Errorf("sinks.%s: use_path_style is only valid for aws_s3", name)
 	}
 	return nil
 }

--- a/internal/manager/startup_config_test.go
+++ b/internal/manager/startup_config_test.go
@@ -247,6 +247,45 @@ sinks:
 			wantErr: "sinks.s3-prod.region is required for aws_s3",
 		},
 		{
+			name: "s3_sink_use_path_style",
+			body: `
+sinks:
+  s3-compat:
+    type: aws_s3
+    uri: s3://my-bucket/logs/
+    region: us-east-1
+    use_path_style: true
+logs:
+  detection:
+    sink: s3-compat
+`,
+			assertCfg: func(t *testing.T, cfg StartupConfig) {
+				t.Helper()
+				if !cfg.Sinks["s3-compat"].UsePathStyle {
+					t.Fatal("use_path_style: got false, want true")
+				}
+			},
+		},
+		{
+			name: "s3_sink_use_path_style_default_false",
+			body: `
+sinks:
+  s3-prod:
+    type: aws_s3
+    uri: s3://my-bucket/logs/
+    region: us-east-1
+logs:
+  detection:
+    sink: s3-prod
+`,
+			assertCfg: func(t *testing.T, cfg StartupConfig) {
+				t.Helper()
+				if cfg.Sinks["s3-prod"].UsePathStyle {
+					t.Fatal("use_path_style: got true, want false")
+				}
+			},
+		},
+		{
 			name: "s3_sink_with_pubsub_fields",
 			body: `
 sinks:
@@ -278,6 +317,17 @@ sinks:
 			wantErr: "sinks.gcs-prod.uri must start with gs://",
 		},
 		{
+			name: "gcs_sink_with_path_style",
+			body: `
+sinks:
+  gcs-prod:
+    type: google_storage
+    uri: gs://bucket/logs
+    use_path_style: true
+`,
+			wantErr: "sinks.gcs-prod: use_path_style is only valid for aws_s3",
+		},
+		{
 			name: "gcs_sink_with_pubsub_fields",
 			body: `
 sinks:
@@ -307,6 +357,18 @@ sinks:
     project_id: project
 `,
 			wantErr: "sinks.pubsub-detect.topic is required for google_pubsub",
+		},
+		{
+			name: "pubsub_sink_with_path_style",
+			body: `
+sinks:
+  pubsub-detect:
+    type: google_pubsub
+    project_id: project
+    topic: detections
+    use_path_style: true
+`,
+			wantErr: "sinks.pubsub-detect: use_path_style is only valid for aws_s3",
 		},
 		{
 			name: "pubsub_sink_with_object_storage_fields",


### PR DESCRIPTION
<!--
Thanks for contributing to cicd-sensor!
Please fill in the sections below. Use Conventional Commits in the PR title.
-->

## Summary

<!-- What does this change do, and why? Link related issues with "Fixes #123" / "Refs #123". -->

S3-compatible object stores such as MinIO and LocalStack require path-style addressing (`endpoint/bucket`) instead of virtual-hosted-style  (`bucket.endpoint`).
Add a `use_path_style` option to the `aws_s3` sink to enable this. The option is validated to be S3-only — setting it on `google_storage` or `google_pubsub` sinks returns a config error.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor / cleanup
- [ ] Docs
- [ ] CI / tooling
- [ ] Other:

## Test plan

<!-- How did you verify this works? Commands run, scenarios covered, manual checks performed. -->

- [x] Config parse test verifies `use_path_style: true` is reflected in the sink config
- [x] Config parse test verifies the default is `false` when omitted
- [x] Validation tests confirm `use_path_style` on `google_storage` / `google_pubsub` produces an error

## Checklist

- [x] `go test ./...` passes locally
- [x] `gofmt -l` and `go vet ./...` are clean
- [x] Docs and rule samples are updated if behavior changed
- [x] No secrets, credentials, or unrelated changes included
