### PR TITLE
feat(rules): add AsyncAPI npm compromise C2 IP IOC

### DIFF
--- a/rules/ioc.yaml
+++ b/rules/ioc.yaml
@@ -1,7 +1,6 @@
 rule_sets:
   - ruleset_id: cicd_sensor_baseline/ioc
-    # This file currently carries one example IOC. Add future short-lived,
-    # high-confidence campaign indicators here.
+    # Short-lived, high-confidence campaign indicators live here.
 
     rules:
       - rule_id: mini_shaihulud_antv_c2_domain
@@ -40,3 +39,27 @@ rule_sets:
           mitre_tactic: command-and-control
           ioc_date: "2026-06-17"
           source_url: https://x.com/lmt_swallow/status/2067082668458786967
+
+      - rule_id: asyncapi_npm_compromise_c2_ip
+        rule_name: "IOC: AsyncAPI npm package compromise C2 IP"
+        description: |
+          What:
+            Outbound C2 connections from the @asyncapi npm package compromise
+            (@asyncapi/specs, @asyncapi/generator, @asyncapi/generator-helpers,
+            @asyncapi/generator-components).
+          Why:
+            Active-compromise IOC. Compromised @asyncapi packages beacon to these IPs.
+          Notes:
+            Preserve job logs and artifacts, then rotate credentials reachable from the job.
+        event_type: network_connect
+        condition: |
+          family == "ipv4" &&
+          (
+            remote_ip == "209.94.90.1" ||
+            remote_ip == "85.137.53.71"
+          )
+        action: terminate
+        tags:
+          mitre_tactic: command-and-control
+          ioc_date: "2026-07-14"
+          source_url: https://x.com/lmt_swallow/status/2076943312909672912


### PR DESCRIPTION
## What

Adds an IOC rule terminating outbound connections to the two C2 IPs
(209.94.90.1, 85.137.53.71) reported for the asyncapi npm package
compromise (@asyncapi/specs, @asyncapi/generator,
@asyncapi/generator-{helpers,components}).

Source: https://x.com/lmt_swallow/status/2076943312909672912 (2026-07-14)

## Notes

- Same shape as the existing `mastra_npm_compromise_c2_ip` rule.
- IP-only: no C2 domain has been published for this campaign yet.
- Also fixes the stale "one example IOC" comment at the top of the file.

## Validation

- `make rules-validate` / `make rules-bundle-validate` pass
- `go test ./internal/rulesource/ ./internal/rule/...` pass