### PR TITLE
chore(deps): schedule Renovate updates weekly

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -7,6 +7,13 @@
   "dependencyDashboard": true,
   "internalChecksFilter": "strict",
   "rebaseWhen": "behind-base-branch",
+  // Routine dependency branches are created and updated Tuesday morning JST.
+  // Renovate vulnerability alert PRs bypass this schedule.
+  "timezone": "Asia/Tokyo",
+  "schedule": [
+    "* 9-12 * * 2"
+  ],
+  "updateNotScheduled": false,
   "labels": [
     "dependencies"
   ],
@@ -38,15 +45,12 @@
       "groupName": "github actions"
     },
     {
-      "description": "Group Dockerfile base image updates weekly before 1am UTC Tuesday / 10am JST Tuesday",
+      "description": "Group Dockerfile base image updates",
       "matchManagers": [
         "dockerfile"
       ],
       "groupName": "dockerfile base images",
-      "minimumReleaseAgeBehaviour": "timestamp-optional",
-      "schedule": [
-        "before 1am on tuesday"
-      ]
+      "minimumReleaseAgeBehaviour": "timestamp-optional"
     },
     {
       "description": "Update SHA-pinned GitHub Actions examples in README and docs",


### PR DESCRIPTION
## What

- Schedule routine Renovate updates for Tuesday mornings, `09:00-13:00 JST`.
- Apply the schedule consistently across Go modules, GitHub Actions, Docker images, and documentation examples.
- Prevent existing dependency branches from updating outside the scheduled window.
- Keep vulnerability alert updates exempt from the weekly schedule.

## Why

Reduce dependency update churn by batching routine updates into one weekly window, while preserving the existing seven-day minimum release age and immediate handling of security advisories.
