### PR TITLE
docs: introduce Takumi Runner as a third-party hosted manager service

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,14 @@ cicd-sensor ships with a set of baseline rules. See the [Baseline Rules guide](h
 - [Attestation predicate](https://cicd-sensor.github.io/user-guide/attestation-predicate.html): runtime-trace predicate for CI/CD runtime evidence.
 - [Developer Guide](https://cicd-sensor.github.io/developer-guide/overview.html): agent, eBPF runtime, manager, and rule engine internals.
 
+## Third-party services
+
+cicd-sensor is a vendor-neutral open-source project: it works on its own, and any manager it talks to is one you choose to run. Instead of hosting the manager yourself, you can point cicd-sensor at a vendor-operated one.
+
+[Takumi Runner](https://flatt.tech/takumi) by GMO Flatt Security acts as a hosted cicd-sensor Manager and adds its own threat detection and trace analysis on top of the collected logs. See their integration guide ([English](https://shisho.dev/docs/r/202608-takumi-runner-cicd-sensor-integration/) / [Japanese](https://shisho.dev/docs/ja/r/202608-takumi-runner-cicd-sensor-integration/)) for setup. It is a separate commercial product, and cicd-sensor works without it.
+
+Other vendors and services are equally welcome to integrate with cicd-sensor.
+
 ## About the project
 
 > [!NOTE]

--- a/docs/index.md
+++ b/docs/index.md
@@ -59,6 +59,12 @@ cicd-sensor treats GitHub Actions and GitLab CI/CD as supported targets.
 It works on both public and private repositories, with no third-party SaaS dependency.
 For platform and runner environment status, see [Platform support](user-guide/overview.md#platform-support).
 
+## Third-party services
+
+cicd-sensor is vendor-neutral: it works on its own, and any manager it talks to is one you choose to run. If you would rather not host the manager yourself, [Takumi Runner](https://flatt.tech/takumi) by GMO Flatt Security acts as a hosted cicd-sensor Manager and adds its own threat detection and trace analysis over the collected logs. See their integration guide ([English](https://shisho.dev/docs/r/202608-takumi-runner-cicd-sensor-integration/) / [Japanese](https://shisho.dev/docs/ja/r/202608-takumi-runner-cicd-sensor-integration/)), and [Hosted manager (third party)](user-guide/manager.md#hosted-manager-third-party) for where it fits.
+
+Other vendors and services are equally welcome to integrate with cicd-sensor.
+
 ## About the project
 
 <style>

--- a/docs/user-guide/manager.md
+++ b/docs/user-guide/manager.md
@@ -58,6 +58,14 @@ Design HTTPS / TLS, authentication boundaries, and private network exposure with
 Use HTTPS for production deployments.
 Plain HTTP is supported for trusted private networks where the network boundary is the accepted protection, and the Agent logs `manager_url_insecure_scheme` when configured with an HTTP Manager URL.
 
+### Hosted manager (third party)
+
+Hosting the manager yourself is not the only option. A third-party service can run the manager for you, and the Agent or the Action points at it through `manager-url` / `manager-token` exactly as it would for a self-hosted manager.
+
+[Takumi Runner](https://flatt.tech/takumi) by GMO Flatt Security works as a hosted cicd-sensor Manager: it terminates the Agent's config fetch and log ingest, and adds the vendor's own threat detection and trace analysis over the collected logs. See the vendor's integration guide ([English](https://shisho.dev/docs/r/202608-takumi-runner-cicd-sensor-integration/) / [Japanese](https://shisho.dev/docs/ja/r/202608-takumi-runner-cicd-sensor-integration/)) for setup. It is a separate commercial product, not operated by the cicd-sensor project.
+
+Other vendors and services are equally welcome to integrate with cicd-sensor; any service can operate a manager the same way.
+
 ## Network requirements
 
 Allow outbound HTTPS from the manager to the following hosts when baseline rules are enabled.


### PR DESCRIPTION
Add a "Third-party services" section to README and the docs (Getting Started, Manager guide) introducing Takumi Runner by GMO Flatt Security, which acts as a hosted cicd-sensor Manager with vendor-side threat detection and trace analysis.

The wording keeps cicd-sensor's positioning explicit: vendor-neutral, works standalone, and the listing is not exclusive — other vendors and services are equally welcome to integrate.

Links: integration guide ([English](https://shisho.dev/docs/r/202608-takumi-runner-cicd-sensor-integration/) / [Japanese](https://shisho.dev/docs/ja/r/202608-takumi-runner-cicd-sensor-integration/))
