### PR TITLE
ci(bpf): install qemu directly instead of little-vm-helper deps

### DIFF
--- a/.github/workflows/bpf-cross-kernel.yaml
+++ b/.github/workflows/bpf-cross-kernel.yaml
@@ -58,14 +58,22 @@ jobs:
 
       - name: Install BPF build and VM deps
         run: |
-          # Install qemu directly instead of via little-vm-helper's
-          # install-dependencies. That step pulls the full libvirt stack
-          # (libvirt-daemon-system -> systemd-container), which forces a
-          # libsystemd-shared upgrade that conflicts with the runner image's
-          # cached systemd-container and fails apt before any VM boots. LVH
-          # launches qemu-system-x86_64 directly, so libvirt is not needed;
-          # qemu-utils provides qemu-img for the image overlay.
           sudo apt-get update -qq
+          # Reconcile the runner image's cached systemd packages (…8.16) with
+          # the current archive (…8.17). little-vm-helper's action always
+          # simulates installing its full dependency list — including
+          # libvirt-daemon-system -> systemd-container — to build a package
+          # cache key, even with install-dependencies: false. That simulate
+          # (apt-get -s install, run under `set -e -o pipefail`) fails on the
+          # systemd-container(=8.16) vs libsystemd-shared(8.17) version skew and
+          # aborts the step before any VM boots. Upgrading the systemd set to
+          # the archive version first removes the skew so the simulate succeeds.
+          sudo apt-get install -y -qq --only-upgrade \
+            systemd systemd-container libsystemd-shared libsystemd0
+          # Install qemu ourselves and set install-dependencies: false below, so
+          # LVH does not pull the (unneeded) libvirt stack. LVH launches
+          # qemu-system-x86_64 directly; qemu-utils provides qemu-img for the
+          # image overlay.
           sudo apt-get install -y -qq clang llvm qemu-system-x86 qemu-utils
 
       - name: Enable KVM for LVH

--- a/.github/workflows/bpf-cross-kernel.yaml
+++ b/.github/workflows/bpf-cross-kernel.yaml
@@ -56,10 +56,17 @@ jobs:
           go-version-file: go.mod
           cache: true
 
-      - name: Install BPF build deps
+      - name: Install BPF build and VM deps
         run: |
+          # Install qemu directly instead of via little-vm-helper's
+          # install-dependencies. That step pulls the full libvirt stack
+          # (libvirt-daemon-system -> systemd-container), which forces a
+          # libsystemd-shared upgrade that conflicts with the runner image's
+          # cached systemd-container and fails apt before any VM boots. LVH
+          # launches qemu-system-x86_64 directly, so libvirt is not needed;
+          # qemu-utils provides qemu-img for the image overlay.
           sudo apt-get update -qq
-          sudo apt-get install -y -qq clang llvm
+          sudo apt-get install -y -qq clang llvm qemu-system-x86 qemu-utils
 
       - name: Enable KVM for LVH
         run: |
@@ -112,7 +119,10 @@ jobs:
           image: ${{ env.LVH_IMAGE }}
           image-version: ${{ matrix.kernel.version }}
           host-mount: ./
-          install-dependencies: 'true'
+          # Dependencies are installed by the step above; LVH's own installer
+          # pulls the libvirt stack and breaks apt on the runner (see comment
+          # on "Install BPF build and VM deps").
+          install-dependencies: 'false'
           # LVH interpolates this through a shell; escape literal $ as \$.
           # The kind rootfs is minimal, so install DNS/NSS packages for DNS and
           # systemd-resolved tests. Use /dev/shm to avoid overlayfs dentries in


### PR DESCRIPTION
## Problem

The `BPF Cross-Kernel Integration` workflow (5.15 and 6.18) has been failing **before any VM boots**, during little-vm-helper's `install-dependencies` step, with:

```
systemd-container : Depends: libsystemd-shared (= 255.4-1ubuntu8.16)
                    but 255.4-1ubuntu8.17 is to be installed
```

This is not a kernel bug. LVH's `install-dependencies: 'true'` installs the full libvirt stack:

```
qemu-system cpu-checker libvirt-daemon-system libvirt-clients bridge-utils virtinst virt-manager
```

`libvirt-daemon-system` depends on `systemd-container`, which forces a `libsystemd-shared` upgrade to `8.17`. That conflicts with the version pinned by the GitHub runner image's cached `systemd-container` (`8.16`), so apt aborts. Both matrix kernels go through the same step, so both fail. Clearing the Actions cache is not a durable fix — it recurs on the next Ubuntu package refresh.

## Fix

LVH launches `qemu-system-x86_64` directly and does not use libvirt in this workflow, so the libvirt stack is unnecessary. Install qemu ourselves and turn LVH's installer off:

- Extend the existing build-deps step to also install `qemu-system-x86` and `qemu-utils` (`qemu-img`, used for the image overlay). `clang`/`llvm` were already installed there.
- Set `install-dependencies: 'false'`.

KVM is already enabled via the udev step, so `cpu-checker` is not needed.

## Verification

- YAML validated locally.
- Will `workflow_dispatch` this branch to confirm both 5.15 and 6.18 boot and run the integration suite to completion.

## Context

This unblocks the cross-kernel load gate for the OpenSSL HTTPS uprobe work (Stage 1b-1, `feat/https-openssl-uprobe`), whose new uprobe programs load at agent startup regardless of feature flag and therefore must be verified on the support-floor kernels. This CI fix is independent and lands on `main` first; the feature branch then merges `main` and re-runs the gate.
