### PR TITLE
feat(rules): cover protected path mount exposure

### DIFF
--- a/.github/workflows/releases-rules.yaml
+++ b/.github/workflows/releases-rules.yaml
@@ -72,6 +72,7 @@ jobs:
 
       - name: Build rules bundle
         run: |
+          make rules-test
           make rules-bundle-validate RULE_BUNDLE="${RUNNER_TEMP}/baseline-rules.yaml"
           gzip -n -c "${RUNNER_TEMP}/baseline-rules.yaml" > "${RUNNER_TEMP}/baseline-rules.yaml.gz"
 

--- a/.github/workflows/rules.yaml
+++ b/.github/workflows/rules.yaml
@@ -32,6 +32,8 @@ jobs:
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: go.mod
+      - name: Test rule behavior
+        run: make rules-test
       - name: Validate rules
         run: make rules-validate
       - name: Validate bundled rules

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,7 @@ help:
 	@printf '  %-29s %s\n' 'make build-ctl-cross' 'build cicd-sensorctl for macOS/Windows into ./dist'
 	@printf '  %-29s %s\n' 'make build-local-ctl' 'build cicd-sensorctl for the local host into ./bin'
 	@printf '  %-29s %s\n' 'make bench-cel' 'run CEL evaluation benchmark once'
+	@printf '  %-29s %s\n' 'make rules-test' 'run shipped rule behavior tests'
 	@printf '  %-29s %s\n' 'make rules-bundle' 'bundle rules/ into $(RULE_BUNDLE)'
 	@printf '  %-29s %s\n' 'make rules-artifact-validate' 'pull and validate an OCI rules artifact'
 	@printf '  %-29s %s\n' 'make integration' 'run integration tests'
@@ -131,6 +132,10 @@ bpf-integration:
 .PHONY: rules-validate
 rules-validate:
 	$(GO) run $(GO_MOD_FLAG) ./cmd/cicd-sensorctl rule validate rules/
+
+.PHONY: rules-test
+rules-test:
+	$(GO) test $(GO_MOD_FLAG) -tags rules_validation -count=1 ./rules
 
 .PHONY: rules-bundle
 rules-bundle:

--- a/rules/README.md
+++ b/rules/README.md
@@ -24,6 +24,7 @@ source-backed indicators that are too specific for the generic baseline rules.
 Validate locally:
 
 ```sh
+make rules-test              # evaluate shipped rules against behavior cases
 make rules-validate          # parse + CEL compile + schema
 make rules-bundle-validate   # also bundle and re-validate the bundle
 ```

--- a/rules/generic-persistence.yaml
+++ b/rules/generic-persistence.yaml
@@ -11,6 +11,9 @@ rule_sets:
       user_systemd_fragments:
         - "/.config/systemd/user/"
 
+      user_systemd_dir_fragments:
+        - "/.config/systemd/user"
+
       systemctl_user_persistence_verbs:
         - "daemon-reload"
         - "enable"
@@ -31,10 +34,23 @@ rule_sets:
       cron_persistence_files:
         - "/etc/crontab"
 
+      # Mount events can name a protected directory itself, while the lists
+      # above use trailing slashes to match files placed below the directory.
+      cron_persistence_dir_roots:
+        - "/etc/cron.d"
+        - "/etc/cron.hourly"
+        - "/etc/cron.daily"
+        - "/etc/cron.weekly"
+        - "/etc/cron.monthly"
+        - "/var/spool/cron"
+
       # Shell startup files (system-wide and per-user). System directories use
       # startsWith(); per-user dotfiles use endsWith() against the home path.
       shell_rc_dirs:
         - "/etc/profile.d/"
+
+      shell_rc_dir_roots:
+        - "/etc/profile.d"
 
       shell_rc_files:
         - "/etc/profile"
@@ -60,6 +76,9 @@ rule_sets:
       # Dynamic-linker preload / config locations.
       ld_preload_dirs:
         - "/etc/ld.so.conf.d/"
+
+      ld_preload_dir_roots:
+        - "/etc/ld.so.conf.d"
 
       ld_preload_files:
         - "/etc/ld.so.preload"
@@ -149,12 +168,91 @@ rule_sets:
         tags:
           mitre_tactic: persistence
 
+      # --- Protected path mount exposure -----------------------------------
+      # file_open.path remains process-visible, so a mount can expose the same
+      # persistence location through an alias. These rules detect the mount
+      # attempt that created the alias. source_path is best-effort: classic
+      # mount(2) supplies the raw caller string, which may be relative or
+      # symlinked.
+      - rule_id: cron_mount_exposure
+        rule_name: "Supply-chain: cron persistence path exposed by mount"
+        description: |
+          What:
+            Detects a mount attempt that exposes a system cron file or directory through another path.
+          Why:
+            A later write through the alias can install cron persistence while file_open reports only the alias path.
+          Notes:
+            The event records an attempt, not confirmed success. Classic mount sources are raw, non-canonical strings; review the target path and process context.
+        event_type: mount
+        condition: |
+          list.cron_persistence_dir_roots.exists(d, source_path == d) ||
+          list.cron_persistence_dirs.exists(d, source_path.startsWith(d)) ||
+          list.cron_persistence_files.exists(f, source_path == f)
+        action: detect
+        tags:
+          mitre_tactic: defense-evasion,persistence
+
+      - rule_id: shell_rc_mount_exposure
+        rule_name: "Supply-chain: shell startup path exposed by mount"
+        description: |
+          What:
+            Collects a mount attempt that exposes a shell startup file or directory through another path.
+          Why:
+            A later write through the alias can modify shell startup behavior while file_open reports only the alias path.
+          Notes:
+            Dotfile and container workflows can intentionally mount shell startup files. Classic mount sources are raw, non-canonical strings; review the target path and process context before treating the event as suspicious.
+        event_type: mount
+        condition: |
+          list.shell_rc_dir_roots.exists(d, source_path == d) ||
+          list.shell_rc_dirs.exists(d, source_path.startsWith(d)) ||
+          list.shell_rc_files.exists(f, source_path == f) ||
+          list.shell_rc_suffixes.exists(s, source_path.endsWith(s))
+        action: collect
+        tags:
+          mitre_tactic: defense-evasion,persistence
+
+      - rule_id: ld_so_preload_mount_exposure
+        rule_name: "Supply-chain: dynamic linker path exposed by mount"
+        description: |
+          What:
+            Detects a mount attempt that exposes an ld.so preload or configuration path through another path.
+          Why:
+            A later write through the alias can configure process-wide library injection while file_open reports only the alias path.
+          Notes:
+            The event records an attempt, not confirmed success. Classic mount sources are raw, non-canonical strings; investigate the source, target, and process context.
+        event_type: mount
+        condition: |
+          list.ld_preload_dir_roots.exists(d, source_path == d) ||
+          list.ld_preload_dirs.exists(d, source_path.startsWith(d)) ||
+          list.ld_preload_files.exists(f, source_path == f)
+        action: detect
+        tags:
+          mitre_tactic: defense-evasion,persistence
+
+      - rule_id: user_systemd_service_mount_exposure
+        rule_name: "Supply-chain: user systemd path exposed by mount"
+        description: |
+          What:
+            Detects a mount attempt that exposes a user systemd configuration path through another path.
+          Why:
+            A later write through the alias can install a user service while file_open reports only the alias path.
+          Notes:
+            The event records an attempt, not confirmed success. Classic mount sources are raw, non-canonical strings; review the target path and process context.
+        event_type: mount
+        condition: |
+          list.user_systemd_dir_fragments.exists(p, source_path.endsWith(p)) ||
+          list.user_systemd_fragments.exists(p, source_path.contains(p))
+        action: detect
+        tags:
+          mitre_tactic: defense-evasion,persistence
+
       # --- Cron persistence -------------------------------------------------
       # cron_write/_move/_link cover the three ways a payload reaches a
       # protected cron location: writing it open(O_WRONLY), renaming a file
       # already staged elsewhere (mv), or linking it in (ln). A rule bound to
       # file_open alone is bypassed by the move/link primitives, so each
-      # protected location is monitored across all three event types.
+      # protected location is monitored across all three event types. Mount
+      # aliases are covered separately by cron_mount_exposure above.
       - rule_id: cron_write
         rule_name: "Supply-chain: cron persistence file write"
         description: |

--- a/rules/generic_persistence_test.go
+++ b/rules/generic_persistence_test.go
@@ -1,6 +1,10 @@
-package rulesource_test
+//go:build rules_validation
+
+package rules_test
 
 import (
+	"slices"
+	"strings"
 	"testing"
 
 	"github.com/cicd-sensor/cicd-sensor/internal/jobevent"
@@ -9,16 +13,14 @@ import (
 	"github.com/cicd-sensor/cicd-sensor/internal/rulesource"
 )
 
-// TestPersistenceRulesCoverMoveAndLinkBypass is the regression guard for
-// issue #107: protected-path persistence rules must match across file_open,
-// file_move (mv / rename), and file_link (ln) so that staging a payload and
-// then renaming or linking it into a protected location is not a detection
-// blind spot. It loads the actually shipped baseline ruleset and evaluates
-// the real rule conditions, so it fails if a rule is removed or narrowed.
-func TestPersistenceRulesCoverMoveAndLinkBypass(t *testing.T) {
+// TestPersistenceRulesCoverLandingBypasses is the regression guard for issues
+// #107 and #108. Protected persistence locations must remain covered when a
+// payload is written, moved, linked, or exposed through a mount alias. It loads
+// the shipped baseline ruleset and evaluates the real rule conditions.
+func TestPersistenceRulesCoverLandingBypasses(t *testing.T) {
 	t.Parallel()
 
-	loaded, err := rulesource.LoadRulesFile("../../rules/generic-persistence.yaml")
+	loaded, err := rulesource.LoadRulesFile("generic-persistence.yaml")
 	if err != nil {
 		t.Fatalf("load persistence rules: %v", err)
 	}
@@ -52,6 +54,18 @@ func TestPersistenceRulesCoverMoveAndLinkBypass(t *testing.T) {
 		{"cron_move", celengine.CELInputEvent{FromPath: "/tmp/job", ToPath: "/workspace/rootfs/etc/cron.d/fixture"}, false},
 		{"cron_link", celengine.CELInputEvent{CreatedPath: "/etc/cron.d/evil", ExistingPath: "/tmp/job", IsSymlink: true}, true},
 		{"cron_link", celengine.CELInputEvent{CreatedPath: "/workspace/rootfs/etc/cron.d/fixture", ExistingPath: "/tmp/job", IsSymlink: true}, false},
+		{"cron_mount_exposure", celengine.CELInputEvent{SourcePath: "/etc/cron.d", TargetPath: "/tmp/cron"}, true},
+		{"cron_mount_exposure", celengine.CELInputEvent{SourcePath: "/etc/cron.d/", TargetPath: "/tmp/cron"}, true},
+		{"cron_mount_exposure", celengine.CELInputEvent{SourcePath: "/etc/cron.d/evil", TargetPath: "/tmp/cron"}, true},
+		{"cron_mount_exposure", celengine.CELInputEvent{SourcePath: "/var/spool/cron", TargetPath: "/tmp/cron"}, true},
+		{"cron_mount_exposure", celengine.CELInputEvent{SourcePath: "/etc/crontab", TargetPath: "/tmp/crontab"}, true},
+		{"cron_mount_exposure", celengine.CELInputEvent{SourcePath: "/workspace/rootfs/etc/cron.d", TargetPath: "/tmp/cron"}, false},
+		{"cron_mount_exposure", celengine.CELInputEvent{SourcePath: "/tmp/source", TargetPath: "/etc/cron.d"}, false},
+		{"cron_mount_exposure", celengine.CELInputEvent{SourcePath: "/etc", TargetPath: "/tmp/etc"}, false},
+		{"cron_mount_exposure", celengine.CELInputEvent{SourcePath: "etc/cron.d", TargetPath: "/tmp/cron"}, false},
+		{"cron_mount_exposure", celengine.CELInputEvent{SourcePath: "/etc/cron.daily-backup", TargetPath: "/tmp/cron"}, false},
+		{"cron_mount_exposure", celengine.CELInputEvent{SourcePath: "/var/lib/docker/overlay2/rootfs", TargetPath: "/tmp/rootfs"}, false},
+		{"cron_mount_exposure", celengine.CELInputEvent{TargetPath: "/tmp/cron"}, false},
 
 		// Shell startup files.
 		{"shell_rc_write", celengine.CELInputEvent{Path: "/home/runner/.bashrc", IsWrite: true}, true},
@@ -64,6 +78,13 @@ func TestPersistenceRulesCoverMoveAndLinkBypass(t *testing.T) {
 		{"shell_rc_link", celengine.CELInputEvent{CreatedPath: "/home/runner/.zshrc", ExistingPath: "/tmp/rc", IsSymlink: true}, true},
 		{"shell_rc_link", celengine.CELInputEvent{CreatedPath: "/workspace/dotfiles/.zshrc", ExistingPath: "/tmp/rc", IsSymlink: true}, true},
 		{"shell_rc_link", celengine.CELInputEvent{CreatedPath: "/workspace/rootfs/etc/profile.d/fixture.sh", ExistingPath: "/tmp/rc", IsSymlink: true}, false},
+		{"shell_rc_mount_exposure", celengine.CELInputEvent{SourcePath: "/etc/profile.d", TargetPath: "/tmp/profile.d"}, true},
+		{"shell_rc_mount_exposure", celengine.CELInputEvent{SourcePath: "/etc/profile.d/evil.sh", TargetPath: "/tmp/profile"}, true},
+		{"shell_rc_mount_exposure", celengine.CELInputEvent{SourcePath: "/etc/profile", TargetPath: "/tmp/profile"}, true},
+		{"shell_rc_mount_exposure", celengine.CELInputEvent{SourcePath: "/home/runner/.bashrc", TargetPath: "/tmp/bashrc"}, true},
+		{"shell_rc_mount_exposure", celengine.CELInputEvent{SourcePath: "/workspace/rootfs/etc/profile", TargetPath: "/tmp/profile"}, false},
+		{"shell_rc_mount_exposure", celengine.CELInputEvent{SourcePath: "/etc/profile.d-backup", TargetPath: "/tmp/profile"}, false},
+		{"shell_rc_mount_exposure", celengine.CELInputEvent{SourcePath: "/proc/thread-self/fd/10", TargetPath: "/tmp/fd"}, false},
 
 		// Dynamic linker preload.
 		{"ld_so_preload_write", celengine.CELInputEvent{Path: "/etc/ld.so.preload", IsWrite: true}, true},
@@ -72,10 +93,20 @@ func TestPersistenceRulesCoverMoveAndLinkBypass(t *testing.T) {
 		{"ld_so_preload_move", celengine.CELInputEvent{FromPath: "/tmp/p", ToPath: "/workspace/rootfs/etc/ld.so.conf.d/fixture.conf"}, false},
 		{"ld_so_preload_link", celengine.CELInputEvent{CreatedPath: "/etc/ld.so.conf.d/evil.conf", ExistingPath: "/tmp/p", IsHardlink: true}, true},
 		{"ld_so_preload_link", celengine.CELInputEvent{CreatedPath: "/workspace/rootfs/etc/ld.so.conf.d/fixture.conf", ExistingPath: "/tmp/p", IsHardlink: true}, false},
+		{"ld_so_preload_mount_exposure", celengine.CELInputEvent{SourcePath: "/etc/ld.so.conf.d", TargetPath: "/tmp/ld"}, true},
+		{"ld_so_preload_mount_exposure", celengine.CELInputEvent{SourcePath: "/etc/ld.so.preload", TargetPath: "/tmp/preload"}, true},
+		{"ld_so_preload_mount_exposure", celengine.CELInputEvent{SourcePath: "/etc/ld.so.conf", TargetPath: "/tmp/ld"}, true},
+		{"ld_so_preload_mount_exposure", celengine.CELInputEvent{SourcePath: "/workspace/rootfs/etc/ld.so.preload", TargetPath: "/tmp/preload"}, false},
+		{"ld_so_preload_mount_exposure", celengine.CELInputEvent{SourcePath: "/etc/ld.so.conf.d-backup", TargetPath: "/tmp/ld"}, false},
+		{"ld_so_preload_mount_exposure", celengine.CELInputEvent{SourcePath: "/var/lib/docker/overlay2/rootfs", TargetPath: "/tmp/rootfs"}, false},
 
 		// User systemd service unit (same move/link gap closed).
 		{"user_systemd_service_move", celengine.CELInputEvent{FromPath: "/tmp/x.service", ToPath: "/home/runner/.config/systemd/user/x.service"}, true},
 		{"user_systemd_service_link", celengine.CELInputEvent{CreatedPath: "/home/runner/.config/systemd/user/x.service", ExistingPath: "/tmp/x.service", IsSymlink: true}, true},
+		{"user_systemd_service_mount_exposure", celengine.CELInputEvent{SourcePath: "/home/runner/.config/systemd/user", TargetPath: "/tmp/user-systemd"}, true},
+		{"user_systemd_service_mount_exposure", celengine.CELInputEvent{SourcePath: "/home/runner/.config/systemd/user/evil.service", TargetPath: "/tmp/evil.service"}, true},
+		{"user_systemd_service_mount_exposure", celengine.CELInputEvent{SourcePath: "/workspace/systemd/evil.service", TargetPath: "/tmp/evil.service"}, false},
+		{"user_systemd_service_mount_exposure", celengine.CELInputEvent{SourcePath: "/var/lib/docker/overlay2/rootfs", TargetPath: "/tmp/rootfs"}, false},
 	}
 
 	for _, tc := range cases {
@@ -106,17 +137,21 @@ func TestPersistenceRulesCoverMoveAndLinkBypass(t *testing.T) {
 	}
 
 	wantActions := map[string]rule.RuleAction{
-		"cron_write":                rule.RuleActionCollect,
-		"cron_move":                 rule.RuleActionCollect,
-		"cron_link":                 rule.RuleActionDetect,
-		"shell_rc_write":            rule.RuleActionCollect,
-		"shell_rc_move":             rule.RuleActionCollect,
-		"shell_rc_link":             rule.RuleActionCollect,
-		"ld_so_preload_write":       rule.RuleActionDetect,
-		"ld_so_preload_move":        rule.RuleActionDetect,
-		"ld_so_preload_link":        rule.RuleActionDetect,
-		"user_systemd_service_move": rule.RuleActionDetect,
-		"user_systemd_service_link": rule.RuleActionDetect,
+		"cron_write":                          rule.RuleActionCollect,
+		"cron_move":                           rule.RuleActionCollect,
+		"cron_link":                           rule.RuleActionDetect,
+		"cron_mount_exposure":                 rule.RuleActionDetect,
+		"shell_rc_write":                      rule.RuleActionCollect,
+		"shell_rc_move":                       rule.RuleActionCollect,
+		"shell_rc_link":                       rule.RuleActionCollect,
+		"shell_rc_mount_exposure":             rule.RuleActionCollect,
+		"ld_so_preload_write":                 rule.RuleActionDetect,
+		"ld_so_preload_move":                  rule.RuleActionDetect,
+		"ld_so_preload_link":                  rule.RuleActionDetect,
+		"ld_so_preload_mount_exposure":        rule.RuleActionDetect,
+		"user_systemd_service_move":           rule.RuleActionDetect,
+		"user_systemd_service_link":           rule.RuleActionDetect,
+		"user_systemd_service_mount_exposure": rule.RuleActionDetect,
 	}
 	for id, want := range wantActions {
 		r, ok := byID[id]
@@ -150,10 +185,45 @@ func TestPersistenceRulesCoverMoveAndLinkBypass(t *testing.T) {
 			}
 		}
 	}
+
+	for _, id := range []string{
+		"cron_mount_exposure",
+		"shell_rc_mount_exposure",
+		"ld_so_preload_mount_exposure",
+		"user_systemd_service_mount_exposure",
+	} {
+		r, ok := byID[id]
+		if !ok {
+			t.Fatalf("expected rule %q to be shipped", id)
+		}
+		if r.EventType != jobevent.Mount {
+			t.Fatalf("rule %q event_type=%q, want %q", id, r.EventType, jobevent.Mount)
+		}
+	}
+
+	for _, pair := range []struct {
+		dirs  string
+		roots string
+	}{
+		{dirs: "cron_persistence_dirs", roots: "cron_persistence_dir_roots"},
+		{dirs: "shell_rc_dirs", roots: "shell_rc_dir_roots"},
+		{dirs: "ld_preload_dirs", roots: "ld_preload_dir_roots"},
+	} {
+		dirs := slices.Clone(set.Lists[pair.dirs])
+		for i := range dirs {
+			dirs[i] = strings.TrimSuffix(dirs[i], "/")
+		}
+		if !slices.Equal(dirs, set.Lists[pair.roots]) {
+			t.Fatalf("list %q must equal %q with trailing slashes removed: got %v, want %v",
+				pair.roots, pair.dirs, set.Lists[pair.roots], dirs)
+		}
+	}
 }
 
 func caseLabel(in celengine.CELInputEvent) string {
 	switch {
+	case in.SourcePath != "":
+		return "source=" + in.SourcePath
 	case in.ToPath != "":
 		return "to=" + in.ToPath
 	case in.CreatedPath != "":


### PR DESCRIPTION
Closes #108.

## What

Add baseline persistence rules for mount attempts that expose known sensitive paths through another location.

| Protected path family | Action |
| --- | --- |
| Cron files and directories | `detect` |
| Shell startup files | `collect` |
| Dynamic linker configuration | `detect` |
| User systemd configuration | `detect` |

The rules match `mount.source_path` only. Shell startup mounts remain `collect` because dotfile and container workflows may mount them intentionally.

Move the shipped-rule behavior test under `rules/` and add `make rules-test`. The dedicated Rules workflow and rules release workflow now run these semantic tests in addition to schema and CEL compilation.

## Why

`file_open.path` is the process-visible path. If a protected file or directory is exposed through a mount alias, a later write can appear only under that alias and bypass the existing path-based persistence rules.

The `mount` event added in #122 provides the operation needed to observe this setup. These rules intentionally cover only direct, known source paths:

- classic `mount(2)` sources are raw and non-canonical;
- relative and symlinked source aliases are not resolved;
- protected paths appearing only as `target_path` are not matched.

This keeps the initial rules narrow. In measured dind workloads, normal container setup used sources under `/var/lib/docker`, `/proc`, and similar runtime paths, which do not match these rules.
