### PR TITLE
feat(rules): add Miasma DHT bootstrap domain IOC

### DIFF
--- a/rules/ioc.yaml
+++ b/rules/ioc.yaml
@@ -63,3 +63,29 @@ rule_sets:
           mitre_tactic: command-and-control
           ioc_date: "2026-07-14"
           source_url: https://x.com/lmt_swallow/status/2076943312909672912
+
+      - rule_id: asyncapi_miasma_dht_bootstrap_domain
+        rule_name: "IOC: Miasma BitTorrent DHT bootstrap resolution"
+        description: |
+          What:
+            DNS resolution of public BitTorrent DHT bootstrap nodes, used by
+            the @asyncapi npm compromise stage 2 (Miasma variant) as a C2
+            rendezvous channel.
+          Why:
+            Active-compromise IOC in the current campaign. The domains are
+            legitimate DHT bootstrap infrastructure, but a CI job has no
+            ordinary reason to join the BitTorrent DHT, so resolution from a
+            tracked job is treated as compromise.
+          Notes:
+            Projects that legitimately exercise BitTorrent clients in CI
+            should exclude this rule with a rule modifier. Preserve job logs
+            and artifacts, then rotate credentials reachable from the job.
+        event_type: domain
+        condition: |
+          domain == "router.bittorrent.com" ||
+          domain == "dht.transmissionbt.com"
+        action: terminate
+        tags:
+          mitre_tactic: command-and-control
+          ioc_date: "2026-07-14"
+          source_url: https://x.com/lmt_swallow/status/2076945835313840559

--- a/rules/ioc.yaml
+++ b/rules/ioc.yaml
@@ -89,3 +89,30 @@ rule_sets:
           mitre_tactic: command-and-control
           ioc_date: "2026-07-14"
           source_url: https://x.com/lmt_swallow/status/2076945835313840559
+
+      - rule_id: miasma_systemd_unit_write
+        rule_name: "IOC: Miasma systemd persistence write"
+        description: |
+          What:
+            Write below a systemd directory whose path contains "miasma",
+            covering the @asyncapi npm compromise stage 2 persistence unit
+            (~/.config/systemd/user/miasma-monitor.service) and renamed
+            variants of the same worm family.
+          Why:
+            Active-compromise IOC. The Miasma lineage persists through a
+            systemd unit carrying its family name; no legitimate CI write
+            matches both fragments.
+          Notes:
+            Generic user-systemd persistence rules still cover arbitrary unit
+            names and renamed or linked landings at detect level. Preserve job
+            logs and artifacts, then rotate credentials reachable from the job.
+        event_type: file_open
+        condition: |
+          is_write &&
+          path.contains("/systemd/") &&
+          path.contains("miasma")
+        action: terminate
+        tags:
+          mitre_tactic: persistence
+          ioc_date: "2026-07-14"
+          source_url: https://x.com/lmt_swallow/status/2076945835313840559


### PR DESCRIPTION
## What

Adds two IOC rules for the @asyncapi npm compromise stage 2 payload
(Miasma variant), following up on #121 (C2 IPs for the same campaign).

1. `asyncapi_miasma_dht_bootstrap_domain` — terminates DNS resolution of
   the public BitTorrent DHT bootstrap nodes used as a C2 rendezvous
   channel: `router.bittorrent.com`, `dht.transmissionbt.com`.
2. `miasma_systemd_unit_write` — terminates writes below a systemd
   directory whose path contains "miasma", covering the reported
   persistence unit (`~/.config/systemd/user/miasma-monitor.service`) and
   renamed variants.

Source: https://x.com/lmt_swallow/status/2076945835313840559 (2026-07-14)

## Notes

- The DHT domains are legitimate bootstrap infrastructure; the signal is
  contextual — a CI job has no ordinary reason to join the BitTorrent DHT.
  Projects that legitimately exercise BitTorrent clients in CI should
  exclude the rule with a rule modifier (noted in the rule description).
- Generic user-systemd persistence rules keep covering arbitrary unit names
  and rename/link landings at detect level; the write IOC adds a
  high-confidence terminate for this family.

## Validation

- `make rules-validate` / `make rules-bundle-validate` pass
- `go test ./internal/rulesource/ ./internal/rule/baseline/` pass