### PR TITLE
feat(rules): detect Node.js second-stage execution

### DIFF
--- a/.github/ISSUE_TEMPLATE/false_positive.md
+++ b/.github/ISSUE_TEMPLATE/false_positive.md
@@ -1,0 +1,51 @@
+---
+name: False positive report
+about: Report a rule detection on expected CI/CD activity
+title: '[False positive] '
+labels: bug
+assignees: ''
+---
+
+## Detected rule
+
+- Ruleset ID:
+- Rule ID:
+- Rule revision:
+- Action: <!-- detect / terminate -->
+
+## Expected activity
+
+<!-- What command, tool, package, or workflow behavior triggered the rule? Why is it expected? -->
+
+## Steps to reproduce
+
+<!-- Provide the smallest workflow or command sequence that reproduces the detection. -->
+
+1.
+2.
+3.
+
+## Detection evidence
+
+<!-- Paste the relevant detection entry or report excerpt, not the complete debug bundle. -->
+
+```text
+```
+
+- [ ] I removed tokens, credentials, secrets, and other sensitive data from this report.
+
+## Environment
+
+- cicd-sensor version:
+- Deployment: <!-- GitHub-hosted runner / Self-hosted Machine Runner / GitHub ARC / GitLab Runner -->
+- Runner OS / architecture:
+- Linux kernel: <!-- output of `uname -r` -->
+- Relevant tool / package and version:
+
+## Impact and workaround
+
+<!-- Did the rule only report a detection, or did it terminate the job? Include any modifier or workaround currently used. -->
+
+## Additional context
+
+<!-- Related issues, logs, or other details that may help distinguish expected behavior from an attack. -->

--- a/rules/generic-execution.yaml
+++ b/rules/generic-execution.yaml
@@ -1,5 +1,11 @@
 rule_sets:
   - ruleset_id: cicd_sensor_baseline/generic_execution
+    lists:
+      node_user_script_dirs:
+        - "/.local/share/"
+
+      node_package_manager_data_dirs:
+        - "/.local/share/pnpm/"
 
     rules:
       - rule_id: python_tmp_pyz_exec
@@ -18,6 +24,40 @@ rule_sets:
             process.exec_path.endsWith("/python3")
           ) &&
           process.argv.exists(arg, arg.contains("/tmp/") && arg.endsWith(".pyz"))
+        action: detect
+        tags:
+          mitre_tactic: execution
+
+      - rule_id: node_inline_eval_descendant_user_data_script_exec
+        rule_name: "Supply-chain: user-data Node.js below inline evaluation"
+        description: |
+          What:
+            Detects Node.js executing JavaScript from a user's local data directory when its process ancestry contains Node.js inline evaluation.
+          Why:
+            A malicious dependency can use an inline downloader to stage and launch a longer-lived second process outside node_modules.
+          Notes:
+            This proves process lineage, not that the ancestor downloaded or wrote the script or is its direct parent. Direct inline evaluation, project-local .config scripts, scripts below node_modules, and pnpm's own installation do not match.
+        event_type: process_exec
+        condition: |
+          process.exec_path.endsWith("/node") &&
+          process.argv.exists(arg,
+            list.node_user_script_dirs.exists(d, arg.contains(d)) &&
+            !arg.contains("/node_modules/") &&
+            !list.node_package_manager_data_dirs.exists(d, arg.contains(d)) &&
+            (
+              arg.endsWith(".js") ||
+              arg.endsWith(".mjs") ||
+              arg.endsWith(".cjs")
+            )
+          ) &&
+          process.ancestors.exists(a,
+            a.exec_path.endsWith("/node") &&
+            a.argv.exists(arg,
+              arg == "-e" ||
+              arg == "--eval" ||
+              arg.startsWith("--eval=")
+            )
+          )
         action: detect
         tags:
           mitre_tactic: execution

--- a/rules/generic_execution_test.go
+++ b/rules/generic_execution_test.go
@@ -1,0 +1,101 @@
+//go:build rules_validation
+
+package rules_test
+
+import (
+	"testing"
+
+	"github.com/cicd-sensor/cicd-sensor/internal/jobevent"
+	"github.com/cicd-sensor/cicd-sensor/internal/rule"
+	"github.com/cicd-sensor/cicd-sensor/internal/rule/celengine"
+	"github.com/cicd-sensor/cicd-sensor/internal/rulesource"
+)
+
+func TestNodeInlineEvalDescendantUserDataScriptExecRule(t *testing.T) {
+	t.Parallel()
+
+	loaded, err := rulesource.LoadRulesFile("generic-execution.yaml")
+	if err != nil {
+		t.Fatalf("load execution rules: %v", err)
+	}
+	if len(loaded.RuleSets) != 1 {
+		t.Fatalf("expected 1 ruleset, got %d", len(loaded.RuleSets))
+	}
+	set := loaded.RuleSets[0]
+
+	var target rule.Rule
+	for _, candidate := range set.Rules {
+		if candidate.RuleID == "node_inline_eval_descendant_user_data_script_exec" {
+			target = candidate
+			break
+		}
+	}
+	if target.RuleID == "" {
+		t.Fatal("node_inline_eval_descendant_user_data_script_exec rule not present in shipped ruleset")
+	}
+	if target.EventType != jobevent.ProcessExec {
+		t.Fatalf("event_type=%q, want %q", target.EventType, jobevent.ProcessExec)
+	}
+	if target.Action != rule.RuleActionDetect {
+		t.Fatalf("action=%q, want %q", target.Action, rule.RuleActionDetect)
+	}
+
+	env, err := celengine.NewEnv()
+	if err != nil {
+		t.Fatalf("new env: %v", err)
+	}
+	prog, err := env.Compile(target.RuleID, target.EventType, target.Condition, set.Lists)
+	if err != nil {
+		t.Fatalf("compile rule: %v", err)
+	}
+	staticActivation, err := celengine.NewListActivation(rule.NormalizePredefinedLists(set.Lists))
+	if err != nil {
+		t.Fatalf("list activation: %v", err)
+	}
+
+	tests := []struct {
+		name      string
+		input     celengine.CELInputEvent
+		wantMatch bool
+	}{
+		{
+			name: "detects inline eval staging a user data script",
+			input: celengine.CELInputEvent{
+				Process: celengine.NewCELProcess("/usr/bin/node", []string{"node", "/home/runner/.local/share/NodeJS/sync.js"}, []celengine.CELAncestor{
+					{ExecPath: "/usr/bin/node", Argv: []string{"node", "-e", "downloader"}},
+					{ExecPath: "/usr/bin/node", Argv: []string{"node", "app.js"}},
+				}),
+			},
+			wantMatch: true,
+		},
+		{
+			name: "requires inline eval in the ancestry",
+			input: celengine.CELInputEvent{
+				Process: celengine.NewCELProcess("/usr/bin/node", []string{"node", "/home/runner/.local/share/NodeJS/sync.js"}, []celengine.CELAncestor{
+					{ExecPath: "/usr/bin/node", Argv: []string{"node", "npm-cli.js", "test"}},
+				}),
+			},
+		},
+		{
+			name: "excludes project config scripts below inline eval",
+			input: celengine.CELInputEvent{
+				Process: celengine.NewCELProcess("/usr/bin/node", []string{"node", "/home/runner/work/project/.config/build.js"}, []celengine.CELAncestor{
+					{ExecPath: "/usr/bin/node", Argv: []string{"node", "-e", "wrapper"}},
+				}),
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			matched, err := prog.EvalActivation(celengine.NewEventActivation(tc.input).WithParent(staticActivation))
+			if err != nil {
+				t.Fatalf("evaluate rule: %v", err)
+			}
+			if matched != tc.wantMatch {
+				t.Fatalf("matched=%v, want %v", matched, tc.wantMatch)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### What

- Add a baseline `process_exec` rule for Node.js executing a JavaScript file under `/.local/share/` when a Node.js inline-evaluation process (`-e` / `--eval`) exists in its ancestry.
- Exclude scripts under `node_modules` and pnpm-managed user data.
- Add focused tests for the intended process chain, required inline-eval ancestry, and the project-local `.config` false-positive boundary.
- Add a dedicated false-positive Issue template that collects the rule identity, minimal reproduction, sanitized evidence, environment, and operational impact.

### Why

The AsyncAPI supply-chain compromise used a process chain where Node.js inline evaluation launched a second-stage script from `~/.local/share/NodeJS/`. Detecting that lineage provides a reusable behavioral signal without relying on malware-specific filenames or network IOCs.

GitHub-hosted E2E testing initially found that including generic `/.config/` paths also matched a legitimate project-local build script. The rule was therefore narrowed to the observed `/.local/share/` behavior.

After narrowing, ordinary npm, pnpm, Yarn, lifecycle, test, build, and inline-evaluation workloads produced no detections on Node.js 20, 22, and 24. The benign attack-shaped positive control was detected on all three versions.

A structured false-positive report makes rule tuning actionable while reducing the risk of users sharing complete debug bundles or sensitive process arguments.
