### PR TITLE
chore(renovate): update docs action examples without delay

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -58,6 +58,9 @@
         "custom.regex"
       ],
       "groupName": "github actions docs examples",
+      "schedule": [
+        "at any time"
+      ],
       "minimumReleaseAge": "0 days",
       "semanticCommitType": "docs",
       "semanticCommitScope": "examples",


### PR DESCRIPTION
## What

- Override the Renovate schedule for SHA-pinned GitHub Actions examples in README and docs to `at any time`.
- Keep the repository-wide Tuesday schedule for routine dependency updates.

## Why

The repository-wide weekly schedule also applied to the custom regex manager used for documentation examples. Although those updates already bypass the seven-day release cooldown, they could only be created during the Tuesday Renovate window.

This allows action example updates to be created on the next Mend Renovate run after a release without changing the schedule for other dependencies.

## Validation

- `RENOVATE_ALLOWED_ENV='[\"GOPROXY\"]' renovate-config-validator --no-global --strict .github/renovate.json5`
- `git diff --check`