### PR TITLE
fix(agent): flush streaming logs at project result and parallelize finalize sends

### DIFF
--- a/cmd/cicd-sensor/agent.go
+++ b/cmd/cicd-sensor/agent.go
@@ -89,7 +89,7 @@ func runAgentStart(args []string) {
 	fs.StringVar(&runner, "runner", "", "Runner type (machine or kubernetes).")
 	fs.StringVar(&managerURL, "manager-url", "", "Host scope manager URL.")
 	fs.StringVar(&managerTokenFilePath, "manager-token-file", "", "Path to a file containing the host scope manager bearer token. Overrides CICD_SENSOR_MANAGER_TOKEN.")
-	fs.DurationVar(&shutdownGrace, "shutdown-grace", 8*time.Second, "Best-effort drain window used after SIGTERM.")
+	fs.DurationVar(&shutdownGrace, "shutdown-grace", 8*time.Second, "Best-effort drain window used after SIGTERM. Must end before the supervisor's kill timeout (for example systemd TimeoutStopSec), or the drain is cut off mid-flight.")
 	fs.DurationVar(&jobTTL, "job-ttl", job.DefaultTTL, "Job age threshold after which the job is expired and forcibly finalized; expiry is checked about once per minute.")
 	if err := fs.Parse(args[1:]); err != nil {
 		os.Exit(2)

--- a/cmd/cicd-sensor/host.go
+++ b/cmd/cicd-sensor/host.go
@@ -152,6 +152,10 @@ func runHostEnd(args []string) {
 	}
 }
 
+// The health probe is the double-end guarantee: if the Job was already
+// finalized (e.g. an early host end from inside the job), the probe fails
+// and the completed hook exits non-zero. The agent-side end handler is
+// lenient on a missing Job; only this probe fails closed.
 func postGitHubHostEnd(ctx context.Context, socketPath string, req map[string]string) error {
 	if err := postSocket(ctx, socketPath, "/v1/github/job/health", req); err != nil {
 		return fmt.Errorf("job health: %w", err)

--- a/docs/developer-guide/agent.md
+++ b/docs/developer-guide/agent.md
@@ -171,6 +171,8 @@ The control socket is mode `0o777`; request identification uses `SO_PEERCRED`:
 
 GitHub `project/start` is the mixed case: on a self-hosted runner the peer must already belong to the host Job (it attaches project scope); on a hosted runner no prior Job exists, so the peer's cgroup seeds a new project-only Job. Co-resident untrusted local users are out of scope.
 
+Endpoints reachable from inside the job may only accelerate log delivery (`project/result` flushes buffered manager logs); finalization stays with triggers the job cannot forge: cgroup lifecycle, the completed hook, TTL, and shutdown. For `host end`, the CLI's `job/health` probe before the end call is what makes a double end fail the completed hook — the agent-side handler is lenient on a missing Job.
+
 Kubernetes support keeps the GitHub k8s start endpoint on a separate runner socket because the caller is inside the ARC runner container, while the normal control socket and NRI staging callers are host-side agent components.
 This keeps the container-visible surface to job start only and preserves the boundary between runner container code and host-side staging / runtime control.
 The same runner socket may later carry GitHub Kubernetes project start/result endpoints, but the normal agent control socket should not be mounted into workflow containers.

--- a/docs/user-guide/github-self-hosted.md
+++ b/docs/user-guide/github-self-hosted.md
@@ -104,6 +104,7 @@ sudo journalctl -u cicd-sensor-agent.service -f
 
 The start hook is required to begin monitoring, so failures should fail the job.
 The completed hook runs job health check and finalize inside `host end`.
+The health check is also a tamper signal: if monitoring was already finalized — for example a process inside the job invoked `host end` early to cut monitoring short — the health check fails, the completed hook exits non-zero, and the job shows the failure instead of finishing with a clean-looking summary.
 
 ## Action support
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -33,6 +33,10 @@ type Agent struct {
 	engineDone                <-chan error
 }
 
+// defaultAgentShutdownGrace bounds the best-effort drain in shutdown. The
+// effective window is min(grace, supervisor kill timeout): a supervisor that
+// SIGKILLs earlier (systemd TimeoutStopSec) truncates the drain mid-flight,
+// so deployments must keep the grace under that timeout (--shutdown-grace).
 const defaultAgentShutdownGrace = 8 * time.Second
 
 // NewAgent creates an agent for one provider and one control socket.

--- a/internal/agent/joblogs/manager_job_logs.go
+++ b/internal/agent/joblogs/manager_job_logs.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"sync"
 
 	"github.com/cicd-sensor/cicd-sensor/internal/agent/managerclient"
 	"github.com/cicd-sensor/cicd-sensor/internal/jobcontext"
@@ -176,18 +177,35 @@ func (o *ManagerJobLogs) DroppedLogRecords(logType managerv1beta1.LogType) uint6
 	}
 }
 
-// FinalizeStreamingLogs closes detection and runtime event logs.
-func (o *ManagerJobLogs) FinalizeStreamingLogs(ctx context.Context) error {
+// FlushStreamingLogs sends buffered detection and runtime event records now
+// while keeping the workers open for later records and the final close.
+func (o *ManagerJobLogs) FlushStreamingLogs(ctx context.Context) error {
 	var errs []error
 	if o.detection != nil {
-		if err := o.detection.Close(ctx); err != nil {
+		if err := o.detection.Flush(ctx); err != nil {
 			errs = append(errs, err)
 		}
 	}
 	if o.runtimeEvent != nil {
-		if err := o.runtimeEvent.Close(ctx); err != nil {
+		if err := o.runtimeEvent.Flush(ctx); err != nil {
 			errs = append(errs, err)
 		}
 	}
 	return errors.Join(errs...)
+}
+
+// FinalizeStreamingLogs closes detection and runtime event logs in
+// parallel so one slow drain cannot serialize in front of the other during
+// a deadline-bounded shutdown (#143).
+func (o *ManagerJobLogs) FinalizeStreamingLogs(ctx context.Context) error {
+	var wg sync.WaitGroup
+	var detectionErr, runtimeEventErr error
+	if o.detection != nil {
+		wg.Go(func() { detectionErr = o.detection.Close(ctx) })
+	}
+	if o.runtimeEvent != nil {
+		wg.Go(func() { runtimeEventErr = o.runtimeEvent.Close(ctx) })
+	}
+	wg.Wait()
+	return errors.Join(detectionErr, runtimeEventErr)
 }

--- a/internal/agent/joblogs/manager_job_logs_test.go
+++ b/internal/agent/joblogs/manager_job_logs_test.go
@@ -184,6 +184,49 @@ func TestManagerJobLogsEmitAndCloseSummaryLog(t *testing.T) {
 	}
 }
 
+func TestManagerJobLogsFlushStreamingLogsSendsBufferedRecords(t *testing.T) {
+	poster := &recordingLogBatchSender{}
+	conn := newManagerJobLogsWithSender(testLogger, poster.sendBatch,
+		jobcontext.GitHubJobIdentity("github.com", "acme/example", "123", "build", "1", "runner-1"),
+		jobcontext.ScopeTypeProject,
+		&managerv1beta1.OutputSettings{
+			Detection:    &managerv1beta1.OutputSetting{Enabled: true},
+			RuntimeEvent: &managerv1beta1.OutputSetting{Enabled: true},
+		},
+	)
+
+	if err := conn.WriteDetectionPayload(context.Background(), []byte(`{"type":"detection"}`)); err != nil {
+		t.Fatalf("write detection: %v", err)
+	}
+	if err := conn.WriteRuntimeEventPayload(context.Background(), []byte(`{"type":"runtime_event"}`)); err != nil {
+		t.Fatalf("write runtime event: %v", err)
+	}
+	if err := conn.FlushStreamingLogs(context.Background()); err != nil {
+		t.Fatalf("flush streaming: %v", err)
+	}
+	if got := poster.count(); got != 2 {
+		t.Fatalf("batches after flush: got %d, want 2", got)
+	}
+	// Workers stay open: later records still deliver at finalize.
+	if err := conn.WriteRuntimeEventPayload(context.Background(), []byte(`{"type":"runtime_event_late"}`)); err != nil {
+		t.Fatalf("write runtime event after flush: %v", err)
+	}
+	if err := conn.FinalizeStreamingLogs(context.Background()); err != nil {
+		t.Fatalf("finalize streaming: %v", err)
+	}
+	if got := poster.count(); got != 3 {
+		t.Fatalf("batches after finalize: got %d, want 3", got)
+	}
+}
+
+func TestManagerJobLogsFlushStreamingLogsWithoutWorkersIsNoOp(t *testing.T) {
+	var conn ManagerJobLogs
+
+	if err := conn.FlushStreamingLogs(context.Background()); err != nil {
+		t.Fatalf("flush without workers: %v", err)
+	}
+}
+
 func TestManagerJobLogsRejectsStreamingWritesAfterFinalize(t *testing.T) {
 	poster := &recordingLogBatchSender{}
 	conn := newManagerJobLogsWithSender(testLogger, poster.sendBatch,
@@ -228,5 +271,47 @@ func TestAttachRecordersForTesting(t *testing.T) {
 	}
 	if got := poster.count(); got != 2 {
 		t.Fatalf("sent batches: got %d, want 2", got)
+	}
+}
+
+func TestManagerJobLogsFinalizeStreamingLogsClosesWorkersInParallel(t *testing.T) {
+	release := make(chan struct{})
+	entered := make(chan struct{}, 1)
+	blockingSend := func(ctx context.Context, _ managerclient.LogBatch) error {
+		select {
+		case entered <- struct{}{}:
+		default:
+		}
+		select {
+		case <-release:
+			return nil
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	poster := &recordingLogBatchSender{}
+	identity := jobcontext.GitHubJobIdentity("github.com", "acme/example", "123", "build", "1", "runner-1")
+	var conn ManagerJobLogs
+	conn.AttachDetectionRecorderForTesting(identity, jobcontext.ScopeTypeProject, blockingSend)
+	conn.AttachRuntimeEventRecorderForTesting(identity, jobcontext.ScopeTypeProject, poster.sendBatch)
+
+	if err := conn.WriteDetectionPayload(context.Background(), []byte(`{"type":"detection"}`)); err != nil {
+		t.Fatalf("write detection: %v", err)
+	}
+	<-entered
+	if err := conn.WriteRuntimeEventPayload(context.Background(), []byte(`{"type":"runtime_event"}`)); err != nil {
+		t.Fatalf("write runtime event: %v", err)
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- conn.FinalizeStreamingLogs(context.Background()) }()
+
+	// While the detection worker is blocked in its send, the runtime event
+	// close must still drain: the closes run in parallel.
+	waitForBatchCount(t, poster, 1)
+
+	close(release)
+	if err := <-done; err != nil {
+		t.Fatalf("finalize streaming: %v", err)
 	}
 }

--- a/internal/agent/joblogs/manager_output.go
+++ b/internal/agent/joblogs/manager_output.go
@@ -63,6 +63,28 @@ func (s *managerOutput) EmitAndClose(ctx context.Context, payload []byte) error 
 	return s.close(ctx, payload)
 }
 
+// Flush sends buffered records now and keeps the worker open for later
+// records and the final close. A closed output reports success because the
+// close path already drained the buffer.
+func (s *managerOutput) Flush(ctx context.Context) error {
+	if s == nil {
+		return nil
+	}
+	s.mu.Lock()
+	closed := s.closed
+	s.mu.Unlock()
+	if closed {
+		return nil
+	}
+
+	reply := make(chan error, 1)
+	req := managerOutputRequest{ctx: ctx, flush: true, reply: reply}
+	if err := s.enqueueRequest(ctx, req); err != nil {
+		return err
+	}
+	return waitJobLogOutputClose(ctx, reply, s.done)
+}
+
 func (s *managerOutput) Close(ctx context.Context) error {
 	return s.close(ctx, nil)
 }

--- a/internal/agent/joblogs/manager_output_test.go
+++ b/internal/agent/joblogs/manager_output_test.go
@@ -34,6 +34,12 @@ func (s *recordingLogBatchSender) count() int {
 	return len(s.batches)
 }
 
+func (s *recordingLogBatchSender) setErr(err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.err = err
+}
+
 func TestNewManagerOutputNilSenderReturnsNil(t *testing.T) {
 	t.Parallel()
 
@@ -169,6 +175,79 @@ func TestManagerOutput_EmitAndCloseFlushesFinalRecord(t *testing.T) {
 	}
 	if err := out.Emit(context.Background(), []byte(`{"late":true}`)); err != errManagerOutputClosed {
 		t.Fatalf("emit after close: got %v, want %v", err, errManagerOutputClosed)
+	}
+}
+
+func TestManagerOutput_FlushSendsBufferedRecordsAndKeepsWorkerOpen(t *testing.T) {
+	poster := &recordingLogBatchSender{}
+	out := testManagerOutput(poster.sendBatch, &managerv1beta1.OutputSetting{})
+
+	if err := out.Emit(context.Background(), []byte(`{"n":1}`)); err != nil {
+		t.Fatalf("emit before flush: %v", err)
+	}
+	if err := out.Flush(context.Background()); err != nil {
+		t.Fatalf("flush: %v", err)
+	}
+	if got := poster.count(); got != 1 {
+		t.Fatalf("batches after flush: got %d, want 1", got)
+	}
+	if err := out.Emit(context.Background(), []byte(`{"n":2}`)); err != nil {
+		t.Fatalf("emit after flush: %v", err)
+	}
+	if err := out.Close(context.Background()); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	if got := poster.count(); got != 2 {
+		t.Fatalf("batches after close: got %d, want 2", got)
+	}
+}
+
+func TestManagerOutput_FlushWithEmptyBufferSendsNothing(t *testing.T) {
+	poster := &recordingLogBatchSender{}
+	out := testManagerOutput(poster.sendBatch, &managerv1beta1.OutputSetting{})
+
+	if err := out.Flush(context.Background()); err != nil {
+		t.Fatalf("flush empty buffer: %v", err)
+	}
+	if err := out.Close(context.Background()); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	if got := poster.count(); got != 0 {
+		t.Fatalf("batches: got %d, want 0", got)
+	}
+}
+
+func TestManagerOutput_FlushAfterCloseReturnsNil(t *testing.T) {
+	poster := &recordingLogBatchSender{}
+	out := testManagerOutput(poster.sendBatch, &managerv1beta1.OutputSetting{})
+
+	if err := out.Close(context.Background()); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	if err := out.Flush(context.Background()); err != nil {
+		t.Fatalf("flush after close: got %v, want nil", err)
+	}
+}
+
+func TestManagerOutput_FlushErrorRetainsRecordsForClose(t *testing.T) {
+	poster := &recordingLogBatchSender{err: errors.New("manager unavailable")}
+	out := testManagerOutput(poster.sendBatch, &managerv1beta1.OutputSetting{})
+
+	if err := out.Emit(context.Background(), []byte(`{"n":1}`)); err != nil {
+		t.Fatalf("emit: %v", err)
+	}
+	if err := out.Flush(context.Background()); err == nil {
+		t.Fatal("flush: got nil, want send error")
+	}
+	poster.setErr(nil)
+	if err := out.Close(context.Background()); err != nil {
+		t.Fatalf("close after failed flush: %v", err)
+	}
+	if got := poster.count(); got != 1 {
+		t.Fatalf("batches after close: got %d, want 1", got)
+	}
+	if got := len(poster.batches[0].Records); got != 1 {
+		t.Fatalf("retained records in close batch: got %d, want 1", got)
 	}
 }
 

--- a/internal/agent/joblogs/manager_worker.go
+++ b/internal/agent/joblogs/manager_worker.go
@@ -40,7 +40,10 @@ type managerOutputRequest struct {
 	ctx     context.Context
 	payload []byte
 	close   bool
-	reply   chan error
+	// flush requests a synchronous send of the buffered records without
+	// closing the worker. Failed sends keep the buffer for a later retry.
+	flush bool
+	reply chan error
 }
 
 func newManagerWorker(cfg managerWorkerConfig) *managerWorker {
@@ -145,6 +148,10 @@ func (w *managerWorker) run(requests <-chan managerOutputRequest, done chan<- st
 				}
 				req.reply <- flush(req.ctx)
 				return
+			}
+			if req.flush {
+				req.reply <- flush(req.ctx)
+				continue
 			}
 			if len(req.payload) == 0 {
 				continue

--- a/internal/agent/joblogs/testing.go
+++ b/internal/agent/joblogs/testing.go
@@ -21,6 +21,13 @@ func (o *ManagerJobLogs) AttachRuntimeEventRecorderForTesting(identity jobcontex
 	o.attachRecorderForTesting(identity, scopeType, managerv1beta1.LogType_LOG_TYPE_RUNTIME_EVENT, sendBatch, func(out *managerOutput) { o.runtimeEvent = out })
 }
 
+// AttachBufferedRuntimeEventRecorderForTesting wires the runtime event output
+// of o without a flush threshold or interval, so records stay buffered until
+// an explicit flush or close. Use it to exercise flush paths.
+func (o *ManagerJobLogs) AttachBufferedRuntimeEventRecorderForTesting(identity jobcontext.JobIdentity, scopeType jobcontext.ScopeType, sendBatch func(context.Context, managerclient.LogBatch) error) {
+	o.runtimeEvent = newManagerOutput(o.logger, sendBatch, identity, scopeType, managerv1beta1.LogType_LOG_TYPE_RUNTIME_EVENT, &managerv1beta1.OutputSetting{Enabled: true}, runtimeEventManagerOutputChannelCap)
+}
+
 // AttachSummaryRecorderForTesting wires the final summary output of o to
 // deliver each batch to sendBatch.
 func (o *ManagerJobLogs) AttachSummaryRecorderForTesting(identity jobcontext.JobIdentity, scopeType jobcontext.ScopeType, sendBatch func(context.Context, managerclient.LogBatch) error) {

--- a/internal/agent/jobregistry/finalize.go
+++ b/internal/agent/jobregistry/finalize.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/cicd-sensor/cicd-sensor/internal/agent/job"
@@ -107,6 +108,8 @@ func (jr *JobRegistry) OnJobEnded(jobID jobcontext.JobIdentity, reason kerneltra
 func (jr *JobRegistry) RequestGitHubHostEnd(ctx context.Context, identity jobcontext.JobIdentity, peerPID int32) error {
 	job := jr.get(identity)
 	if job == nil {
+		// Lenient on purpose: the CLI's job/health probe before this call is
+		// the double-end failure guarantee (see postGitHubHostEnd).
 		jr.logger.WarnContext(ctx, "host_end_job_not_found", "job_identity", identity)
 		return nil
 	}
@@ -161,36 +164,49 @@ func (jr *JobRegistry) finalizeTakenJobSync(ctx context.Context, job *job.Job, r
 		}
 	}
 	<-job.Done()
-	// Flush streaming logs before the final summary row.
-	if host := job.HostScope(); host != nil {
-		if err := host.FinalizeStreamingLogs(ctx); err != nil {
-			jr.logger.WarnContext(ctx, "job_host_scope_finalize_failed", "error", err)
-		}
-	}
-	if project := job.ProjectScope(); project != nil {
-		if err := project.FinalizeStreamingLogs(ctx); err != nil {
-			jr.logger.WarnContext(ctx, "job_project_scope_finalize_failed", "error", err)
-		}
-	}
-	jr.logger.InfoContext(ctx, "job_finalized", "job_identity", job.Identity(), "reason", string(reason))
+	// The summary is sent in parallel with the streaming flush so a kill
+	// timer landing mid-drain cannot starve it behind the backlog (#143).
+	// Safe: scope state is quiescent after the drain above and each send
+	// has its own worker. Row ordering across log types is not promised.
 	summaryIn := jobscope.SummaryLogInputs{
 		Identity:   job.Identity(),
 		Metadata:   job.Metadata(),
 		RunnerType: job.RunnerType(),
 		StartedAt:  job.StartedAt(),
 	}
-	var errs []error
-	if host := job.HostScope(); host != nil {
-		if err := host.EmitSummaryLog(ctx, summaryIn, string(reason), finalizedAt); err != nil {
-			errs = append(errs, fmt.Errorf("emit host summary log: %w", err))
+	var wg sync.WaitGroup
+	var summaryErr error
+	wg.Go(func() {
+		var errs []error
+		if host := job.HostScope(); host != nil {
+			if err := host.EmitSummaryLog(ctx, summaryIn, string(reason), finalizedAt); err != nil {
+				errs = append(errs, fmt.Errorf("emit host summary log: %w", err))
+			}
 		}
+		if project := job.ProjectScope(); project != nil {
+			if err := project.EmitSummaryLog(ctx, summaryIn, string(reason), finalizedAt); err != nil {
+				errs = append(errs, fmt.Errorf("emit project summary log: %w", err))
+			}
+		}
+		summaryErr = errors.Join(errs...)
+	})
+	if host := job.HostScope(); host != nil {
+		wg.Go(func() {
+			if err := host.FinalizeStreamingLogs(ctx); err != nil {
+				jr.logger.WarnContext(ctx, "job_host_scope_finalize_failed", "error", err)
+			}
+		})
 	}
 	if project := job.ProjectScope(); project != nil {
-		if err := project.EmitSummaryLog(ctx, summaryIn, string(reason), finalizedAt); err != nil {
-			errs = append(errs, fmt.Errorf("emit project summary log: %w", err))
-		}
+		wg.Go(func() {
+			if err := project.FinalizeStreamingLogs(ctx); err != nil {
+				jr.logger.WarnContext(ctx, "job_project_scope_finalize_failed", "error", err)
+			}
+		})
 	}
-	return errors.Join(errs...)
+	wg.Wait()
+	jr.logger.InfoContext(ctx, "job_finalized", "job_identity", job.Identity(), "reason", string(reason))
+	return summaryErr
 }
 
 func (jr *JobRegistry) takeJob(identity jobcontext.JobIdentity) (*job.Job, bool) {

--- a/internal/agent/jobregistry/finalize_output_test.go
+++ b/internal/agent/jobregistry/finalize_output_test.go
@@ -230,3 +230,125 @@ func decodeManagerBatchRecords(t *testing.T, batch *managerv1beta1.IngestLogBatc
 	}
 	return records
 }
+
+// gatedLogBatchSender blocks every send until release is closed, signaling
+// entered on the first blocked send.
+type gatedLogBatchSender struct {
+	release chan struct{}
+	entered chan struct{}
+}
+
+func newGatedLogBatchSender() *gatedLogBatchSender {
+	return &gatedLogBatchSender{
+		release: make(chan struct{}),
+		entered: make(chan struct{}, 1),
+	}
+}
+
+func (g *gatedLogBatchSender) sendBatch(ctx context.Context, _ managerclient.LogBatch) error {
+	select {
+	case g.entered <- struct{}{}:
+	default:
+	}
+	select {
+	case <-g.release:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func TestFinalizeSendsSummaryWhileStreamingFlushIsBlocked(t *testing.T) {
+	t.Parallel()
+
+	gate := newGatedLogBatchSender()
+	summaryPoster := &recordingManagerBatchPoster{}
+	identity := jobcontext.GitHubJobIdentity("github.com", "acme/example", "123", "build", "1", "runner-1")
+	metadata := jobcontext.JobMetadata{}
+	job, eventCh := newTestJob(identity, metadata, testEventChannelSize)
+	scope := jobscope.NewHost()
+	logs := joblogs.NewForTesting(testLogger, summaryPoster.sendBatch)
+	logs.AttachBufferedRuntimeEventRecorderForTesting(identity, scope.Type, gate.sendBatch)
+	logs.AttachSummaryRecorderForTesting(identity, scope.Type, summaryPoster.sendBatch)
+	scope.SetManagerJobLogs(logs)
+	if err := job.SetHostScope(testCtx, scope); err != nil {
+		t.Fatalf("SetHostScope: %v", err)
+	}
+	scope.WriteRuntimeEventLog(testCtx, identity, metadata, "machine", testDispatchEvent("/usr/bin/curl", "registry.npmjs.org", 443), testLogger)
+	close(eventCh)
+
+	jr := New(testLogger)
+	done := make(chan error, 1)
+	go func() {
+		done <- jr.finalizeTakenJobSync(testCtx, job, kerneltracker.EndShutdown, time.Now().UTC())
+	}()
+
+	<-gate.entered
+	// The summary must arrive while the streaming flush is still blocked in
+	// its send: it rides in parallel instead of queuing behind the backlog.
+	waitForJob(t, "summary sent while streaming flush is blocked", func() bool {
+		return len(managerBatchPosterSnapshot(summaryPoster)) == 1
+	})
+
+	close(gate.release)
+	if err := <-done; err != nil {
+		t.Fatalf("finalizeTakenJobSync: %v", err)
+	}
+}
+
+func TestFinalizeFlushesScopesInParallel(t *testing.T) {
+	t.Parallel()
+
+	gate := newGatedLogBatchSender()
+	poster := &recordingManagerBatchPoster{}
+	identity := jobcontext.GitHubJobIdentity("github.com", "acme/example", "123", "build", "1", "runner-1")
+	metadata := jobcontext.JobMetadata{}
+	job, eventCh := newTestJob(identity, metadata, testEventChannelSize)
+
+	host := jobscope.NewHost()
+	hostLogs := joblogs.NewForTesting(testLogger, poster.sendBatch)
+	hostLogs.AttachBufferedRuntimeEventRecorderForTesting(identity, host.Type, gate.sendBatch)
+	hostLogs.AttachSummaryRecorderForTesting(identity, host.Type, poster.sendBatch)
+	host.SetManagerJobLogs(hostLogs)
+	if err := job.SetHostScope(testCtx, host); err != nil {
+		t.Fatalf("SetHostScope: %v", err)
+	}
+
+	project := jobscope.NewProject()
+	projectLogs := joblogs.NewForTesting(testLogger, poster.sendBatch)
+	projectLogs.AttachBufferedRuntimeEventRecorderForTesting(identity, project.Type, poster.sendBatch)
+	projectLogs.AttachSummaryRecorderForTesting(identity, project.Type, poster.sendBatch)
+	project.SetManagerJobLogs(projectLogs)
+	if err := job.SetProjectScope(testCtx, project); err != nil {
+		t.Fatalf("SetProjectScope: %v", err)
+	}
+
+	host.WriteRuntimeEventLog(testCtx, identity, metadata, "machine", testDispatchEvent("/usr/bin/curl", "registry.npmjs.org", 443), testLogger)
+	project.WriteRuntimeEventLog(testCtx, identity, metadata, "machine", testDispatchEvent("/usr/bin/curl", "registry.npmjs.org", 443), testLogger)
+	close(eventCh)
+
+	jr := New(testLogger)
+	done := make(chan error, 1)
+	go func() {
+		done <- jr.finalizeTakenJobSync(testCtx, job, kerneltracker.EndShutdown, time.Now().UTC())
+	}()
+
+	<-gate.entered
+	// While the host scope's streaming flush is blocked, the project scope's
+	// flush and both summaries must still complete: 3 batches total.
+	waitForJob(t, "project flush and summaries sent while host flush is blocked", func() bool {
+		return len(managerBatchPosterSnapshot(poster)) == 3
+	})
+	types := make(map[managerv1beta1.LogType]int)
+	for _, batch := range managerBatchPosterSnapshot(poster) {
+		types[batch.LogType]++
+	}
+	if types[managerv1beta1.LogType_LOG_TYPE_RUNTIME_EVENT] != 1 || types[managerv1beta1.LogType_LOG_TYPE_SUMMARY] != 2 {
+		t.Fatalf("batch types while host flush blocked: got %v, want 1 runtime_event and 2 summaries", types)
+	}
+
+	close(gate.release)
+	if err := <-done; err != nil {
+		t.Fatalf("finalizeTakenJobSync: %v", err)
+	}
+}

--- a/internal/agent/jobregistry/project_result.go
+++ b/internal/agent/jobregistry/project_result.go
@@ -11,7 +11,15 @@ import (
 	"github.com/cicd-sensor/cicd-sensor/internal/jobcontext"
 )
 
-// RequestGitHubProjectResult builds the GitHub project-scope report document.
+// projectResultFlushTimeout keeps a slow manager from stalling the project
+// result response past the CLI's 30s socket client timeout.
+const projectResultFlushTimeout = 10 * time.Second
+
+// RequestGitHubProjectResult builds the GitHub project-scope report document
+// and flushes the scope's buffered streaming logs while the job is alive, so
+// VM-teardown finalize only carries the tail delta and the summary (#143).
+// It must not finalize the Job or emit a summary: in-job callers may only
+// accelerate delivery.
 func (jr *JobRegistry) RequestGitHubProjectResult(ctx context.Context, identity jobcontext.JobIdentity, peerPID int32) ([]byte, error) {
 	j := jr.get(identity)
 	if j == nil {
@@ -35,6 +43,18 @@ func (jr *JobRegistry) RequestGitHubProjectResult(ctx context.Context, identity 
 		return nil, fmt.Errorf("marshal project result: %w", err)
 	}
 	body = append(body, '\n')
+
+	// Fail-open: the report body must still be produced, monitoring
+	// continues, and shutdown finalize still sends the tail and summary.
+	flushCtx, cancelFlush := context.WithTimeout(ctx, projectResultFlushTimeout)
+	if err := projectScope.FlushManagerLogs(flushCtx); err != nil {
+		jr.logger.WarnContext(ctx, "project_result_flush_failed",
+			"job_identity", identity,
+			"error", err,
+		)
+	}
+	cancelFlush()
+
 	if err := projectScope.CloseDebugOutput(ctx); err != nil {
 		return nil, fmt.Errorf("close debug output before project result response: %w", err)
 	}

--- a/internal/agent/jobregistry/project_result_test.go
+++ b/internal/agent/jobregistry/project_result_test.go
@@ -2,12 +2,14 @@ package jobregistry_test
 
 import (
 	"compress/gzip"
+	"context"
 	"encoding/json"
 	"errors"
 	"io"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -154,4 +156,104 @@ func readProjectResultDebugGzip(t *testing.T, debugDir string) string {
 		t.Fatalf("close gzip reader: %v", err)
 	}
 	return string(body)
+}
+
+type recordingProjectLogSender struct {
+	mu      sync.Mutex
+	err     error
+	records [][]byte
+}
+
+func (r *recordingProjectLogSender) sendBatch(_ context.Context, batch managerclient.LogBatch) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.err != nil {
+		return r.err
+	}
+	for _, record := range batch.Records {
+		r.records = append(r.records, append([]byte(nil), record...))
+	}
+	return nil
+}
+
+func (r *recordingProjectLogSender) count() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.records)
+}
+
+func TestJobRegistry_RequestGitHubProjectResult_FlushesBufferedStreamingLogs(t *testing.T) {
+	jr := newJobRegistry(t)
+	id := jobcontext.GitHubJobIdentity("github.com", "acme/example", "123", "build", "1", "runner-1")
+	meta := jobcontext.JobMetadata{}
+
+	if _, err := jr.ApplyGitHubProjectStart(testCtx, jobregistry.GitHubProjectStartConfig{
+		Identity:   id,
+		Metadata:   meta,
+		RunnerType: "machine",
+	}); err != nil {
+		t.Fatalf("apply project start: %v", err)
+	}
+	job := registeredJob(jr, id)
+	if job == nil || job.ProjectScope() == nil {
+		t.Fatal("project job not registered")
+	}
+	recorder := &recordingProjectLogSender{}
+	project := job.ProjectScope()
+	project.ManagerJobLogsForTesting().AttachBufferedRuntimeEventRecorderForTesting(id, project.Type, recorder.sendBatch)
+
+	project.WriteRuntimeEventLog(testCtx, id, meta, "machine", testProjectResultEvent("event-before-result"), testLogger)
+	if got := recorder.count(); got != 0 {
+		t.Fatalf("runtime event records before project result: got %d, want 0", got)
+	}
+
+	if _, err := jr.RequestGitHubProjectResult(testCtx, id, 0); err != nil {
+		t.Fatalf("request project result: %v", err)
+	}
+	if got := recorder.count(); got != 1 {
+		t.Fatalf("runtime event records after project result: got %d, want 1", got)
+	}
+
+	// A repeated project result flushes whatever buffered since.
+	project.WriteRuntimeEventLog(testCtx, id, meta, "machine", testProjectResultEvent("event-between-results"), testLogger)
+	body, err := jr.RequestGitHubProjectResult(testCtx, id, 0)
+	if err != nil {
+		t.Fatalf("second project result: %v", err)
+	}
+	if len(body) == 0 {
+		t.Fatal("second project result body is empty")
+	}
+	if got := recorder.count(); got != 2 {
+		t.Fatalf("runtime event records after second call: got %d, want 2", got)
+	}
+}
+
+func TestJobRegistry_RequestGitHubProjectResult_FlushFailureStillReturnsBody(t *testing.T) {
+	jr := newJobRegistry(t)
+	id := jobcontext.GitHubJobIdentity("github.com", "acme/example", "123", "build", "1", "runner-1")
+	meta := jobcontext.JobMetadata{}
+
+	if _, err := jr.ApplyGitHubProjectStart(testCtx, jobregistry.GitHubProjectStartConfig{
+		Identity:   id,
+		Metadata:   meta,
+		RunnerType: "machine",
+	}); err != nil {
+		t.Fatalf("apply project start: %v", err)
+	}
+	job := registeredJob(jr, id)
+	if job == nil || job.ProjectScope() == nil {
+		t.Fatal("project job not registered")
+	}
+	recorder := &recordingProjectLogSender{err: errors.New("manager unavailable")}
+	project := job.ProjectScope()
+	project.ManagerJobLogsForTesting().AttachBufferedRuntimeEventRecorderForTesting(id, project.Type, recorder.sendBatch)
+	project.WriteRuntimeEventLog(testCtx, id, meta, "machine", testProjectResultEvent("event-before-result"), testLogger)
+
+	body, err := jr.RequestGitHubProjectResult(testCtx, id, 0)
+	if err != nil {
+		t.Fatalf("project result with failing flush: %v", err)
+	}
+	if !json.Valid(body) {
+		t.Fatal("result body is not valid JSON")
+	}
 }

--- a/internal/agent/jobscope/manager_logs.go
+++ b/internal/agent/jobscope/manager_logs.go
@@ -47,6 +47,16 @@ func (s *JobScopeState) EmitSummaryLog(ctx context.Context, in SummaryLogInputs,
 	return s.managerJobLogs.EmitAndCloseSummaryLog(ctx, payload)
 }
 
+// FlushManagerLogs sends buffered streaming logs now, keeping the Job
+// tracked and its workers open. Reachable from inside the job, so it may
+// only accelerate delivery — never stop collection or emit the summary.
+func (s *JobScopeState) FlushManagerLogs(ctx context.Context) error {
+	if s == nil {
+		return nil
+	}
+	return s.managerJobLogs.FlushStreamingLogs(ctx)
+}
+
 func (s *JobScopeState) WriteDetectionLogForHit(ctx context.Context, identity jobcontext.JobIdentity, metadata jobcontext.JobMetadata, runnerType string, hit observations.HitEntry, event jobevent.EventRecord, logger *slog.Logger) {
 	if s == nil || hit.Identity.IsZero() {
 		return

--- a/internal/agent/jobscope/manager_logs_test.go
+++ b/internal/agent/jobscope/manager_logs_test.go
@@ -623,3 +623,50 @@ func testJobScopeNetworkEvent(id, remoteIP string) jobevent.EventRecord {
 		},
 	}
 }
+
+func TestJobScopeStateFlushManagerLogs_DeliversBufferedStreamingRecords(t *testing.T) {
+	t.Parallel()
+
+	recorder := &recordingJobScopeBatches{}
+	scope := jobscope.NewProject()
+	scope.ManagerJobLogsForTesting().AttachBufferedRuntimeEventRecorderForTesting(testJobIdentity, scope.Type, recorder.sendBatch)
+
+	scope.WriteRuntimeEventLog(context.Background(), testJobIdentity, testJobMetadata, "machine", testJobScopeNetworkEvent("flush-1", "203.0.113.10"), testJobScopeLogger)
+	if got := len(recorder.runtimeEventEntries(t)); got != 0 {
+		t.Fatalf("runtime event entries before flush: got %d, want 0", got)
+	}
+
+	if err := scope.FlushManagerLogs(context.Background()); err != nil {
+		t.Fatalf("flush: %v", err)
+	}
+	if got := len(recorder.runtimeEventEntries(t)); got != 1 {
+		t.Fatalf("runtime event entries after flush: got %d, want 1", got)
+	}
+
+	// The flush must not close the worker: later records still deliver.
+	scope.WriteRuntimeEventLog(context.Background(), testJobIdentity, testJobMetadata, "machine", testJobScopeNetworkEvent("flush-2", "203.0.113.11"), testJobScopeLogger)
+	if err := scope.FinalizeStreamingLogs(context.Background()); err != nil {
+		t.Fatalf("finalize streaming: %v", err)
+	}
+	if got := len(recorder.runtimeEventEntries(t)); got != 2 {
+		t.Fatalf("runtime event entries after finalize: got %d, want 2", got)
+	}
+}
+
+func TestJobScopeStateFlushManagerLogs_NilScopeIsNoOp(t *testing.T) {
+	t.Parallel()
+
+	var scope *jobscope.JobScopeState
+	if err := scope.FlushManagerLogs(context.Background()); err != nil {
+		t.Fatalf("nil scope flush: %v", err)
+	}
+}
+
+func TestJobScopeStateFlushManagerLogs_NoWorkersIsNoOp(t *testing.T) {
+	t.Parallel()
+
+	scope := jobscope.NewProject()
+	if err := scope.FlushManagerLogs(context.Background()); err != nil {
+		t.Fatalf("flush without workers: %v", err)
+	}
+}

--- a/internal/agent/managerclient/collector_service_client.go
+++ b/internal/agent/managerclient/collector_service_client.go
@@ -97,6 +97,13 @@ func (c *CollectorServiceClient) sendIngestLogBatch(ctx context.Context, batch *
 			)
 		}
 		attempt++
+		// jitterHalf sleeps at least delay/2. If the caller's deadline
+		// cannot cover that, a retry can never run: return the real send
+		// error now instead of burning the remaining finalize budget in a
+		// sleep that only ends in ctx.Err().
+		if deadline, ok := ctx.Deadline(); ok && time.Until(deadline) <= delay/2 {
+			return fmt.Errorf("send collector ingest log batch: %w", err)
+		}
 		if sleepErr := c.sleep(ctx, c.jitter(delay)); sleepErr != nil {
 			return fmt.Errorf("send collector ingest log batch: %w", errors.Join(err, sleepErr))
 		}

--- a/internal/agent/managerclient/collector_service_client_test.go
+++ b/internal/agent/managerclient/collector_service_client_test.go
@@ -268,3 +268,36 @@ func newFakeCollectorServer(t *testing.T, svc managerv1beta1connect.CollectorSer
 	server.Start()
 	return server
 }
+
+func TestCollectorServiceClient_SendBatchDoesNotStartBackoffItCannotFinish(t *testing.T) {
+	svc := &fakeCollectorService{
+		handler: func(context.Context, *connect.Request[managerv1beta1.IngestLogRequest]) (*connect.Response[managerv1beta1.IngestLogResponse], error) {
+			return nil, connect.NewError(connect.CodeUnavailable, errors.New("manager down"))
+		},
+	}
+	server := newFakeCollectorServer(t, svc)
+	defer server.Close()
+
+	slept := false
+	client := newCollectorServiceClient(testCollectorServiceLogger, server.Client(), Connection{BaseURL: server.URL, Token: testOutputManagerToken},
+		func(context.Context, time.Duration) error { slept = true; return nil },
+		func(d time.Duration) time.Duration { return d },
+	)
+	// Deadline shorter than the minimum jittered backoff (base/2): the client
+	// must return the send error instead of sleeping into ctx expiry.
+	ctx, cancel := context.WithTimeout(context.Background(), 400*time.Millisecond)
+	defer cancel()
+	err := client.sendIngestLogBatch(ctx, &managerv1beta1.IngestLogBatch{CompressedJsonl: []byte{0x1f, 0x8b}})
+	if err == nil {
+		t.Fatal("send batch: got nil, want error")
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("send batch error: got deadline exceeded, want underlying send error: %v", err)
+	}
+	if slept {
+		t.Fatal("backoff sleep started despite insufficient deadline")
+	}
+	if svc.calls != 1 {
+		t.Fatalf("calls: got %d, want 1", svc.calls)
+	}
+}


### PR DESCRIPTION
Refs #143

On GitHub-hosted runners, buffered runtime_event logs and the summary are only sent during agent shutdown, and the action's systemd unit SIGKILLs the agent at `TimeoutStopSec=5s` — before the 8s shutdown grace. Short jobs lose whatever the 5s timer cuts off. Sends inside finalize were also fully sequential, so the summary always sat at the end of the line.

## Changes

- `project result` now flushes the project scope's buffered streaming logs while the job is still alive, so shutdown only carries the tail delta and the summary. Fail-open with a 10s cap; no summary is emitted and the Job is not finalized — in-job callers may only accelerate delivery, never stop collection.
- Finalize sends run in parallel: the summary rides the first round-trip instead of queuing behind the backlog drain; per-scope flushes and per-log-type closes are also parallel. Consumers may see the summary before the last streaming batch (no output has ever promised row ordering).
- The collector client no longer starts a retry backoff that cannot complete within the caller's deadline; it returns the real send error instead.
- Docs/comments: the `host end` double-call invariant (the CLI's `job/health` probe is what fails the completed hook on an early end) and the `--shutdown-grace` < supervisor kill timeout contract.

## Not in this PR

- cicd-sensor-action: raising `TimeoutStopSec` and aligning `--shutdown-grace` (separate action-repo PR).
- Manual verification with the issue's 10-job matrix (planned after the action-side fix).

## Testing

`go test -race ./...`, `go vet ./...`. New gated-sender tests assert the summary is delivered while a streaming flush is blocked, and that one scope's blocked flush does not stall the other scope or the summaries.
