### PR TITLE
fix(rules): reduce persistence rule false positives

### DIFF
--- a/internal/rulesource/persistence_bypass_test.go
+++ b/internal/rulesource/persistence_bypass_test.go
@@ -42,24 +42,36 @@ func TestPersistenceRulesCoverMoveAndLinkBypass(t *testing.T) {
 		input     celengine.CELInputEvent
 		wantMatch bool
 	}{
-		// Cron: write, rename, and link into /etc/cron.d all detect.
+		// Cron: write, rename, and link into /etc/cron.d all match.
 		{"cron_write", celengine.CELInputEvent{Path: "/etc/cron.d/evil", IsWrite: true}, true},
 		{"cron_write", celengine.CELInputEvent{Path: "/etc/crontab", IsWrite: true}, true},
 		{"cron_write", celengine.CELInputEvent{Path: "/etc/cron.d/evil", IsWrite: false}, false},
+		{"cron_write", celengine.CELInputEvent{Path: "/workspace/rootfs/etc/cron.d/fixture", IsWrite: true}, false},
 		{"cron_move", celengine.CELInputEvent{FromPath: "/tmp/job", ToPath: "/etc/cron.d/evil"}, true},
 		{"cron_move", celengine.CELInputEvent{FromPath: "/tmp/a", ToPath: "/tmp/b"}, false},
+		{"cron_move", celengine.CELInputEvent{FromPath: "/tmp/job", ToPath: "/workspace/rootfs/etc/cron.d/fixture"}, false},
 		{"cron_link", celengine.CELInputEvent{CreatedPath: "/etc/cron.d/evil", ExistingPath: "/tmp/job", IsSymlink: true}, true},
+		{"cron_link", celengine.CELInputEvent{CreatedPath: "/workspace/rootfs/etc/cron.d/fixture", ExistingPath: "/tmp/job", IsSymlink: true}, false},
 
 		// Shell startup files.
 		{"shell_rc_write", celengine.CELInputEvent{Path: "/home/runner/.bashrc", IsWrite: true}, true},
+		{"shell_rc_write", celengine.CELInputEvent{Path: "/workspace/dotfiles/.bashrc", IsWrite: true}, true},
 		{"shell_rc_write", celengine.CELInputEvent{Path: "/etc/profile.d/evil.sh", IsWrite: true}, true},
+		{"shell_rc_write", celengine.CELInputEvent{Path: "/workspace/rootfs/etc/profile.d/fixture.sh", IsWrite: true}, false},
 		{"shell_rc_move", celengine.CELInputEvent{FromPath: "/tmp/rc", ToPath: "/home/runner/.bashrc"}, true},
+		{"shell_rc_move", celengine.CELInputEvent{FromPath: "/tmp/rc", ToPath: "/workspace/dotfiles/.bashrc"}, true},
+		{"shell_rc_move", celengine.CELInputEvent{FromPath: "/tmp/rc", ToPath: "/workspace/rootfs/etc/profile.d/fixture.sh"}, false},
 		{"shell_rc_link", celengine.CELInputEvent{CreatedPath: "/home/runner/.zshrc", ExistingPath: "/tmp/rc", IsSymlink: true}, true},
+		{"shell_rc_link", celengine.CELInputEvent{CreatedPath: "/workspace/dotfiles/.zshrc", ExistingPath: "/tmp/rc", IsSymlink: true}, true},
+		{"shell_rc_link", celengine.CELInputEvent{CreatedPath: "/workspace/rootfs/etc/profile.d/fixture.sh", ExistingPath: "/tmp/rc", IsSymlink: true}, false},
 
 		// Dynamic linker preload.
 		{"ld_so_preload_write", celengine.CELInputEvent{Path: "/etc/ld.so.preload", IsWrite: true}, true},
+		{"ld_so_preload_write", celengine.CELInputEvent{Path: "/workspace/rootfs/etc/ld.so.conf.d/fixture.conf", IsWrite: true}, false},
 		{"ld_so_preload_move", celengine.CELInputEvent{FromPath: "/tmp/p", ToPath: "/etc/ld.so.preload"}, true},
+		{"ld_so_preload_move", celengine.CELInputEvent{FromPath: "/tmp/p", ToPath: "/workspace/rootfs/etc/ld.so.conf.d/fixture.conf"}, false},
 		{"ld_so_preload_link", celengine.CELInputEvent{CreatedPath: "/etc/ld.so.conf.d/evil.conf", ExistingPath: "/tmp/p", IsHardlink: true}, true},
+		{"ld_so_preload_link", celengine.CELInputEvent{CreatedPath: "/workspace/rootfs/etc/ld.so.conf.d/fixture.conf", ExistingPath: "/tmp/p", IsHardlink: true}, false},
 
 		// User systemd service unit (same move/link gap closed).
 		{"user_systemd_service_move", celengine.CELInputEvent{FromPath: "/tmp/x.service", ToPath: "/home/runner/.config/systemd/user/x.service"}, true},
@@ -91,6 +103,29 @@ func TestPersistenceRulesCoverMoveAndLinkBypass(t *testing.T) {
 				t.Fatalf("rule %s matched=%v, want %v", r.RuleID, matched, tc.wantMatch)
 			}
 		})
+	}
+
+	wantActions := map[string]rule.RuleAction{
+		"cron_write":                rule.RuleActionCollect,
+		"cron_move":                 rule.RuleActionCollect,
+		"cron_link":                 rule.RuleActionDetect,
+		"shell_rc_write":            rule.RuleActionCollect,
+		"shell_rc_move":             rule.RuleActionCollect,
+		"shell_rc_link":             rule.RuleActionCollect,
+		"ld_so_preload_write":       rule.RuleActionDetect,
+		"ld_so_preload_move":        rule.RuleActionDetect,
+		"ld_so_preload_link":        rule.RuleActionDetect,
+		"user_systemd_service_move": rule.RuleActionDetect,
+		"user_systemd_service_link": rule.RuleActionDetect,
+	}
+	for id, want := range wantActions {
+		r, ok := byID[id]
+		if !ok {
+			t.Fatalf("expected rule %q to be shipped", id)
+		}
+		if r.Action != want {
+			t.Fatalf("rule %q action=%q, want %q", id, r.Action, want)
+		}
 	}
 
 	// Guard the event-type coverage explicitly: each persistence category

--- a/rules/generic-persistence.yaml
+++ b/rules/generic-persistence.yaml
@@ -18,7 +18,7 @@ rule_sets:
         - "restart"
         - "start"
 
-      # Cron persistence locations. Matched with contains() so that any file
+      # Cron persistence locations. Matched with startsWith() so that any file
       # created, renamed, or linked inside these directories is covered.
       cron_persistence_dirs:
         - "/etc/cron.d/"
@@ -32,7 +32,7 @@ rule_sets:
         - "/etc/crontab"
 
       # Shell startup files (system-wide and per-user). System directories use
-      # contains(); per-user dotfiles use endsWith() against the home path.
+      # startsWith(); per-user dotfiles use endsWith() against the home path.
       shell_rc_dirs:
         - "/etc/profile.d/"
 
@@ -159,7 +159,7 @@ rule_sets:
         rule_name: "Supply-chain: cron persistence file write"
         description: |
           What:
-            Detects writes to system cron locations (/etc/cron.*, /etc/crontab, /var/spool/cron).
+            Collects writes to system cron locations (/etc/cron.*, /etc/crontab, /var/spool/cron).
           Why:
             Dropping a job into a cron directory persists payload execution outside the CI job lineage.
           Notes:
@@ -168,10 +168,10 @@ rule_sets:
         condition: |
           is_write &&
           (
-            list.cron_persistence_dirs.exists(d, path.contains(d)) ||
+            list.cron_persistence_dirs.exists(d, path.startsWith(d)) ||
             list.cron_persistence_files.exists(f, path == f)
           )
-        action: detect
+        action: collect
         tags:
           mitre_tactic: persistence
 
@@ -179,16 +179,16 @@ rule_sets:
         rule_name: "Supply-chain: cron persistence file move (rename bypass)"
         description: |
           What:
-            Detects a rename whose destination is a system cron location.
+            Collects a rename whose destination is a system cron location.
           Why:
             Renaming a staged file into /etc/cron.d (mv) reaches the same persistence as a direct write but emits file_move instead of file_open, evading write-only rules.
           Notes:
-            Inspect the source path and the moved content; package tooling rarely renames into cron directories.
+            Package tooling can atomically rename files into cron directories; correlate the source path and process ancestry before treating the event as suspicious.
         event_type: file_move
         condition: |
-          list.cron_persistence_dirs.exists(d, to_path.contains(d)) ||
+          list.cron_persistence_dirs.exists(d, to_path.startsWith(d)) ||
           list.cron_persistence_files.exists(f, to_path == f)
-        action: detect
+        action: collect
         tags:
           mitre_tactic: persistence
 
@@ -203,7 +203,7 @@ rule_sets:
             Review the link target; legitimate workflows seldom link into cron directories.
         event_type: file_link
         condition: |
-          list.cron_persistence_dirs.exists(d, created_path.contains(d)) ||
+          list.cron_persistence_dirs.exists(d, created_path.startsWith(d)) ||
           list.cron_persistence_files.exists(f, created_path == f)
         action: detect
         tags:
@@ -214,7 +214,7 @@ rule_sets:
         rule_name: "Supply-chain: shell startup file write"
         description: |
           What:
-            Detects writes to shell startup files (/etc/profile, /etc/profile.d, *.bashrc, *.zshrc, *.profile, ...).
+            Collects writes to shell startup files (/etc/profile, /etc/profile.d, *.bashrc, *.zshrc, *.profile, ...).
           Why:
             Shell rc files execute on every interactive/login shell, persisting a payload across sessions and jobs.
           Notes:
@@ -223,11 +223,11 @@ rule_sets:
         condition: |
           is_write &&
           (
-            list.shell_rc_dirs.exists(d, path.contains(d)) ||
+            list.shell_rc_dirs.exists(d, path.startsWith(d)) ||
             list.shell_rc_files.exists(f, path == f) ||
             list.shell_rc_suffixes.exists(s, path.endsWith(s))
           )
-        action: detect
+        action: collect
         tags:
           mitre_tactic: persistence
 
@@ -235,17 +235,17 @@ rule_sets:
         rule_name: "Supply-chain: shell startup file move (rename bypass)"
         description: |
           What:
-            Detects a rename whose destination is a shell startup file.
+            Collects a rename whose destination is a shell startup file.
           Why:
             Renaming a staged file over ~/.bashrc or into /etc/profile.d reaches shell-rc persistence while emitting file_move instead of file_open.
           Notes:
             Inspect the source path and content; correlate with unexpected ancestry.
         event_type: file_move
         condition: |
-          list.shell_rc_dirs.exists(d, to_path.contains(d)) ||
+          list.shell_rc_dirs.exists(d, to_path.startsWith(d)) ||
           list.shell_rc_files.exists(f, to_path == f) ||
           list.shell_rc_suffixes.exists(s, to_path.endsWith(s))
-        action: detect
+        action: collect
         tags:
           mitre_tactic: persistence
 
@@ -253,17 +253,17 @@ rule_sets:
         rule_name: "Supply-chain: shell startup file link (link bypass)"
         description: |
           What:
-            Detects a hardlink or symlink created at a shell startup file path.
+            Collects a hardlink or symlink created at a shell startup file path.
           Why:
             Linking a payload into a shell rc path installs persistence without writing the protected path, evading write-only rules.
           Notes:
             Review the link target before treating it as benign.
         event_type: file_link
         condition: |
-          list.shell_rc_dirs.exists(d, created_path.contains(d)) ||
+          list.shell_rc_dirs.exists(d, created_path.startsWith(d)) ||
           list.shell_rc_files.exists(f, created_path == f) ||
           list.shell_rc_suffixes.exists(s, created_path.endsWith(s))
-        action: detect
+        action: collect
         tags:
           mitre_tactic: persistence
 
@@ -282,7 +282,7 @@ rule_sets:
           is_write &&
           (
             list.ld_preload_files.exists(f, path == f) ||
-            list.ld_preload_dirs.exists(d, path.contains(d))
+            list.ld_preload_dirs.exists(d, path.startsWith(d))
           )
         action: detect
         tags:
@@ -300,7 +300,7 @@ rule_sets:
         event_type: file_move
         condition: |
           list.ld_preload_files.exists(f, to_path == f) ||
-          list.ld_preload_dirs.exists(d, to_path.contains(d))
+          list.ld_preload_dirs.exists(d, to_path.startsWith(d))
         action: detect
         tags:
           mitre_tactic: defense-evasion,persistence
@@ -317,7 +317,7 @@ rule_sets:
         event_type: file_link
         condition: |
           list.ld_preload_files.exists(f, created_path == f) ||
-          list.ld_preload_dirs.exists(d, created_path.contains(d))
+          list.ld_preload_dirs.exists(d, created_path.startsWith(d))
         action: detect
         tags:
           mitre_tactic: defense-evasion,persistence


### PR DESCRIPTION
## What

- Change `shell_rc_write`, `shell_rc_move`, and `shell_rc_link` from `detect` to `collect`.
- Change `cron_write` and `cron_move` from `detect` to `collect`.
- Keep `cron_link`, `ld_so_*`, and `user_systemd_service_*` as `detect`.
- Match system directories with `startsWith()` instead of `contains()`.
- Add regression coverage for rule actions and repository-local rootfs fixtures.

## Why

Pre-release false-positive testing found that common development tools modify shell startup files:

- nvm appends to `.bashrc`
- rustup creates or updates `.profile`
- `conda init` rewrites `.bashrc`
- `sed -i` replaces shell startup files through rename
- dotfiles setups commonly create symlinks

A normal `apt-get install sysstat` also writes and renames files under `/etc/cron.d` and `/etc/cron.daily`.

These events remain useful security context, but should not produce baseline detections by themselves. In addition, `contains()` matched repository fixtures such as `/workspace/rootfs/etc/cron.d/example`, even though they were not active system paths.

Closes #107
