### PR TITLE
ci: add third-party hosted manager integration test (Takumi Runner)

### DIFF
--- a/.github/workflows/releases-sensor.yaml
+++ b/.github/workflows/releases-sensor.yaml
@@ -83,9 +83,19 @@ jobs:
     needs: [validate]
     uses: ./.github/workflows/blacksmith-bpf-integration.yaml
 
+  takumi-integration:
+    name: Third-party manager integration gate
+    needs: [validate]
+    # Third-party service (Takumi Runner by GMO Flatt Security); the called
+    # workflow's auth job needs OIDC to authenticate with Shisho Cloud.
+    permissions:
+      contents: read
+      id-token: write
+    uses: ./.github/workflows/third-party-manager-integration-takumi.yaml
+
   approval:
     name: Approve release
-    needs: [validate, ci, bpf-integration, blacksmith-bpf-integration]
+    needs: [validate, ci, bpf-integration, blacksmith-bpf-integration, takumi-integration]
     runs-on: ubuntu-24.04
     environment: sensor-releases/approval
     permissions:

--- a/.github/workflows/third-party-manager-integration-takumi.yaml
+++ b/.github/workflows/third-party-manager-integration-takumi.yaml
@@ -27,40 +27,34 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  auth:
-    name: Authenticate with Shisho Cloud
+  integration:
+    name: Sensor with third-party hosted manager (Takumi)
     # OIDC trust and the bot only exist for the canonical repo; skip forks.
     if: github.repository == 'cicd-sensor/cicd-sensor'
     runs-on: ubuntu-24.04
-    timeout-minutes: 5
-    # Keyless OIDC auth. Kept as a separate job so that id-token: write is
-    # not granted to the job that runs the monitored workload.
+    timeout-minutes: 15
+    # id-token: write is needed by the Shisho Cloud auth step. Auth runs in
+    # the same job as the sensor because GitHub drops secret-masked values
+    # from job outputs, so the token cannot cross a job boundary.
     permissions:
+      contents: read
       id-token: write
-    outputs:
-      token: ${{ steps.auth.outputs.token }}
     steps:
-      - name: Authenticate with Shisho Cloud
+      - name: Authenticate with Shisho Cloud (keyless OIDC)
         id: auth
         uses: flatt-security/shisho-cloud-action@9b68d33503ebf75d7c285d489b288f96ef3df758 # v1.1.0
         with:
           bot-id: "BT01M0D9877ZSZK7DAX0G2WCKCRB" # cicd-sensor
           export-token: true
-          # Must cover the full run of the monitored job; tokens cannot be
-          # refreshed mid-job.
+          # Must cover the full run of this job; tokens cannot be refreshed
+          # mid-job.
           expires-in-minutes: 60
 
-  integration:
-    name: Sensor with third-party hosted manager (Takumi)
-    needs: auth
-    runs-on: ubuntu-24.04
-    timeout-minutes: 15
-    steps:
       - name: Start cicd-sensor (third-party Takumi manager)
         uses: cicd-sensor/cicd-sensor-action@6511eb44c91d71b2b93d71193b1bf2cb18352f66 # v0.0.38
         with:
           manager-url: https://manager.cicdsensor.cloud.shisho.dev
-          manager-token: ${{ needs.auth.outputs.token }}
+          manager-token: ${{ steps.auth.outputs.token }}
 
       - name: Generate one event of every type
         run: |

--- a/.github/workflows/third-party-manager-integration-takumi.yaml
+++ b/.github/workflows/third-party-manager-integration-takumi.yaml
@@ -1,0 +1,104 @@
+---
+name: Third-Party Manager Integration (Takumi)
+
+# Third-party integration test. Takumi Runner (a commercial service by GMO
+# Flatt Security, not operated by the cicd-sensor project) runs a hosted
+# cicd-sensor Manager; this workflow verifies that cicd-sensor-action can
+# authenticate to and deliver trace logs through that third-party manager.
+# https://shisho.dev/docs/t/runner/features/cicdsensor-integration/
+
+"on":
+  schedule:
+    # Weekly smoke test; external service, so keep the cadence low.
+    - cron: "0 3 * * 1"
+  workflow_dispatch:
+  # Allow release-sensor to reuse this as a release gate.
+  workflow_call:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: takumi-integration-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  auth:
+    name: Authenticate with Shisho Cloud
+    # OIDC trust and the bot only exist for the canonical repo; skip forks.
+    if: github.repository == 'cicd-sensor/cicd-sensor'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    # Keyless OIDC auth. Kept as a separate job so that id-token: write is
+    # not granted to the job that runs the monitored workload.
+    permissions:
+      id-token: write
+    outputs:
+      token: ${{ steps.auth.outputs.token }}
+    steps:
+      - name: Authenticate with Shisho Cloud
+        id: auth
+        uses: flatt-security/shisho-cloud-action@9b68d33503ebf75d7c285d489b288f96ef3df758 # v1.1.0
+        with:
+          bot-id: "BT01M0D9877ZSZK7DAX0G2WCKCRB" # cicd-sensor
+          export-token: true
+          # Must cover the full run of the monitored job; tokens cannot be
+          # refreshed mid-job.
+          expires-in-minutes: 60
+
+  integration:
+    name: Sensor with third-party hosted manager (Takumi)
+    needs: auth
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - name: Start cicd-sensor (third-party Takumi manager)
+        uses: cicd-sensor/cicd-sensor-action@6511eb44c91d71b2b93d71193b1bf2cb18352f66 # v0.0.38
+        with:
+          manager-url: https://manager.cicdsensor.cloud.shisho.dev
+          manager-token: ${{ needs.auth.outputs.token }}
+
+      - name: Generate one event of every type
+        run: |
+          set -eu
+          # Cover every sensor event type so the delivered trace exercises
+          # the full schema: process_exec, domain, network_connect,
+          # http_request, unix_socket_connect, file_open, file_move,
+          # file_link, file_remove, and mount.
+
+          # process_exec: every command below is an exec event.
+          uname -a
+
+          # domain + network_connect (tcp/443 over TLS)
+          curl -sS -o /dev/null https://api.github.com/zen
+
+          # http_request: cleartext HTTP request line (tcp/80)
+          curl -sS -o /dev/null http://example.com/
+
+          # domain: DNS resolution without a follow-up connection
+          getent hosts example.org >/dev/null
+
+          # unix_socket_connect: dockerd control socket
+          docker version >/dev/null
+
+          # file_open (write, then read) / file_move / file_link / file_remove
+          workdir=$(mktemp -d)
+          echo "sample" > "$workdir/sample.txt"
+          cat "$workdir/sample.txt" >/dev/null
+          mv "$workdir/sample.txt" "$workdir/sample.moved"
+          ln "$workdir/sample.moved" "$workdir/sample.link"
+          rm "$workdir/sample.link"
+
+          # mount + umount
+          sudo mount -t tmpfs takumi-itest /mnt
+          sudo umount /mnt
+
+      - name: Verify sensor is tracking the job
+        run: |
+          set -eu
+          pgrep -x cicd-sensor >/dev/null || {
+            echo "cicd-sensor agent is not running" >&2
+            exit 1
+          }
+      # Log delivery to the manager happens in the action's post step at job
+      # end; a delivery failure surfaces there.

--- a/.github/workflows/third-party-manager-integration-takumi.yaml
+++ b/.github/workflows/third-party-manager-integration-takumi.yaml
@@ -12,6 +12,10 @@ name: Third-Party Manager Integration (Takumi)
     # Weekly smoke test; external service, so keep the cadence low.
     - cron: "0 3 * * 1"
   workflow_dispatch:
+  # Self-test: run when this workflow itself changes in a PR.
+  pull_request:
+    paths:
+      - .github/workflows/third-party-manager-integration-takumi.yaml
   # Allow release-sensor to reuse this as a release gate.
   workflow_call:
 


### PR DESCRIPTION
Add an integration test against a third-party hosted manager: Takumi Runner by GMO Flatt Security, which operates a hosted cicd-sensor Manager (https://shisho.dev/docs/t/runner/features/cicdsensor-integration/).

The workflow:

- Authenticates to Shisho Cloud via keyless OIDC (`flatt-security/shisho-cloud-action`, pinned), with `id-token: write` confined to a dedicated auth job.
- Runs `cicd-sensor-action` pointed at the Takumi manager endpoint and generates one event of every sensor event type (process_exec, domain, network_connect, http_request, unix_socket_connect, file_open, file_move, file_link, file_remove, mount).
- Runs weekly and on `workflow_dispatch`, and is wired into `releases-sensor.yaml` as a release gate via `workflow_call`.

Notes:

- Requires the org Actions allowlist to include `flatt-security/shisho-cloud-action`, and the Shisho Cloud bot (`BT01M0D9877ZSZK7DAX0G2WCKCRB`) to have the Takumi Runner Trace Sender role with an OIDC trust condition for this repo.
- This adds an external-service dependency to the release path; if Takumi is unavailable, the release gate blocks. Drop it from the `approval` needs to make it non-blocking instead.
