### PR TITLE
fix: harden process termination safety

### DIFF
--- a/docs/user-guide/manager.md
+++ b/docs/user-guide/manager.md
@@ -55,6 +55,8 @@ See [cicd-sensor GitHub Packages](https://github.com/orgs/cicd-sensor/packages?r
 
 The manager does not terminate TLS directly.
 Design HTTPS / TLS, authentication boundaries, and private network exposure with cloud-side components such as a load balancer, ingress, API Gateway, service mesh, or private network.
+Use HTTPS for production deployments.
+Plain HTTP is supported for trusted private networks where the network boundary is the accepted protection, and the Agent logs `manager_url_insecure_scheme` when configured with an HTTP Manager URL.
 
 ## Network requirements
 

--- a/docs/user-guide/self-hosted-install.md
+++ b/docs/user-guide/self-hosted-install.md
@@ -140,6 +140,9 @@ Remove it if your maintenance workflow normally uses stop / restart.
 Machine runner deployments assume dockerd.
 Place `cicd-sensor proxy dockerd` in front of the Docker socket so cicd-sensor can observe container creation.
 
+Important: the proxy observes container creation for attribution; it is not an authorization boundary.
+Keep the proxy socket's owner, group, and mode equivalent to the original Docker socket, because access to either socket grants Docker daemon privileges.
+
 After installation, workflows and runner-side Docker clients still connect to `/run/docker.sock`.
 `/run/docker.sock` is served by the cicd-sensor Docker proxy, and the real dockerd socket moves to `/run/docker-upstream.sock`.
 

--- a/internal/agent/evaluation/evaluator.go
+++ b/internal/agent/evaluation/evaluator.go
@@ -221,7 +221,15 @@ func terminateProcess(ctx context.Context, event jobevent.EventRecord, logger *s
 		return
 	}
 
-	pgid, _ := syscall.Getpgid(int(pid))
+	pgid, err := syscall.Getpgid(int(pid))
+	if err != nil {
+		logger.WarnContext(ctx, "terminate_process_skipped", "reason", "getpgid_failed", "pid", pid, "error", err)
+		return
+	}
+	if pgid <= 0 {
+		logger.WarnContext(ctx, "terminate_process_skipped", "reason", "invalid_pgid", "pid", pid, "pgid", pgid)
+		return
+	}
 
 	if err := syscall.Kill(int(pid), syscall.SIGKILL); err != nil {
 		logger.WarnContext(ctx, "terminate_process_failed", "pid", pid, "error", err)
@@ -229,6 +237,10 @@ func terminateProcess(ctx context.Context, event jobevent.EventRecord, logger *s
 	}
 	logger.WarnContext(ctx, "terminate_process_sent", "pid", pid)
 
+	if pgid == syscall.Getpgrp() {
+		logger.WarnContext(ctx, "terminate_process_group_sigint_skipped", "reason", "agent_process_group", "pid", pid, "pgid", pgid)
+		return
+	}
 	if err := syscall.Kill(-pgid, syscall.SIGINT); err != nil {
 		logger.WarnContext(ctx, "terminate_process_group_sigint_failed", "pid", pid, "pgid", pgid, "error", err)
 	} else {

--- a/internal/agent/evaluation/evaluator_test.go
+++ b/internal/agent/evaluation/evaluator_test.go
@@ -1,7 +1,11 @@
 package evaluation
 
 import (
+	"bytes"
 	"context"
+	"log/slog"
+	"math"
+	"strings"
 	"sync"
 	"testing"
 
@@ -180,4 +184,55 @@ func TestEvaluateEvent_NilInputsAreNoOp(t *testing.T) {
 
 	eval := &EvaluationState{}
 	EvaluateEvent(testCtx, eval, testDispatchEvent("/usr/bin/curl", "example.com", 443), testEvalIdentity, jobcontext.JobMetadata{}, "machine", nil, nil, testLogger, testActivation())
+}
+
+func TestTerminateProcess_SkipsUnsafeTargets(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		pid        int32
+		wantLog    string
+		forbidLogs []string
+	}{
+		{
+			name:    "missing zero pid",
+			pid:     0,
+			wantLog: "reason=missing_pid",
+		},
+		{
+			name:    "missing negative pid",
+			pid:     -1,
+			wantLog: "reason=missing_pid",
+		},
+		{
+			name:       "nonexistent pid",
+			pid:        math.MaxInt32,
+			wantLog:    "reason=getpgid_failed",
+			forbidLogs: []string{"terminate_process_sent", "terminate_process_group_sigint"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var logs bytes.Buffer
+			logger := slog.New(slog.NewTextHandler(&logs, nil))
+			event := testDispatchEvent("/usr/bin/test", "example.com", 443)
+			event.Process.PID = tt.pid
+
+			terminateProcess(t.Context(), event, logger)
+
+			got := logs.String()
+			if !strings.Contains(got, tt.wantLog) {
+				t.Fatalf("terminate log: got %q, want substring %q", got, tt.wantLog)
+			}
+			for _, forbidden := range tt.forbidLogs {
+				if strings.Contains(got, forbidden) {
+					t.Fatalf("terminate log: got unexpected substring %q in %q", forbidden, got)
+				}
+			}
+		})
+	}
 }

--- a/internal/agent/evaluation/terminate_integration_test.go
+++ b/internal/agent/evaluation/terminate_integration_test.go
@@ -3,7 +3,12 @@
 package evaluation
 
 import (
+	"bytes"
+	"context"
+	"log/slog"
+	"os"
 	"os/exec"
+	"strings"
 	"syscall"
 	"testing"
 	"time"
@@ -13,6 +18,8 @@ import (
 	"github.com/cicd-sensor/cicd-sensor/internal/jobevent"
 	"github.com/cicd-sensor/cicd-sensor/internal/rule"
 )
+
+const terminateProcessSameGroupHelperEnv = "CICD_SENSOR_TERMINATE_SAME_GROUP_HELPER"
 
 func TestEvaluateEvent_TerminateKillsEventProcessIntegration(t *testing.T) {
 	cmd := exec.Command("sleep", "30")
@@ -26,9 +33,12 @@ func TestEvaluateEvent_TerminateKillsEventProcessIntegration(t *testing.T) {
 	t.Cleanup(func() {
 		if cmd.Process != nil {
 			_ = cmd.Process.Kill()
-			_, _ = cmd.Process.Wait()
 		}
 	})
+	waitCh := make(chan error, 1)
+	go func() {
+		waitCh <- cmd.Wait()
+	}()
 
 	hostScope := jobscope.NewHost()
 	hostScope.RuleSets = []rule.RuleSet{{
@@ -48,11 +58,6 @@ func TestEvaluateEvent_TerminateKillsEventProcessIntegration(t *testing.T) {
 
 	EvaluateEvent(testCtx, eval, event, testEvalIdentity, jobcontext.JobMetadata{}, "machine", hostScope, nil, testLogger, testActivation())
 
-	waitCh := make(chan error, 1)
-	go func() {
-		waitCh <- cmd.Wait()
-	}()
-
 	select {
 	case err := <-waitCh:
 		if err == nil {
@@ -67,5 +72,80 @@ func TestEvaluateEvent_TerminateKillsEventProcessIntegration(t *testing.T) {
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("sleep was not killed by terminate rule")
+	}
+}
+
+func TestTerminateProcess_SkipsAgentProcessGroupIntegration(t *testing.T) {
+	if os.Getenv(terminateProcessSameGroupHelperEnv) != "1" {
+		ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+		defer cancel()
+
+		cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=^TestTerminateProcess_SkipsAgentProcessGroupIntegration$")
+		cmd.Env = append(os.Environ(), terminateProcessSameGroupHelperEnv+"=1")
+		// The helper gets its own process group so a regressed guard can only
+		// signal the helper, never the parent go test process or its shell.
+		cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+		output, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("isolated terminate helper failed: %v\n%s", err, output)
+		}
+		return
+	}
+
+	var selfLogs bytes.Buffer
+	selfLogger := slog.New(slog.NewTextHandler(&selfLogs, nil))
+	selfEvent := testDispatchEvent("/usr/bin/test", "example.com", 443)
+	selfEvent.Process.PID = int32(os.Getpid())
+	terminateProcess(t.Context(), selfEvent, selfLogger)
+	if got := selfLogs.String(); !strings.Contains(got, `msg=terminate_process_skipped reason=self_pid`) {
+		t.Fatalf("terminate log does not report self pid skip: %s", got)
+	}
+
+	cmd := exec.Command("sleep", "30")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start sleep: %v", err)
+	}
+	childPGID, err := syscall.Getpgid(cmd.Process.Pid)
+	if err != nil {
+		t.Fatalf("get sleep process group: %v", err)
+	}
+	if helperPGID := syscall.Getpgrp(); childPGID != helperPGID {
+		t.Fatalf("sleep process group: got %d, want helper group %d", childPGID, helperPGID)
+	}
+	t.Cleanup(func() {
+		if cmd.Process != nil {
+			_ = cmd.Process.Kill()
+		}
+	})
+	waitCh := make(chan error, 1)
+	go func() {
+		waitCh <- cmd.Wait()
+	}()
+
+	var logs bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logs, nil))
+	event := testDispatchEvent("/usr/bin/sleep", "example.com", 443)
+	event.Process.PID = int32(cmd.Process.Pid)
+
+	terminateProcess(t.Context(), event, logger)
+
+	select {
+	case err := <-waitCh:
+		if err == nil {
+			t.Fatal("sleep exited cleanly, want SIGKILL")
+		}
+		status, ok := cmd.ProcessState.Sys().(syscall.WaitStatus)
+		if !ok {
+			t.Fatalf("process state sys: got %T, want syscall.WaitStatus", cmd.ProcessState.Sys())
+		}
+		if !status.Signaled() || status.Signal() != syscall.SIGKILL {
+			t.Fatalf("sleep exit status: got %v, want SIGKILL", status)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("sleep was not killed by terminateProcess")
+	}
+
+	if got := logs.String(); !strings.Contains(got, `msg=terminate_process_group_sigint_skipped reason=agent_process_group`) {
+		t.Fatalf("terminate log does not report process-group skip: %s", got)
 	}
 }


### PR DESCRIPTION
## What

- Reject process termination when the target process group cannot be resolved safely.
- Skip process-group `SIGINT` when it would signal the Agent's own process group.
- Add subprocess-isolated integration coverage for self-PID and shared-process-group guards.
- Clarify the Docker proxy authorization boundary and Manager transport expectations.

## Why

Ignoring a `Getpgid` failure could leave the process group ID as zero. Passing that value to `kill` targets the caller's process group and could interrupt the Agent itself.

The documentation changes record the intentional trust-model decisions from the security review: the Docker proxy provides container attribution rather than Docker authorization, and production Manager connections should use HTTPS while trusted private-network HTTP remains supported.

Closes #41