### PR TITLE
feat(agent): make job TTL configurable via --job-ttl

### DIFF
--- a/cmd/cicd-sensor/agent.go
+++ b/cmd/cicd-sensor/agent.go
@@ -32,6 +32,7 @@ type agentStartOptions struct {
 	SocketPath                string
 	GitHubK8sRunnerSocketPath string
 	ShutdownGrace             time.Duration
+	JobTTL                    time.Duration
 }
 
 func runAgentSubcommand(args []string) {
@@ -57,6 +58,7 @@ func runAgentStart(args []string) {
 	var managerTokenFilePath string
 	var githubK8sRunnerSocketPath string
 	var shutdownGrace time.Duration
+	var jobTTL time.Duration
 	socketPath = defaultSocketPath
 	githubK8sRunnerSocketPath = os.Getenv("CICD_SENSOR_GITHUB_K8S_RUNNER_SOCKET")
 	fs.Usage = func() {
@@ -77,6 +79,8 @@ func runAgentStart(args []string) {
 		fmt.Fprintln(fs.Output(), "        Host scope manager bearer token. Required only when --manager-url is set.")
 		fmt.Fprintln(fs.Output(), "  --shutdown-grace DURATION")
 		fmt.Fprintln(fs.Output(), "        Best-effort drain window used after SIGTERM. (default 8s)")
+		fmt.Fprintln(fs.Output(), "  --job-ttl DURATION")
+		fmt.Fprintln(fs.Output(), "        Maximum lifetime of a job before forced finalization. (default 24h)")
 	}
 	fs.StringVar(&socketPath, "socket", socketPath, "Agent control socket path.")
 	fs.StringVar(&githubK8sRunnerSocketPath, "github-k8s-runner-socket", githubK8sRunnerSocketPath, "GitHub Kubernetes runner socket path.")
@@ -85,6 +89,7 @@ func runAgentStart(args []string) {
 	fs.StringVar(&managerURL, "manager-url", "", "Host scope manager URL.")
 	fs.StringVar(&managerTokenFilePath, "manager-token-file", "", "Path to a file containing the host scope manager bearer token. Overrides CICD_SENSOR_MANAGER_TOKEN.")
 	fs.DurationVar(&shutdownGrace, "shutdown-grace", 8*time.Second, "Best-effort drain window used after SIGTERM.")
+	fs.DurationVar(&jobTTL, "job-ttl", 24*time.Hour, "Maximum lifetime of a job before forced finalization.")
 	if err := fs.Parse(args[1:]); err != nil {
 		os.Exit(2)
 	}
@@ -106,6 +111,7 @@ func runAgentStart(args []string) {
 		SocketPath:                socketPath,
 		GitHubK8sRunnerSocketPath: githubK8sRunnerSocketPath,
 		ShutdownGrace:             shutdownGrace,
+		JobTTL:                    jobTTL,
 	}
 	if err := validateAgentStartRequiredOptions(opts); err != nil {
 		fmt.Fprintln(os.Stderr, err)
@@ -158,6 +164,7 @@ func runAgentStart(args []string) {
 
 	a := agent.NewAgent(logger, opts.SocketPath, jobcontext.Provider(opts.Provider), opts.Runner, hostManager, hostManagerClient)
 	a.SetShutdownGrace(opts.ShutdownGrace)
+	a.SetJobTTL(opts.JobTTL)
 	a.SetGitHubK8sRunnerSocketPath(opts.GitHubK8sRunnerSocketPath)
 	if err := a.Run(ctx); err != nil {
 		if errors.Is(err, listener.ErrAlreadyRunning) {
@@ -209,6 +216,9 @@ func validateAgentStartRequiredOptions(opts agentStartOptions) error {
 	}
 	if opts.ShutdownGrace <= 0 {
 		return fmt.Errorf("shutdown-grace must be positive")
+	}
+	if opts.JobTTL <= 0 {
+		return fmt.Errorf("job-ttl must be positive")
 	}
 	return nil
 }

--- a/cmd/cicd-sensor/agent.go
+++ b/cmd/cicd-sensor/agent.go
@@ -8,10 +8,12 @@ import (
 	"log/slog"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 
 	"github.com/cicd-sensor/cicd-sensor/internal/agent"
+	"github.com/cicd-sensor/cicd-sensor/internal/agent/job"
 	"github.com/cicd-sensor/cicd-sensor/internal/agent/listener"
 	"github.com/cicd-sensor/cicd-sensor/internal/agent/managerclient"
 	"github.com/cicd-sensor/cicd-sensor/internal/jobcontext"
@@ -79,8 +81,7 @@ func runAgentStart(args []string) {
 		fmt.Fprintln(fs.Output(), "        Host scope manager bearer token. Required only when --manager-url is set.")
 		fmt.Fprintln(fs.Output(), "  --shutdown-grace DURATION")
 		fmt.Fprintln(fs.Output(), "        Best-effort drain window used after SIGTERM. (default 8s)")
-		fmt.Fprintln(fs.Output(), "  --job-ttl DURATION")
-		fmt.Fprintln(fs.Output(), "        Maximum lifetime of a job before forced finalization. (default 24h)")
+		fmt.Fprintf(fs.Output(), "  --job-ttl DURATION\n        Job age threshold after which the job is expired and forcibly finalized.\n        Expiry is checked about once per minute, so finalization may happen up to\n        about one minute after the TTL is reached. (default %s)\n", formatDuration(job.DefaultTTL))
 	}
 	fs.StringVar(&socketPath, "socket", socketPath, "Agent control socket path.")
 	fs.StringVar(&githubK8sRunnerSocketPath, "github-k8s-runner-socket", githubK8sRunnerSocketPath, "GitHub Kubernetes runner socket path.")
@@ -89,7 +90,7 @@ func runAgentStart(args []string) {
 	fs.StringVar(&managerURL, "manager-url", "", "Host scope manager URL.")
 	fs.StringVar(&managerTokenFilePath, "manager-token-file", "", "Path to a file containing the host scope manager bearer token. Overrides CICD_SENSOR_MANAGER_TOKEN.")
 	fs.DurationVar(&shutdownGrace, "shutdown-grace", 8*time.Second, "Best-effort drain window used after SIGTERM.")
-	fs.DurationVar(&jobTTL, "job-ttl", 24*time.Hour, "Maximum lifetime of a job before forced finalization.")
+	fs.DurationVar(&jobTTL, "job-ttl", job.DefaultTTL, "Job age threshold after which the job is expired and forcibly finalized; expiry is checked about once per minute.")
 	if err := fs.Parse(args[1:]); err != nil {
 		os.Exit(2)
 	}
@@ -221,6 +222,21 @@ func validateAgentStartRequiredOptions(opts agentStartOptions) error {
 		return fmt.Errorf("job-ttl must be positive")
 	}
 	return nil
+}
+
+// formatDuration renders d like Duration.String but without zero-valued
+// trailing units, so help text reads "24h" instead of "24h0m0s". Only
+// suffixes that follow a larger unit are trimmed; values like "30s" or
+// "1h0m30s" are returned unchanged.
+func formatDuration(d time.Duration) string {
+	s := d.String()
+	if strings.HasSuffix(s, "h0m0s") {
+		return strings.TrimSuffix(s, "0m0s")
+	}
+	if strings.HasSuffix(s, "m0s") {
+		return strings.TrimSuffix(s, "0s")
+	}
+	return s
 }
 
 func resolveAgentStartOptions(opts agentStartOptions) (agentStartOptions, error) {

--- a/cmd/cicd-sensor/agent_test.go
+++ b/cmd/cicd-sensor/agent_test.go
@@ -193,6 +193,31 @@ func TestResolveAgentStartOptions(t *testing.T) {
 	}
 }
 
+func TestFormatDuration(t *testing.T) {
+	tests := []struct {
+		name string
+		d    time.Duration
+		want string
+	}{
+		{name: "trims zero minutes and seconds after hours (the --job-ttl default)", d: 24 * time.Hour, want: "24h"},
+		{name: "trims zero seconds after minutes", d: 90 * time.Minute, want: "1h30m"},
+		{name: "trims zero seconds after bare minutes", d: time.Minute, want: "1m"},
+		{name: "keeps seconds-only value unchanged", d: 30 * time.Second, want: "30s"},
+		{name: "keeps zero middle unit when seconds are non-zero", d: time.Hour + 30*time.Second, want: "1h0m30s"},
+		{name: "keeps sub-second value unchanged", d: 1500 * time.Millisecond, want: "1.5s"},
+		{name: "keeps zero duration canonical form", d: 0, want: "0s"},
+		{name: "trims negative duration the same way", d: -24 * time.Hour, want: "-24h"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := formatDuration(tc.d); got != tc.want {
+				t.Fatalf("formatDuration(%v): got %q, want %q", tc.d, got, tc.want)
+			}
+		})
+	}
+}
+
 func withAgentProvider(opts agentStartOptions, provider string) agentStartOptions {
 	opts.Provider = provider
 	return opts

--- a/cmd/cicd-sensor/agent_test.go
+++ b/cmd/cicd-sensor/agent_test.go
@@ -13,6 +13,7 @@ func TestValidateAgentStartRequiredOptions(t *testing.T) {
 		Provider:      "github",
 		Runner:        "machine",
 		ShutdownGrace: time.Second,
+		JobTTL:        time.Hour,
 	}
 
 	tests := []struct {
@@ -27,6 +28,7 @@ func TestValidateAgentStartRequiredOptions(t *testing.T) {
 				Provider:      "gitlab",
 				Runner:        "kubernetes",
 				ShutdownGrace: time.Second,
+				JobTTL:        time.Hour,
 			},
 		},
 		{
@@ -53,6 +55,11 @@ func TestValidateAgentStartRequiredOptions(t *testing.T) {
 			name:        "non-positive shutdown grace",
 			opts:        withAgentShutdownGrace(valid, 0),
 			wantErrText: "shutdown-grace must be positive",
+		},
+		{
+			name:        "non-positive job ttl",
+			opts:        withAgentJobTTL(valid, 0),
+			wantErrText: "job-ttl must be positive",
 		},
 		{
 			name:        "github k8s runner socket outside github kubernetes",
@@ -85,6 +92,7 @@ func TestValidateAgentStartOptionsRequiresManagerToken(t *testing.T) {
 		Provider:      "github",
 		Runner:        "machine",
 		ShutdownGrace: time.Second,
+		JobTTL:        time.Hour,
 	}
 
 	if err := validateAgentStartOptions(opts); err != nil {
@@ -111,6 +119,7 @@ func TestValidateAgentStartOptionsRequiresManagerForKubernetes(t *testing.T) {
 		Provider:      "github",
 		Runner:        "kubernetes",
 		ShutdownGrace: time.Second,
+		JobTTL:        time.Hour,
 	}
 
 	err := validateAgentStartOptions(opts)
@@ -196,6 +205,11 @@ func withAgentRunner(opts agentStartOptions, runner string) agentStartOptions {
 
 func withAgentShutdownGrace(opts agentStartOptions, shutdownGrace time.Duration) agentStartOptions {
 	opts.ShutdownGrace = shutdownGrace
+	return opts
+}
+
+func withAgentJobTTL(opts agentStartOptions, jobTTL time.Duration) agentStartOptions {
+	opts.JobTTL = jobTTL
 	return opts
 }
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -27,6 +27,7 @@ type Agent struct {
 	socketPath                string
 	githubK8sRunnerSocketPath string
 	shutdownGrace             time.Duration
+	jobTTL                    time.Duration
 	reaperCancel              context.CancelFunc
 	cancelEngine              context.CancelFunc
 	engineDone                <-chan error
@@ -55,6 +56,14 @@ func NewAgent(logger *slog.Logger, socketPath string, provider jobcontext.Provid
 func (a *Agent) SetShutdownGrace(grace time.Duration) {
 	if grace > 0 {
 		a.shutdownGrace = grace
+	}
+}
+
+// SetJobTTL overrides the default maximum job lifetime before forced
+// finalization. Non-positive values are ignored.
+func (a *Agent) SetJobTTL(ttl time.Duration) {
+	if ttl > 0 {
+		a.jobTTL = ttl
 	}
 }
 
@@ -87,6 +96,7 @@ func (a *Agent) Run(ctx context.Context) error {
 		}
 	}
 	jobRegistry := jobregistry.New(a.logger)
+	jobRegistry.SetJobTTL(a.jobTTL)
 
 	kernelTracker, err := kerneltracker.New(a.logger, jobRegistry)
 	if err != nil {

--- a/internal/agent/job/job.go
+++ b/internal/agent/job/job.go
@@ -31,7 +31,8 @@ const (
 	JobStateClosing JobState = "closing"
 )
 
-// DefaultTTL is the maximum lifetime of a job before forced finalization.
+// DefaultTTL is the maximum lifetime of a job before forced finalization,
+// used when NewJob receives a non-positive ttl.
 const DefaultTTL = 24 * time.Hour
 
 var (
@@ -71,11 +72,15 @@ type evaluationBundle struct {
 	evaluation *evaluation.EvaluationState
 }
 
-// NewJob creates a running job.
-func NewJob(logger *slog.Logger, identity jobcontext.JobIdentity, metadata jobcontext.JobMetadata, runnerType string, eventCh <-chan jobevent.EventRecord) *Job {
+// NewJob creates a running job. The TTL deadline is derived once here and
+// never changes afterward; a non-positive ttl falls back to DefaultTTL.
+func NewJob(logger *slog.Logger, identity jobcontext.JobIdentity, metadata jobcontext.JobMetadata, runnerType string, eventCh <-chan jobevent.EventRecord, ttl time.Duration) *Job {
 	now := time.Now().UTC()
 	if logger == nil {
 		logger = slog.Default()
+	}
+	if ttl <= 0 {
+		ttl = DefaultTTL
 	}
 
 	job := &Job{
@@ -87,7 +92,7 @@ func NewJob(logger *slog.Logger, identity jobcontext.JobIdentity, metadata jobco
 		eventCh:    eventCh,
 		doneCh:     make(chan struct{}),
 		startedAt:  now,
-		deadlineAt: now.Add(DefaultTTL),
+		deadlineAt: now.Add(ttl),
 	}
 	job.evaluation.Store(&evaluationBundle{})
 	if eventCh == nil {

--- a/internal/agent/job/job_dispatch_test.go
+++ b/internal/agent/job/job_dispatch_test.go
@@ -354,11 +354,11 @@ func waitForJob(t *testing.T, reason string, condition func() bool) {
 
 func newTestJob(identity jobcontext.JobIdentity, metadata jobcontext.JobMetadata, eventChannelSize int) (*Job, chan jobevent.EventRecord) {
 	eventCh := make(chan jobevent.EventRecord, eventChannelSize)
-	return NewJob(testLogger, identity, metadata, "machine", eventCh), eventCh
+	return NewJob(testLogger, identity, metadata, "machine", eventCh, 0), eventCh
 }
 
 func newTestJobWithoutWorker(identity jobcontext.JobIdentity, metadata jobcontext.JobMetadata) *Job {
-	return NewJob(testLogger, identity, metadata, "machine", nil)
+	return NewJob(testLogger, identity, metadata, "machine", nil, 0)
 }
 
 func sendTestEvent(t *testing.T, eventCh chan<- jobevent.EventRecord, event jobevent.EventRecord) {

--- a/internal/agent/job/job_lifecycle_test.go
+++ b/internal/agent/job/job_lifecycle_test.go
@@ -15,7 +15,7 @@ func TestJob_Lifecycle(t *testing.T) {
 	id := jobcontext.GitHubJobIdentity("github.com", "acme/example", "123", "build", "1", "runner-1")
 	meta := jobcontext.JobMetadata{}
 	eventCh := make(chan jobevent.EventRecord, externalTestEventChannelSize)
-	j := job.NewJob(externalTestLogger, id, meta, "machine", eventCh)
+	j := job.NewJob(externalTestLogger, id, meta, "machine", eventCh, 0)
 
 	if j.State() != job.JobStateRunning {
 		t.Fatalf("initial state: got %q", j.State())
@@ -43,7 +43,7 @@ func TestJob_Lifecycle(t *testing.T) {
 
 func TestJob_FinalizeIdempotent(t *testing.T) {
 	eventCh := make(chan jobevent.EventRecord, externalTestEventChannelSize)
-	j := job.NewJob(externalTestLogger, jobcontext.GitLabJobIdentity("gitlab.com", "group/project", "123"), jobcontext.JobMetadata{}, "machine", eventCh)
+	j := job.NewJob(externalTestLogger, jobcontext.GitLabJobIdentity("gitlab.com", "group/project", "123"), jobcontext.JobMetadata{}, "machine", eventCh, 0)
 
 	j.MarkClosing()
 	close(eventCh)
@@ -60,7 +60,7 @@ func TestJob_FinalizeIdempotent(t *testing.T) {
 }
 
 func TestJob_NilEventChannelIsImmediatelyDone(t *testing.T) {
-	j := job.NewJob(externalTestLogger, jobcontext.GitLabJobIdentity("gitlab.com", "group/project", "123"), jobcontext.JobMetadata{}, "machine", nil)
+	j := job.NewJob(externalTestLogger, jobcontext.GitLabJobIdentity("gitlab.com", "group/project", "123"), jobcontext.JobMetadata{}, "machine", nil, 0)
 
 	select {
 	case <-j.Done():
@@ -73,7 +73,7 @@ func TestJob_NilEventChannelIsImmediatelyDone(t *testing.T) {
 }
 
 func TestJob_NilLoggerUsesDefaultLogger(t *testing.T) {
-	j := job.NewJob(nil, jobcontext.GitLabJobIdentity("gitlab.com", "group/project", "123"), jobcontext.JobMetadata{}, "machine", nil)
+	j := job.NewJob(nil, jobcontext.GitLabJobIdentity("gitlab.com", "group/project", "123"), jobcontext.JobMetadata{}, "machine", nil, 0)
 
 	select {
 	case <-j.Done():
@@ -85,8 +85,29 @@ func TestJob_NilLoggerUsesDefaultLogger(t *testing.T) {
 	}
 }
 
+func TestJob_NewJobTTLDeadline(t *testing.T) {
+	tests := []struct {
+		name    string
+		ttl     time.Duration
+		wantTTL time.Duration
+	}{
+		{name: "explicit ttl sets the deadline window", ttl: 2 * time.Hour, wantTTL: 2 * time.Hour},
+		{name: "zero ttl falls back to DefaultTTL", ttl: 0, wantTTL: job.DefaultTTL},
+		{name: "negative ttl falls back to DefaultTTL", ttl: -time.Hour, wantTTL: job.DefaultTTL},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			j := job.NewJob(externalTestLogger, jobcontext.GitLabJobIdentity("gitlab.com", "group/project", "123"), jobcontext.JobMetadata{}, "machine", nil, tc.ttl)
+			if got := j.DeadlineAt().Sub(j.StartedAt()); got != tc.wantTTL {
+				t.Fatalf("deadline window: got %s, want %s", got, tc.wantTTL)
+			}
+		})
+	}
+}
+
 func TestJob_IsExpired(t *testing.T) {
-	j := job.NewJob(externalTestLogger, jobcontext.GitLabJobIdentity("gitlab.com", "group/project", "123"), jobcontext.JobMetadata{}, "machine", nil)
+	j := job.NewJob(externalTestLogger, jobcontext.GitLabJobIdentity("gitlab.com", "group/project", "123"), jobcontext.JobMetadata{}, "machine", nil, 0)
 	if j.IsExpired() {
 		t.Fatal("new job should not be expired")
 	}
@@ -100,7 +121,7 @@ func TestJob_IsExpired(t *testing.T) {
 func TestJob_SetProjectScope_ResolvesScopeRules(t *testing.T) {
 	id := jobcontext.GitHubJobIdentity("github.com", "acme/example", "123", "build", "1", "runner-1")
 	meta := jobcontext.JobMetadata{}
-	j := job.NewJob(externalTestLogger, id, meta, "machine", make(chan jobevent.EventRecord, externalTestEventChannelSize))
+	j := job.NewJob(externalTestLogger, id, meta, "machine", make(chan jobevent.EventRecord, externalTestEventChannelSize), 0)
 
 	scope := &jobscope.JobScopeState{
 		Type: jobcontext.ScopeTypeProject,

--- a/internal/agent/jobregistry/jobregistry.go
+++ b/internal/agent/jobregistry/jobregistry.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"log/slog"
 	"sync"
+	"time"
 
 	"github.com/cicd-sensor/cicd-sensor/internal/agent/job"
 	"github.com/cicd-sensor/cicd-sensor/internal/agent/joblogs"
@@ -61,6 +62,9 @@ type JobRegistry struct {
 	kernelTracker *kerneltracker.KernelTracker
 	jobs          map[jobcontext.JobIdentity]*job.Job
 	baselineLoad  BaselineLoader
+	// jobTTL is the maximum job lifetime stamped onto every new Job.
+	// Zero means job.DefaultTTL.
+	jobTTL time.Duration
 	// starting hides half-created jobs and serializes duplicate start requests.
 	starting map[jobcontext.JobIdentity]chan struct{}
 }
@@ -82,6 +86,17 @@ func New(logger *slog.Logger) *JobRegistry {
 
 func (jr *JobRegistry) SetBaselineLoadForTesting(load BaselineLoader) {
 	jr.baselineLoad = load
+}
+
+// SetJobTTL overrides the default maximum job lifetime applied to jobs
+// created after the call. Non-positive values are ignored.
+func (jr *JobRegistry) SetJobTTL(ttl time.Duration) {
+	if ttl <= 0 {
+		return
+	}
+	jr.mu.Lock()
+	defer jr.mu.Unlock()
+	jr.jobTTL = ttl
 }
 
 // BindKernelTracker completes startup wiring after the KernelTracker is built.
@@ -163,6 +178,7 @@ func (jr *JobRegistry) registerJobRuntime(ctx context.Context, identity jobconte
 	if jobLogger == nil {
 		jobLogger = jr.logger
 	}
+	jobTTL := jr.jobTTL
 	jr.mu.Unlock()
 
 	var eventCh <-chan jobevent.EventRecord
@@ -176,7 +192,7 @@ func (jr *JobRegistry) registerJobRuntime(ctx context.Context, identity jobconte
 		engineRegistered = true
 	}
 
-	j := job.NewJob(jobLogger, identity, metadata, runnerType, eventCh)
+	j := job.NewJob(jobLogger, identity, metadata, runnerType, eventCh, jobTTL)
 	jr.mu.Lock()
 	if _, ok := jr.jobs[identity]; ok {
 		jr.mu.Unlock()

--- a/internal/agent/jobregistry/project_start_test.go
+++ b/internal/agent/jobregistry/project_start_test.go
@@ -160,6 +160,36 @@ func TestJobRegistry_ApplyGitHubProjectStart_ManagerConfigIgnoresLocalProjectInp
 	}
 }
 
+func TestJobRegistry_SetJobTTL_StampsNewJobs(t *testing.T) {
+	tests := []struct {
+		name    string
+		ttl     time.Duration
+		wantTTL time.Duration
+	}{
+		{name: "configured ttl stamps new jobs", ttl: 2 * time.Hour, wantTTL: 2 * time.Hour},
+		{name: "unset ttl keeps DefaultTTL", ttl: 0, wantTTL: jobpkg.DefaultTTL},
+		{name: "non-positive ttl is ignored", ttl: -time.Hour, wantTTL: jobpkg.DefaultTTL},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			jr := newJobRegistry(t)
+			jr.SetJobTTL(tc.ttl)
+
+			job, err := jr.ApplyGitHubProjectStart(testCtx, jobregistry.GitHubProjectStartConfig{
+				Identity:   jobcontext.GitHubJobIdentity("github.com", "acme/example", "123", "build", "1", "runner-1"),
+				RunnerType: "machine",
+			})
+			if err != nil {
+				t.Fatalf("project start: %v", err)
+			}
+			if got := job.DeadlineAt().Sub(job.StartedAt()); got != tc.wantTTL {
+				t.Fatalf("job ttl: got %s, want %s", got, tc.wantTTL)
+			}
+		})
+	}
+}
+
 func TestJobRegistry_ApplyGitHubProjectStart_SetsProjectScopeOnNewJob(t *testing.T) {
 	jr := newJobRegistry(t)
 	id := jobcontext.GitHubJobIdentity("github.com", "acme/example", "123", "build", "1", "runner-1")

--- a/internal/agent/jobregistry/test_helpers_test.go
+++ b/internal/agent/jobregistry/test_helpers_test.go
@@ -13,7 +13,7 @@ const testEventChannelSize = 4096
 
 func newTestJob(identity jobcontext.JobIdentity, metadata jobcontext.JobMetadata, eventChannelSize int) (*job.Job, chan jobevent.EventRecord) {
 	eventCh := make(chan jobevent.EventRecord, eventChannelSize)
-	return job.NewJob(testLogger, identity, metadata, "machine", eventCh), eventCh
+	return job.NewJob(testLogger, identity, metadata, "machine", eventCh, 0), eventCh
 }
 
 func sendTestEvent(t *testing.T, eventCh chan<- jobevent.EventRecord, event jobevent.EventRecord) {

--- a/internal/agent/test_helpers_test.go
+++ b/internal/agent/test_helpers_test.go
@@ -71,7 +71,7 @@ func hitsWithAction(snapshot observations.StateSnapshot, action rule.RuleAction)
 
 func newTestJob(identity jobcontext.JobIdentity, metadata jobcontext.JobMetadata, eventChannelSize int) (*job.Job, chan jobevent.EventRecord) {
 	eventCh := make(chan jobevent.EventRecord, eventChannelSize)
-	return job.NewJob(testLogger, identity, metadata, "machine", eventCh), eventCh
+	return job.NewJob(testLogger, identity, metadata, "machine", eventCh, 0), eventCh
 }
 
 func sendTestEvent(t *testing.T, eventCh chan<- jobevent.EventRecord, event jobevent.EventRecord) {


### PR DESCRIPTION
## Summary

Refs #22 (TODO: Make Job timeout / TTL configurable).

Add a `--job-ttl DURATION` flag to `cicd-sensor agent start`, defaulting to the existing 24h. `DefaultTTL` was hardcoded in `internal/agent/job/job.go`, and the TTL finalizer reaps jobs against that fixed deadline. Runner hosts differ: ephemeral hosted runners may want a much shorter ceiling so leaked jobs are reclaimed quickly, while long build or soak jobs on self-hosted runners may need more than 24h.

The value is plumbed along the ownership boundaries, mirroring the existing `--shutdown-grace` pattern: CLI flag → `Agent.SetJobTTL` → `JobRegistry.SetJobTTL` → `job.NewJob`. The TTL is host-operator-owned, process-wide configuration, so it lives on `Agent` and is composed into each Job by `JobRegistry` — no scope-owned state is touched, host/project isolation is unchanged, and untrusted inputs (project start requests, manager config) cannot influence it.

Non-positive values are rejected at CLI validation; internal setters ignore non-positive values and `NewJob` falls back to `DefaultTTL`, so every path still produces a job with a deadline. The deadline is still derived once in `NewJob` and never changes afterward, preserving the immutability constraint the finalizer relies on. `JobRegistry.SetJobTTL` is called before the listeners accept job-start requests, and reads/writes go through `jr.mu`, so no job can observe a partially configured TTL.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor / cleanup
- [ ] Docs
- [ ] CI / tooling
- [ ] Other:

## Test plan

- [x] New table-driven tests: deadline derivation in `NewJob` (explicit / zero / negative ttl), registry stamping through `ApplyGitHubProjectStart` (configured / unset / non-positive ttl), and the `job-ttl must be positive` CLI validation case.
- [x] `go test -race` on the touched packages (`internal/agent/job`, `internal/agent/jobregistry`, `cmd/cicd-sensor`).
- [x] Full `go test ./...` and `make rules-validate` pass locally.

## Checklist

- [x] `go test ./...` passes locally
- [x] `gofmt -l` and `go vet ./...` are clean
- [x] Docs and rule samples are updated if behavior changed (no doc change needed: CLI flags are documented in `agent start` usage output, matching `--shutdown-grace`)
- [x] No secrets, credentials, or unrelated changes included
