### PR TITLE
feat: configure process argument redaction for manager logs

### DIFF
--- a/cmd/cicd-sensor-manager/main.go
+++ b/cmd/cicd-sensor-manager/main.go
@@ -14,6 +14,8 @@ import (
 	"syscall"
 	"time"
 
+	"google.golang.org/protobuf/proto"
+
 	"github.com/cicd-sensor/cicd-sensor/internal/manager"
 	"github.com/cicd-sensor/cicd-sensor/internal/managerauth"
 	managerv1beta1 "github.com/cicd-sensor/cicd-sensor/internal/proto/cicd_sensor/manager/v1beta1"
@@ -225,6 +227,9 @@ func readManagerTokenFile(path string) (string, error) {
 }
 
 func buildServedConfig(startup manager.StartupConfig, outputSettings *managerv1beta1.OutputSettings) *manager.ServedConfig {
+	if outputSettings != nil {
+		outputSettings.RedactProcessArgs = proto.Bool(startup.ProcessArgsRedactionEnabled())
+	}
 	return &manager.ServedConfig{
 		ConfigRevision:          startup.Revision,
 		DefaultMaxAlertsPerRule: startup.DefaultMaxAlertsPerRule,

--- a/cmd/cicd-sensor-manager/main_test.go
+++ b/cmd/cicd-sensor-manager/main_test.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"testing"
 
+	"google.golang.org/protobuf/proto"
+
 	"github.com/cicd-sensor/cicd-sensor/internal/manager"
 	"github.com/cicd-sensor/cicd-sensor/internal/managerauth"
 	managerv1beta1 "github.com/cicd-sensor/cicd-sensor/internal/proto/cicd_sensor/manager/v1beta1"
@@ -277,6 +279,7 @@ func TestBuildServedConfig(t *testing.T) {
 		DefaultMaxAlertsPerRule: 7,
 		DisableBaselineRules:    true,
 		MonitorMode:             true,
+		RedactProcessArgs:       proto.Bool(false),
 	}
 	settings := &managerv1beta1.OutputSettings{
 		Detection: &managerv1beta1.OutputSetting{
@@ -305,6 +308,9 @@ func TestBuildServedConfig(t *testing.T) {
 	if !served.MonitorMode {
 		t.Fatalf("MonitorMode: got false, want true")
 	}
+	if served.OutputSettings.RedactProcessArgs == nil || served.OutputSettings.GetRedactProcessArgs() {
+		t.Fatalf("RedactProcessArgs: got %v, want explicit false", served.OutputSettings.RedactProcessArgs)
+	}
 	if !served.OutputSettings.GetDetection().GetEnabled() {
 		t.Fatalf("detection settings: got false, want true")
 	}
@@ -313,6 +319,16 @@ func TestBuildServedConfig(t *testing.T) {
 	}
 	if !served.OutputSettings.GetSummary().GetEnabled() {
 		t.Fatalf("summary settings: got false, want true")
+	}
+}
+
+func TestBuildServedConfig_DefaultsProcessArgsRedaction(t *testing.T) {
+	settings := &managerv1beta1.OutputSettings{}
+
+	served := buildServedConfig(manager.StartupConfig{}, settings)
+
+	if served.OutputSettings.RedactProcessArgs == nil || !served.OutputSettings.GetRedactProcessArgs() {
+		t.Fatalf("RedactProcessArgs: got %v, want explicit true", served.OutputSettings.RedactProcessArgs)
 	}
 }
 

--- a/docs/user-guide/logging.md
+++ b/docs/user-guide/logging.md
@@ -80,6 +80,8 @@ Rules are evaluated against the captured process context, but logs and reports u
 In output, argv values that look like tokens, passwords, secrets, credential material, or auth headers are replaced with `<redacted>`.
 Long argv values are shortened and marked with `<truncated, N bytes>`.
 
+Manager operators can set `redact_process_args: false` to preserve captured argv in manager-bound Detection and Runtime Event Logs. This is an explicit opt-in for sinks approved to handle potentially sensitive command lines. Agent-direct outputs, including project results and debug output, remain sanitized.
+
 This means a rule can match full argv content even when the corresponding log entry shows only a redacted or shortened value.
 
 ## How to use the logs

--- a/docs/user-guide/manager.md
+++ b/docs/user-guide/manager.md
@@ -138,6 +138,7 @@ bind:
 default_max_alerts_per_rule: 10
 disable_baseline_rules: false
 monitor_mode: false
+redact_process_args: true
 
 sinks:
   s3-out:
@@ -166,6 +167,7 @@ For richer routing (per-log-kind destinations, multiple sinks), see
 | `default_max_alerts_per_rule` | Default per-rule Detection Log limit for rules that do not set `max_alerts`. Use 1-100 to set a value; omit it or set 0 to use the system default. | `10` | Manager restart |
 | `disable_baseline_rules` | Disable cicd-sensor baseline rule fetch/prepend when using the manager. Custom rule bundles from `--rules-file` are still served. | `false` | Manager restart |
 | `monitor_mode` | Treat `terminate` rules as `detect` rules. Use this for first rollout or collection-only operation without job stopping. | `false` | Manager restart |
+| `redact_process_args` | Redact credential-like values and shorten long process arguments before the Agent sends Detection and Runtime Event Logs to the manager. Set to `false` only when the manager sinks are approved to receive captured process arguments. Agent-direct outputs remain redacted. | `true` | Manager restart |
 | `sinks` | Physical cloud output destinations, such as S3, GCS, or Pub/Sub. | none | Manager restart |
 | `logs` | Mapping from each manager-ingested `log_type` to one configured sink. | none | Manager restart |
 

--- a/internal/agent/joblogs/detection_log.go
+++ b/internal/agent/joblogs/detection_log.go
@@ -18,6 +18,7 @@ type DetectionLogInput struct {
 	ScopeLogContext
 	Hit                 *observations.HitEntry
 	Event               jobevent.EventRecord
+	RedactProcessArgs   *bool
 	RuleName            string
 	RuleDescription     string
 	RulesetRevision     string
@@ -54,7 +55,7 @@ func MarshalDetectionLogEntry(in DetectionLogInput) ([]byte, error) {
 		RuleDescription:     proto.String(in.RuleDescription),
 		Action:              proto.String(in.Hit.Action),
 		RuleAlertTruncation: proto.String(in.RuleAlertTruncation),
-		Event:               sanitizedLogEventRecord(in.Event),
+		Event:               logEventRecordForOutput(in.Event, in.RedactProcessArgs),
 		RuleTags:            logEventTags(in.RuleTags),
 	}
 	return logJSONMarshal.Marshal(message)

--- a/internal/agent/joblogs/detection_log_test.go
+++ b/internal/agent/joblogs/detection_log_test.go
@@ -11,23 +11,40 @@ import (
 	"github.com/cicd-sensor/cicd-sensor/internal/version"
 )
 
-func TestMarshalDetectionLogEntrySanitizesEventProcess(t *testing.T) {
-	t.Parallel()
-
-	payload, err := MarshalDetectionLogEntry(DetectionLogInput{
-		ScopeLogContext: testScopeLogContext(),
-		Hit:             testHitEntry(),
-		Event:           eventWithSecretArgv(),
-	})
-	if err != nil {
-		t.Fatalf("marshal detection log: %v", err)
+func TestMarshalDetectionLogEntryAppliesProcessArgsRedactionPolicy(t *testing.T) {
+	tests := []struct {
+		name   string
+		redact *bool
+		assert func(*testing.T, *logv1beta1.EventRecord)
+	}{
+		{name: "nil policy defaults to sanitized output", assert: assertProtoEventProcessSanitized},
+		{name: "explicit true sanitizes output", redact: boolPointer(true), assert: assertProtoEventProcessSanitized},
+		{name: "explicit false preserves captured args", redact: boolPointer(false), assert: assertProtoEventProcessUnredacted},
 	}
 
-	var got logv1beta1.DetectionLogEntry
-	if err := protojson.Unmarshal(payload, &got); err != nil {
-		t.Fatalf("unmarshal detection log: %v", err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			event := eventWithSecretArgv()
+			payload, err := MarshalDetectionLogEntry(DetectionLogInput{
+				ScopeLogContext:   testScopeLogContext(),
+				Hit:               testHitEntry(),
+				Event:             event,
+				RedactProcessArgs: tt.redact,
+			})
+			if err != nil {
+				t.Fatalf("marshal detection log: %v", err)
+			}
+
+			var got logv1beta1.DetectionLogEntry
+			if err := protojson.Unmarshal(payload, &got); err != nil {
+				t.Fatalf("unmarshal detection log: %v", err)
+			}
+			tt.assert(t, got.GetEvent())
+			if got, want := event.Process.Argv[1], "--token=supersecret"; got != want {
+				t.Fatalf("input event argv mutated: got %q, want %q", got, want)
+			}
+		})
 	}
-	assertProtoEventProcessSanitized(t, got.GetEvent())
 }
 
 func TestMarshalDetectionLogEntryNilHitReturnsNilPayload(t *testing.T) {

--- a/internal/agent/joblogs/event_record.go
+++ b/internal/agent/joblogs/event_record.go
@@ -12,6 +12,15 @@ func sanitizedLogEventRecord(event jobevent.EventRecord) *logv1beta1.EventRecord
 	return logEventRecord(event)
 }
 
+func logEventRecordForOutput(event jobevent.EventRecord, redactProcessArgs *bool) *logv1beta1.EventRecord {
+	// Nil is the safe default for callers and for config received from managers
+	// that predate the redaction setting.
+	if redactProcessArgs == nil || *redactProcessArgs {
+		return sanitizedLogEventRecord(event)
+	}
+	return logEventRecord(event)
+}
+
 func logEventRecord(event jobevent.EventRecord) *logv1beta1.EventRecord {
 	out := &logv1beta1.EventRecord{
 		Id:      event.ID,

--- a/internal/agent/joblogs/log_common_test.go
+++ b/internal/agent/joblogs/log_common_test.go
@@ -29,6 +29,23 @@ func assertProtoEventProcessSanitized(t *testing.T, event *logv1beta1.EventRecor
 	}
 }
 
+func assertProtoEventProcessUnredacted(t *testing.T, event *logv1beta1.EventRecord) {
+	t.Helper()
+	if event == nil || event.GetProcess() == nil {
+		t.Fatalf("event process missing: %#v", event)
+	}
+	if got, want := event.GetProcess().GetArgv()[1], "--token=supersecret"; got != want {
+		t.Fatalf("event argv: got %q, want %q", got, want)
+	}
+	if got, want := event.GetProcess().GetAncestors()[0].GetArgv()[2], "Bearer abc123"; got != want {
+		t.Fatalf("event ancestor argv: got %q, want %q", got, want)
+	}
+}
+
+func boolPointer(value bool) *bool {
+	return &value
+}
+
 func eventWithSecretArgv() jobevent.EventRecord {
 	return jobevent.EventRecord{
 		ID:        "event-1",

--- a/internal/agent/joblogs/runtime_event_log.go
+++ b/internal/agent/joblogs/runtime_event_log.go
@@ -13,7 +13,8 @@ import (
 
 type RuntimeEventLogInput struct {
 	ScopeLogContext
-	Event jobevent.EventRecord
+	Event             jobevent.EventRecord
+	RedactProcessArgs *bool
 }
 
 func MarshalRuntimeEventLogEntry(in RuntimeEventLogInput) ([]byte, error) {
@@ -27,7 +28,7 @@ func MarshalRuntimeEventLogEntry(in RuntimeEventLogInput) ([]byte, error) {
 		Job:            protoconv.ToLogContext(in.Identity, in.Metadata),
 		Scope:          proto.String(string(in.Scope)),
 		RunnerType:     proto.String(in.RunnerType),
-		Event:          sanitizedLogEventRecord(in.Event),
+		Event:          logEventRecordForOutput(in.Event, in.RedactProcessArgs),
 	}
 	return logJSONMarshal.Marshal(message)
 }

--- a/internal/agent/joblogs/runtime_event_log_test.go
+++ b/internal/agent/joblogs/runtime_event_log_test.go
@@ -10,22 +10,42 @@ import (
 	"github.com/cicd-sensor/cicd-sensor/internal/version"
 )
 
-func TestMarshalRuntimeEventLogEntrySanitizesEventProcess(t *testing.T) {
-	t.Parallel()
-
-	payload, err := MarshalRuntimeEventLogEntry(RuntimeEventLogInput{
-		ScopeLogContext: testScopeLogContext(),
-		Event:           eventWithSecretArgv(),
-	})
-	if err != nil {
-		t.Fatalf("marshal runtime event log: %v", err)
+func TestMarshalRuntimeEventLogEntryAppliesProcessArgsRedactionPolicy(t *testing.T) {
+	tests := []struct {
+		name   string
+		redact *bool
+		assert func(*testing.T, *logv1beta1.EventRecord)
+	}{
+		{name: "nil policy defaults to sanitized output", assert: assertProtoEventProcessSanitized},
+		{name: "explicit true sanitizes output", redact: boolPointer(true), assert: assertProtoEventProcessSanitized},
+		{name: "explicit false preserves captured args", redact: boolPointer(false), assert: assertProtoEventProcessUnredacted},
 	}
 
-	var got logv1beta1.RuntimeEventLogEntry
-	if err := protojson.Unmarshal(payload, &got); err != nil {
-		t.Fatalf("unmarshal runtime event log: %v", err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			event := eventWithSecretArgv()
+			payload, err := MarshalRuntimeEventLogEntry(RuntimeEventLogInput{
+				ScopeLogContext:   testScopeLogContext(),
+				Event:             event,
+				RedactProcessArgs: tt.redact,
+			})
+			if err != nil {
+				t.Fatalf("marshal runtime event log: %v", err)
+			}
+
+			var got logv1beta1.RuntimeEventLogEntry
+			if err := protojson.Unmarshal(payload, &got); err != nil {
+				t.Fatalf("unmarshal runtime event log: %v", err)
+			}
+			tt.assert(t, got.GetEvent())
+			if got, want := event.Process.Argv[1], "--token=supersecret"; got != want {
+				t.Fatalf("input event argv mutated: got %q, want %q", got, want)
+			}
+			if got, want := event.Process.Ancestors[0].Argv[2], "Bearer abc123"; got != want {
+				t.Fatalf("input ancestor argv mutated: got %q, want %q", got, want)
+			}
+		})
 	}
-	assertProtoEventProcessSanitized(t, got.GetEvent())
 }
 
 func TestMarshalRuntimeEventLogEntryStampsLogTypeAndVersions(t *testing.T) {

--- a/internal/agent/jobscope/manager_logs.go
+++ b/internal/agent/jobscope/manager_logs.go
@@ -78,6 +78,7 @@ func (s *JobScopeState) writeDetectionLog(ctx context.Context, identity jobconte
 		return
 	}
 
+	redactProcessArgs := s.processArgsRedactionEnabled()
 	ruleName, ruleDescription, rulesetRevision, ruleTags := s.resolvedRuleInfo(hit.Identity)
 	payload, err := joblogs.MarshalDetectionLogEntry(joblogs.DetectionLogInput{
 		ScopeLogContext: joblogs.ScopeLogContext{
@@ -88,6 +89,7 @@ func (s *JobScopeState) writeDetectionLog(ctx context.Context, identity jobconte
 		},
 		Hit:                 hit,
 		Event:               event,
+		RedactProcessArgs:   &redactProcessArgs,
 		RuleName:            ruleName,
 		RuleDescription:     ruleDescription,
 		RulesetRevision:     rulesetRevision,
@@ -119,6 +121,7 @@ func (s *JobScopeState) WriteRuntimeEventLog(ctx context.Context, identity jobco
 		return
 	}
 
+	redactProcessArgs := s.processArgsRedactionEnabled()
 	payload, err := joblogs.MarshalRuntimeEventLogEntry(joblogs.RuntimeEventLogInput{
 		ScopeLogContext: joblogs.ScopeLogContext{
 			Identity:   identity,
@@ -126,7 +129,8 @@ func (s *JobScopeState) WriteRuntimeEventLog(ctx context.Context, identity jobco
 			RunnerType: runnerType,
 			Scope:      s.Type,
 		},
-		Event: event,
+		Event:             event,
+		RedactProcessArgs: &redactProcessArgs,
 	})
 	if err != nil {
 		if logger != nil {
@@ -145,8 +149,36 @@ func (s *JobScopeState) WriteRuntimeEventLog(ctx context.Context, identity jobco
 		)
 	}
 	if s.debugOutput != nil {
-		_ = s.debugOutput.WriteRuntimeEventPayload(ctx, payload)
+		// Debug artifacts are Agent-owned and explicitly request sanitization
+		// instead of reusing a potentially unredacted Manager payload.
+		redactDebugProcessArgs := true
+		debugPayload, err := joblogs.MarshalRuntimeEventLogEntry(joblogs.RuntimeEventLogInput{
+			ScopeLogContext: joblogs.ScopeLogContext{
+				Identity:   identity,
+				Metadata:   metadata,
+				RunnerType: runnerType,
+				Scope:      s.Type,
+			},
+			Event:             event,
+			RedactProcessArgs: &redactDebugProcessArgs,
+		})
+		if err != nil {
+			if logger != nil {
+				logger.WarnContext(ctx, "debug_runtime_event_marshal_failed",
+					"scope", string(s.Type),
+					"error", err,
+				)
+			}
+			return
+		}
+		_ = s.debugOutput.WriteRuntimeEventPayload(ctx, debugPayload)
 	}
+}
+
+func (s *JobScopeState) processArgsRedactionEnabled() bool {
+	return s.OutputSettings == nil ||
+		s.OutputSettings.RedactProcessArgs == nil ||
+		s.OutputSettings.GetRedactProcessArgs()
 }
 
 func (s *JobScopeState) FinalizeStreamingLogs(ctx context.Context) error {

--- a/internal/agent/jobscope/manager_logs_test.go
+++ b/internal/agent/jobscope/manager_logs_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cicd-sensor/cicd-sensor/internal/resultdoc"
 	"github.com/cicd-sensor/cicd-sensor/internal/rule"
 	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
 )
 
 var (
@@ -132,8 +133,43 @@ func TestJobScopeStateWriteDetectionLogForHit_CollectEmitsDetectionLog(t *testin
 	if got, want := entries[0].GetAction(), string(rule.RuleActionCollect); got != want {
 		t.Fatalf("action: got %q, want %q", got, want)
 	}
+	if got, want := entries[0].GetEvent().GetProcess().GetArgv()[1], "<redacted>"; got != want {
+		t.Fatalf("event argv: got %q, want %q", got, want)
+	}
 	if got := scope.CorrelationHitCountFor(hit.Identity); got != 1 {
 		t.Fatalf("recorded hit count: got %d, want 1", got)
+	}
+}
+
+func TestJobScopeStateWriteDetectionLogForHit_AppliesOutputSettingsProcessArgsPolicy(t *testing.T) {
+	t.Parallel()
+
+	recorder := &recordingJobScopeBatches{}
+	scope := jobscope.NewHost()
+	scope.OutputSettings = &managerv1beta1.OutputSettings{RedactProcessArgs: proto.Bool(false)}
+	scope.ManagerJobLogsForTesting().AttachDetectionRecorderForTesting(testJobIdentity, scope.Type, recorder.sendBatch)
+	hit := observations.HitEntry{
+		Identity:  rule.RuleIdentity{RulesetID: "set", RuleID: "collect_token"},
+		Action:    string(rule.RuleActionCollect),
+		MaxAlerts: 1,
+	}
+	event := testJobScopeProcessEvent("event-unredacted-detection")
+
+	scope.RecordHit(hit, event)
+	scope.WriteDetectionLogForHit(t.Context(), testJobIdentity, testJobMetadata, "machine", hit, event, testJobScopeLogger)
+	if err := scope.FinalizeStreamingLogs(t.Context()); err != nil {
+		t.Fatalf("finalize logs: %v", err)
+	}
+
+	entries := recorder.detectionEntries(t)
+	if len(entries) != 1 {
+		t.Fatalf("detection entries: got %d, want 1", len(entries))
+	}
+	if got, want := entries[0].GetEvent().GetProcess().GetArgv()[1], "--token=secret"; got != want {
+		t.Fatalf("event argv: got %q, want %q", got, want)
+	}
+	if got, want := event.Process.Argv[1], "--token=secret"; got != want {
+		t.Fatalf("input event argv mutated: got %q, want %q", got, want)
 	}
 }
 
@@ -299,6 +335,58 @@ func TestJobScopeStateWriteRuntimeEventLog_EmitsEvent(t *testing.T) {
 	}
 }
 
+func TestJobScopeStateWriteRuntimeEventLog_IsolatesProcessArgsPolicyByScope(t *testing.T) {
+	t.Parallel()
+
+	event := testJobScopeProcessEvent("event-scope-policy")
+	hostRecorder := &recordingJobScopeBatches{}
+	host := jobscope.NewHost()
+	host.OutputSettings = &managerv1beta1.OutputSettings{RedactProcessArgs: proto.Bool(false)}
+	host.ManagerJobLogsForTesting().AttachRuntimeEventRecorderForTesting(testJobIdentity, host.Type, hostRecorder.sendBatch)
+
+	projectRecorder := &recordingJobScopeBatches{}
+	project := jobscope.NewProject()
+	// An older Manager can provide OutputSettings without the new optional
+	// field. The absent value must keep the secure redaction default.
+	project.OutputSettings = &managerv1beta1.OutputSettings{}
+	project.ManagerJobLogsForTesting().AttachRuntimeEventRecorderForTesting(testJobIdentity, project.Type, projectRecorder.sendBatch)
+
+	// Both scopes receive the same EventRecord. Each output must apply only its
+	// own manager policy without mutating data observed by the other scope.
+	host.WriteRuntimeEventLog(t.Context(), testJobIdentity, testJobMetadata, "machine", event, testJobScopeLogger)
+	project.WriteRuntimeEventLog(t.Context(), testJobIdentity, testJobMetadata, "machine", event, testJobScopeLogger)
+	if err := host.FinalizeStreamingLogs(t.Context()); err != nil {
+		t.Fatalf("finalize host logs: %v", err)
+	}
+	if err := project.FinalizeStreamingLogs(t.Context()); err != nil {
+		t.Fatalf("finalize project logs: %v", err)
+	}
+
+	hostEntries := hostRecorder.runtimeEventEntries(t)
+	projectEntries := projectRecorder.runtimeEventEntries(t)
+	if len(hostEntries) != 1 || len(projectEntries) != 1 {
+		t.Fatalf("runtime entries: host=%d project=%d, want 1 each", len(hostEntries), len(projectEntries))
+	}
+	if got, want := hostEntries[0].GetEvent().GetProcess().GetArgv()[1], "--token=secret"; got != want {
+		t.Fatalf("host argv: got %q, want %q", got, want)
+	}
+	if got, want := hostEntries[0].GetEvent().GetProcess().GetAncestors()[0].GetArgv()[2], "Bearer ancestor-secret"; got != want {
+		t.Fatalf("host ancestor argv: got %q, want %q", got, want)
+	}
+	if got, want := projectEntries[0].GetEvent().GetProcess().GetArgv()[1], "<redacted>"; got != want {
+		t.Fatalf("project argv: got %q, want %q", got, want)
+	}
+	if got, want := projectEntries[0].GetEvent().GetProcess().GetAncestors()[0].GetArgv()[2], "<redacted>"; got != want {
+		t.Fatalf("project ancestor argv: got %q, want %q", got, want)
+	}
+	if got, want := event.Process.Argv[1], "--token=secret"; got != want {
+		t.Fatalf("shared event argv mutated: got %q, want %q", got, want)
+	}
+	if got, want := event.Process.Ancestors[0].Argv[2], "Bearer ancestor-secret"; got != want {
+		t.Fatalf("shared event ancestor argv mutated: got %q, want %q", got, want)
+	}
+}
+
 func TestJobScopeStateWriteRuntimeEventLog_WritesDebugOutput(t *testing.T) {
 	t.Parallel()
 
@@ -322,6 +410,39 @@ func TestJobScopeStateWriteRuntimeEventLog_WritesDebugOutput(t *testing.T) {
 	}
 	if got, want := entry.GetEvent().GetNetworkConnect().GetRemoteIp(), "203.0.113.30"; got != want {
 		t.Fatalf("remote ip: got %q, want %q", got, want)
+	}
+}
+
+func TestJobScopeStateWriteRuntimeEventLog_AlwaysSanitizesDebugOutput(t *testing.T) {
+	t.Parallel()
+
+	debugDir := t.TempDir()
+	scope := jobscope.NewProject()
+	scope.OutputSettings = &managerv1beta1.OutputSettings{RedactProcessArgs: proto.Bool(false)}
+	debugOutput, err := joblogs.NewDebugOutputForTesting(testJobScopeLogger, debugDir)
+	if err != nil {
+		t.Fatalf("NewDebugOutput: %v", err)
+	}
+	scope.SetDebugOutput(debugOutput)
+
+	event := testJobScopeProcessEvent("event-debug-redaction")
+	scope.WriteRuntimeEventLog(t.Context(), testJobIdentity, testJobMetadata, "machine", event, testJobScopeLogger)
+	if err := scope.CloseDebugOutput(t.Context()); err != nil {
+		t.Fatalf("close debug output: %v", err)
+	}
+
+	entry := readDebugRuntimeEventEntry(t, debugDir)
+	if got, want := entry.GetEvent().GetProcess().GetArgv()[1], "<redacted>"; got != want {
+		t.Fatalf("debug argv: got %q, want %q", got, want)
+	}
+	if got, want := entry.GetEvent().GetProcess().GetAncestors()[0].GetArgv()[2], "<redacted>"; got != want {
+		t.Fatalf("debug ancestor argv: got %q, want %q", got, want)
+	}
+	if got, want := event.Process.Argv[1], "--token=secret"; got != want {
+		t.Fatalf("input event argv mutated: got %q, want %q", got, want)
+	}
+	if got, want := event.Process.Ancestors[0].Argv[2], "Bearer ancestor-secret"; got != want {
+		t.Fatalf("input event ancestor argv mutated: got %q, want %q", got, want)
 	}
 }
 
@@ -477,6 +598,9 @@ func testJobScopeProcessEvent(id string) jobevent.EventRecord {
 			PID:      100,
 			ExecPath: "/usr/bin/curl",
 			Argv:     []string{"curl", "--token=secret"},
+			Ancestors: []jobevent.AncestorProcess{
+				{ExecPath: "/bin/bash", Argv: []string{"bash", "-c", "Bearer ancestor-secret"}},
+			},
 		},
 	}
 }

--- a/internal/agent/managerclient/config_client_integration_test.go
+++ b/internal/agent/managerclient/config_client_integration_test.go
@@ -26,6 +26,7 @@ import (
 // ApplyManagerConfig → ResolveRules step.
 func TestManagerIntegration_FetchConfig_EndToEnd(t *testing.T) {
 	managerToken := managerauth.TokenPrefix + strings.Repeat("a", 64)
+	redactProcessArgs := false
 
 	configDir := t.TempDir()
 	rulesPath := filepath.Join(configDir, "rules.yaml")
@@ -59,9 +60,10 @@ rule_modifiers:
 		DefaultMaxAlertsPerRule: 23,
 		MonitorMode:             true,
 		OutputSettings: &managerv1beta1.OutputSettings{
-			Summary:      &managerv1beta1.OutputSetting{Enabled: true},
-			Detection:    &managerv1beta1.OutputSetting{Enabled: true},
-			RuntimeEvent: &managerv1beta1.OutputSetting{Enabled: true},
+			Summary:           &managerv1beta1.OutputSetting{Enabled: true},
+			Detection:         &managerv1beta1.OutputSetting{Enabled: true},
+			RuntimeEvent:      &managerv1beta1.OutputSetting{Enabled: true},
+			RedactProcessArgs: &redactProcessArgs,
 		},
 	}
 
@@ -100,6 +102,9 @@ rule_modifiers:
 	}
 	if !result.MonitorMode {
 		t.Fatalf("monitor_mode: got false, want true")
+	}
+	if result.OutputSettings.RedactProcessArgs == nil || result.OutputSettings.GetRedactProcessArgs() {
+		t.Fatalf("redact_process_args: got %v, want explicit false", result.OutputSettings.RedactProcessArgs)
 	}
 	if len(result.RuleSources) != 2 {
 		t.Fatalf("rule_sources: got %d, want 2", len(result.RuleSources))
@@ -142,6 +147,9 @@ rule_modifiers:
 	}
 	if !scope.OutputSettings.GetSummary().GetEnabled() {
 		t.Fatal("expected scope to store output settings from manager response")
+	}
+	if scope.OutputSettings.RedactProcessArgs == nil || scope.OutputSettings.GetRedactProcessArgs() {
+		t.Fatal("expected scope to store disabled process args redaction from manager response")
 	}
 }
 

--- a/internal/agent/managerclient/config_client_test.go
+++ b/internal/agent/managerclient/config_client_test.go
@@ -104,15 +104,24 @@ func TestManagerClient_FetchConfig_Success(t *testing.T) {
 
 func TestManagerClient_FetchConfig_PreservesOutputSettingPolicy(t *testing.T) {
 	tests := []struct {
-		name string
-		in   *managerv1beta1.OutputSetting
+		name                  string
+		in                    *managerv1beta1.OutputSetting
+		redactProcessArgs     *bool
+		wantRedactProcessArgs *bool
 	}{
 		{
 			name: "nil remains nil",
 		},
 		{
-			name: "explicit zero policy remains explicit",
-			in:   &managerv1beta1.OutputSetting{Enabled: true},
+			name:                  "explicit output and redaction policy remain explicit",
+			in:                    &managerv1beta1.OutputSetting{Enabled: true},
+			redactProcessArgs:     boolPointer(false),
+			wantRedactProcessArgs: boolPointer(false),
+		},
+		{
+			name:                  "explicit enabled redaction remains enabled",
+			redactProcessArgs:     boolPointer(true),
+			wantRedactProcessArgs: boolPointer(true),
 		},
 	}
 
@@ -123,7 +132,8 @@ func TestManagerClient_FetchConfig_PreservesOutputSettingPolicy(t *testing.T) {
 					return connect.NewResponse(&managerv1beta1.FetchConfigResponse{
 						Config: &managerv1beta1.ServedConfig{
 							OutputSettings: &managerv1beta1.OutputSettings{
-								Detection: tt.in,
+								Detection:         tt.in,
+								RedactProcessArgs: tt.redactProcessArgs,
 							},
 						},
 					}), nil
@@ -151,6 +161,13 @@ func TestManagerClient_FetchConfig_PreservesOutputSettingPolicy(t *testing.T) {
 			if settings == nil {
 				t.Fatal("output_settings: got nil")
 			}
+			if tt.wantRedactProcessArgs == nil {
+				if settings.RedactProcessArgs != nil {
+					t.Fatalf("redact_process_args: got %v, want nil", settings.RedactProcessArgs)
+				}
+			} else if settings.RedactProcessArgs == nil || settings.GetRedactProcessArgs() != *tt.wantRedactProcessArgs {
+				t.Fatalf("redact_process_args: got %v, want %v", settings.RedactProcessArgs, *tt.wantRedactProcessArgs)
+			}
 			if tt.in == nil {
 				if settings.GetDetection() != nil {
 					t.Fatalf("detection: got %+v, want nil", settings.GetDetection())
@@ -166,6 +183,10 @@ func TestManagerClient_FetchConfig_PreservesOutputSettingPolicy(t *testing.T) {
 			}
 		})
 	}
+}
+
+func boolPointer(value bool) *bool {
+	return &value
 }
 
 func TestManagerClient_FetchConfig_ServerError(t *testing.T) {

--- a/internal/agent/managerclient/host_config_cache_test.go
+++ b/internal/agent/managerclient/host_config_cache_test.go
@@ -65,11 +65,13 @@ func TestHostConfigCache_FetchConfig(t *testing.T) {
 
 func TestHostConfigCache_FetchConfigClonesCachedResult(t *testing.T) {
 	req := testFetchConfigRequest()
+	redactProcessArgs := false
 	cache, err := NewHostConfigCache(slog.Default(), &sequenceFetcher{
 		results: []*FetchResult{{
 			ConfigRevision: "rev-1",
 			OutputSettings: &managerv1beta1.OutputSettings{
-				Summary: &managerv1beta1.OutputSetting{Enabled: true},
+				Summary:           &managerv1beta1.OutputSetting{Enabled: true},
+				RedactProcessArgs: &redactProcessArgs,
 			},
 		}},
 	}, req, time.Hour)
@@ -85,6 +87,7 @@ func TestHostConfigCache_FetchConfigClonesCachedResult(t *testing.T) {
 		t.Fatalf("FetchConfig first: %v", err)
 	}
 	first.OutputSettings.Summary.Enabled = false
+	*first.OutputSettings.RedactProcessArgs = true
 
 	second, err := cache.FetchConfig(t.Context(), req)
 	if err != nil {
@@ -92,6 +95,9 @@ func TestHostConfigCache_FetchConfigClonesCachedResult(t *testing.T) {
 	}
 	if !second.OutputSettings.GetSummary().GetEnabled() {
 		t.Fatal("cached output settings were mutated by caller")
+	}
+	if second.OutputSettings.RedactProcessArgs == nil || second.OutputSettings.GetRedactProcessArgs() {
+		t.Fatal("cached process args redaction policy was mutated by caller")
 	}
 }
 

--- a/internal/manager/startup_config.go
+++ b/internal/manager/startup_config.go
@@ -31,6 +31,7 @@ type StartupConfig struct {
 	DefaultMaxAlertsPerRule int               `yaml:"default_max_alerts_per_rule,omitempty"`
 	DisableBaselineRules    bool              `yaml:"disable_baseline_rules,omitempty"`
 	MonitorMode             bool              `yaml:"monitor_mode,omitempty"`
+	RedactProcessArgs       *bool             `yaml:"redact_process_args,omitempty"`
 	Sinks                   SinksConfig       `yaml:"sinks,omitempty"`
 	Logs                    LogsConfig        `yaml:"logs,omitempty"`
 }
@@ -97,6 +98,12 @@ func LoadStartupConfig(path string) (StartupConfig, error) {
 // BindAddress returns the net/http listen address represented by bind config.
 func (cfg StartupConfig) BindAddress() string {
 	return net.JoinHostPort(cfg.Bind.Address, strconv.Itoa(*cfg.Bind.Port))
+}
+
+// ProcessArgsRedactionEnabled keeps redaction enabled when the setting is
+// absent, including configs written before the setting existed.
+func (cfg StartupConfig) ProcessArgsRedactionEnabled() bool {
+	return cfg.RedactProcessArgs == nil || *cfg.RedactProcessArgs
 }
 
 func validateSinks(sinks SinksConfig) error {

--- a/internal/manager/startup_config_test.go
+++ b/internal/manager/startup_config_test.go
@@ -170,6 +170,34 @@ unexpected_field: true
 	}
 }
 
+func TestStartupConfig_ProcessArgsRedactionEnabled(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    bool
+	}{
+		{name: "omitted policy defaults to redaction", content: "monitor_mode: false\n", want: true},
+		{name: "explicit true enables redaction", content: "redact_process_args: true\n", want: true},
+		{name: "explicit false disables redaction", content: "redact_process_args: false\n", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "manager.yaml")
+			if err := os.WriteFile(path, []byte(tt.content), 0o600); err != nil {
+				t.Fatalf("write config: %v", err)
+			}
+			got, err := LoadStartupConfig(path)
+			if err != nil {
+				t.Fatalf("LoadStartupConfig: %v", err)
+			}
+			if got.ProcessArgsRedactionEnabled() != tt.want {
+				t.Fatalf("ProcessArgsRedactionEnabled: got %v, want %v", got.ProcessArgsRedactionEnabled(), tt.want)
+			}
+		})
+	}
+}
+
 func TestLoadStartupConfig_SinksAndLogs(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/internal/proto/cicd_sensor/manager/v1beta1/types.pb.go
+++ b/internal/proto/cicd_sensor/manager/v1beta1/types.pb.go
@@ -747,14 +747,18 @@ func (x *OutputSetting) GetFlushIntervalSeconds() uint32 {
 	return 0
 }
 
-// OutputSettings tells the agent which logs should be sent to manager.
+// OutputSettings tells the agent which logs to send to manager and how to
+// prepare them.
 type OutputSettings struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Detection     *OutputSetting         `protobuf:"bytes,1,opt,name=detection,proto3" json:"detection,omitempty"`
-	RuntimeEvent  *OutputSetting         `protobuf:"bytes,2,opt,name=runtime_event,json=runtimeEvent,proto3" json:"runtime_event,omitempty"`
-	Summary       *OutputSetting         `protobuf:"bytes,3,opt,name=summary,proto3" json:"summary,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state        protoimpl.MessageState `protogen:"open.v1"`
+	Detection    *OutputSetting         `protobuf:"bytes,1,opt,name=detection,proto3" json:"detection,omitempty"`
+	RuntimeEvent *OutputSetting         `protobuf:"bytes,2,opt,name=runtime_event,json=runtimeEvent,proto3" json:"runtime_event,omitempty"`
+	Summary      *OutputSetting         `protobuf:"bytes,3,opt,name=summary,proto3" json:"summary,omitempty"`
+	// Agents treat absence as true so older managers never opt them into
+	// sending unredacted process arguments.
+	RedactProcessArgs *bool `protobuf:"varint,4,opt,name=redact_process_args,json=redactProcessArgs,proto3,oneof" json:"redact_process_args,omitempty"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
 }
 
 func (x *OutputSettings) Reset() {
@@ -806,6 +810,13 @@ func (x *OutputSettings) GetSummary() *OutputSetting {
 		return x.Summary
 	}
 	return nil
+}
+
+func (x *OutputSettings) GetRedactProcessArgs() bool {
+	if x != nil && x.RedactProcessArgs != nil {
+		return *x.RedactProcessArgs
+	}
+	return false
 }
 
 var File_cicd_sensor_manager_v1beta1_types_proto protoreflect.FileDescriptor
@@ -890,11 +901,13 @@ const file_cicd_sensor_manager_v1beta1_types_proto_rawDesc = "" +
 	"\rOutputSetting\x12\x18\n" +
 	"\aenabled\x18\x01 \x01(\bR\aenabled\x122\n" +
 	"\x15flush_threshold_bytes\x18\x02 \x01(\rR\x13flushThresholdBytes\x124\n" +
-	"\x16flush_interval_seconds\x18\x03 \x01(\rR\x14flushIntervalSeconds\"\xf1\x01\n" +
+	"\x16flush_interval_seconds\x18\x03 \x01(\rR\x14flushIntervalSeconds\"\xbe\x02\n" +
 	"\x0eOutputSettings\x12H\n" +
 	"\tdetection\x18\x01 \x01(\v2*.cicd_sensor.manager.v1beta1.OutputSettingR\tdetection\x12O\n" +
 	"\rruntime_event\x18\x02 \x01(\v2*.cicd_sensor.manager.v1beta1.OutputSettingR\fruntimeEvent\x12D\n" +
-	"\asummary\x18\x03 \x01(\v2*.cicd_sensor.manager.v1beta1.OutputSettingR\asummaryB\x95\x02\n" +
+	"\asummary\x18\x03 \x01(\v2*.cicd_sensor.manager.v1beta1.OutputSettingR\asummary\x123\n" +
+	"\x13redact_process_args\x18\x04 \x01(\bH\x00R\x11redactProcessArgs\x88\x01\x01B\x16\n" +
+	"\x14_redact_process_argsB\x95\x02\n" +
 	"\x1fcom.cicd_sensor.manager.v1beta1B\n" +
 	"TypesProtoP\x01Z\\github.com/cicd-sensor/cicd-sensor/internal/proto/cicd_sensor/manager/v1beta1;managerv1beta1\xa2\x02\x03CMX\xaa\x02\x1aCicdSensor.Manager.V1beta1\xca\x02\x1aCicdSensor\\Manager\\V1beta1\xe2\x02&CicdSensor\\Manager\\V1beta1\\GPBMetadata\xea\x02\x1cCicdSensor::Manager::V1beta1b\x06proto3"
 
@@ -954,6 +967,7 @@ func file_cicd_sensor_manager_v1beta1_types_proto_init() {
 		return
 	}
 	file_cicd_sensor_manager_v1beta1_types_proto_msgTypes[7].OneofWrappers = []any{}
+	file_cicd_sensor_manager_v1beta1_types_proto_msgTypes[10].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{

--- a/proto/cicd_sensor/manager/v1beta1/types.proto
+++ b/proto/cicd_sensor/manager/v1beta1/types.proto
@@ -92,9 +92,13 @@ message OutputSetting {
   uint32 flush_interval_seconds = 3;
 }
 
-// OutputSettings tells the agent which logs should be sent to manager.
+// OutputSettings tells the agent which logs to send to manager and how to
+// prepare them.
 message OutputSettings {
   OutputSetting detection = 1;
   OutputSetting runtime_event = 2;
   OutputSetting summary = 3;
+  // Agents treat absence as true so older managers never opt them into
+  // sending unredacted process arguments.
+  optional bool redact_process_args = 4;
 }


### PR DESCRIPTION
Closes [#115](https://github.com/cicd-sensor/cicd-sensor/issues/115)

## What

- Add `redact_process_args` to `manager.yaml`, defaulting to `true`.
- Distribute the policy through the existing scope-local `OutputSettings`.
- Apply the policy before JSONL serialization and gzip compression for manager-bound Detection and Runtime Event Logs.
- Keep Agent-direct outputs, including project results and debug output, redacted.
- Generate separate payloads for host and project scopes without mutating the shared `EventRecord`.

```mermaid
flowchart LR
    Config["manager.yaml<br/>redact_process_args"]
    Manager["Manager<br/>OutputSettings"]
    Host["Host JobScopeState"]
    Project["Project JobScopeState"]
    Event["Shared EventRecord"]
    HostLogs["Manager-bound<br/>host logs"]
    ProjectLogs["Manager-bound<br/>project logs"]
    Direct["Agent-direct outputs<br/>always redacted"]

    Config --> Manager
    Manager -->|"FetchConfig"| Host
    Manager -->|"FetchConfig"| Project
    Event --> Host
    Event --> Project
    Event --> Direct
    Host -->|"scope policy"| HostLogs
    Project -->|"scope policy"| ProjectLogs
```

## Why

The Manager currently receives gzip-compressed JSONL batches as opaque payloads. Applying redaction in the Manager would require decompression, schema-aware JSONL rewriting, and recompression, expanding the Manager collector's responsibility and failure surface.

The Manager operator still owns the disclosure policy, but the Agent applies it before compression. Keeping the policy in `OutputSettings` also preserves the existing scope boundary, allowing host and project scopes to produce different representations of the same event safely.

The rollout remains secure by default:

- New Agent + old Manager: the optional field is absent, so the Agent redacts.
- Old Agent + new Manager: the unknown field is ignored and the old Agent continues to redact.
- New Agent + new Manager: captured argv is sent only when the Manager explicitly configures `redact_process_args: false`.
