### PR TITLE
feat(rules): detect Keyv Shai-Hulud IOCs

### DIFF
--- a/rules/ioc.yaml
+++ b/rules/ioc.yaml
@@ -116,3 +116,95 @@ rule_sets:
           mitre_tactic: persistence
           ioc_date: "2026-07-14"
           source_url: https://x.com/lmt_swallow/status/2076945835313840559
+
+      - rule_id: keyv_shaihulud_malicious_domain
+        rule_name: "IOC: Keyv Shai-Hulud malicious domain"
+        description: |
+          What:
+            Terminates DNS resolution of attacker-controlled domains used by
+            the August 2026 Keyv/Cacheable npm supply-chain campaign.
+          Why:
+            The Mini Shai-Hulud descendant uses this infrastructure for payload
+            delivery or exfiltration after harvesting CI/CD and developer secrets.
+          Notes:
+            Preserve job logs and artifacts, rebuild the runner, and rotate all
+            credentials reachable from the job.
+        event_type: domain
+        condition: |
+          domain == "npm-cache.com" ||
+          domain == "pypi-get.com" ||
+          domain == "js-mirror.com"
+        action: terminate
+        tags:
+          mitre_tactic: command-and-control
+          ioc_date: "2026-08-04"
+          source_url: https://www.wiz.io/blog/keyv-and-cacheable-npm-supply-chain-attack
+
+      - rule_id: keyv_shaihulud_eth_rpc_domain
+        rule_name: "IOC: Keyv Shai-Hulud Ethereum RPC domain"
+        description: |
+          What:
+            Detects DNS resolution of Ethereum RPC services used by the August
+            2026 Keyv/Cacheable npm supply-chain campaign.
+          Why:
+            The Mini Shai-Hulud descendant contacts these services while
+            operating in compromised development and CI/CD environments.
+          Notes:
+            These are legitimate shared RPC services and may be expected in
+            blockchain CI. Review process ancestry and use a rule modifier for
+            approved workloads.
+        event_type: domain
+        condition: |
+          domain == "eth-mainnet.nodereal.io" ||
+          domain == "go.getblock.io" ||
+          domain == "eth.llamarpc.com"
+        action: detect
+        tags:
+          mitre_tactic: command-and-control
+          ioc_date: "2026-08-04"
+          source_url: https://www.wiz.io/blog/keyv-and-cacheable-npm-supply-chain-attack
+
+      - rule_id: keyv_shaihulud_math_symbol_artifact
+        rule_name: "IOC: Keyv Shai-Hulud Math_Symbol.js artifact"
+        description: |
+          What:
+            Terminates access to the Math_Symbol.js payload artifact below the
+            installed keyv package.
+          Why:
+            This exact package-relative artifact identifies the malicious keyv
+            6.0.0 payload reported in the August 2026 campaign.
+          Notes:
+            Preserve the package tree and job logs, rebuild the runner, and
+            rotate all credentials reachable from the job.
+        event_type: file_open
+        condition: |
+          (is_read || is_write) &&
+          path.endsWith("/node_modules/keyv/Math_Symbol.js")
+        action: terminate
+        tags:
+          mitre_tactic: execution
+          ioc_date: "2026-08-04"
+          source_url: https://www.wiz.io/blog/keyv-and-cacheable-npm-supply-chain-attack
+
+      - rule_id: keyv_shaihulud_bun_download_artifact
+        rule_name: "IOC: Keyv Shai-Hulud Bun download artifact"
+        description: |
+          What:
+            Detects file access below a /tmp/bun-dl-* directory associated with
+            the August 2026 Keyv/Cacheable npm supply-chain campaign.
+          Why:
+            The Mini Shai-Hulud descendant stages Bun through this temporary
+            download path before executing its payload.
+          Notes:
+            Legitimate Bun installation may use the same temporary path. Review
+            process ancestry and correlate with the campaign domain and secret
+            access detections.
+        event_type: file_open
+        condition: |
+          (is_read || is_write) &&
+          path.contains("/tmp/bun-dl-")
+        action: detect
+        tags:
+          mitre_tactic: execution
+          ioc_date: "2026-08-04"
+          source_url: https://www.wiz.io/blog/keyv-and-cacheable-npm-supply-chain-attack


### PR DESCRIPTION
## Summary

- terminate jobs resolving attacker-controlled domains from the August 2026 Keyv/Cacheable campaign
- detect dual-use Ethereum RPC domains associated with the campaign
- terminate access to the malicious `Math_Symbol.js` artifact
- detect access below the `/tmp/bun-dl-*` staging path

## Rationale

The Keyv/Cacheable npm supply-chain compromise uses a Mini Shai-Hulud descendant to harvest CI/CD and developer credentials and communicate with campaign infrastructure.

Attacker-controlled indicators terminate the job. Dual-use Ethereum RPC and Bun download paths remain detect-only to avoid disrupting legitimate blockchain and Bun installation workflows.

## Limitations

The reported `Bun/1.3.13` User-Agent is not covered because the current domain and HTTP event schemas do not expose User-Agent headers, and HTTPS headers are not captured.

## Validation

- `make test`
- `make rules-validate`
- `make rules-bundle-validate`
- `git diff --check`
