### PR TITLE
docs: move third-party services up in README and note data flow to hosted managers

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,14 @@ Most other runtimes have their open-source defenders: Falco, Tetragon, Tracee, W
 
 <sub>Based on public information as of May 2026. Corrections welcome.</sub>
 
+## Third-party services
+
+Takumi Runner by GMO Flatt Security acts as a hosted cicd-sensor Manager and adds its own threat detection and trace analysis on top of the collected logs. See their integration guide ([English](https://shisho.dev/docs/r/202608-takumi-runner-cicd-sensor-integration/) / [Japanese](https://shisho.dev/docs/ja/r/202608-takumi-runner-cicd-sensor-integration/)) for setup. It is a separate commercial product, and cicd-sensor works without it.
+
+<sub>cicd-sensor is a vendor-neutral open-source project: it works on its own, and any manager it talks to is one you choose to run. Other vendors and services are equally welcome to integrate with cicd-sensor.</sub>
+
+<sub>When cicd-sensor is pointed at a third-party hosted manager, the logs and events it collects are sent to that vendor's service.</sub>
+
 ## Supported CI/CD pipelines
 
 | Platform | Environment | Status |
@@ -105,14 +113,6 @@ cicd-sensor ships with a set of baseline rules. See the [Baseline Rules guide](h
 - [Logging](https://cicd-sensor.github.io/user-guide/logging.html): log format delivered by the manager.
 - [Attestation predicate](https://cicd-sensor.github.io/user-guide/attestation-predicate.html): runtime-trace predicate for CI/CD runtime evidence.
 - [Developer Guide](https://cicd-sensor.github.io/developer-guide/overview.html): agent, eBPF runtime, manager, and rule engine internals.
-
-## Third-party services
-
-cicd-sensor is a vendor-neutral open-source project: it works on its own, and any manager it talks to is one you choose to run. Instead of hosting the manager yourself, you can point cicd-sensor at a vendor-operated one.
-
-[Takumi Runner](https://flatt.tech/takumi) by GMO Flatt Security acts as a hosted cicd-sensor Manager and adds its own threat detection and trace analysis on top of the collected logs. See their integration guide ([English](https://shisho.dev/docs/r/202608-takumi-runner-cicd-sensor-integration/) / [Japanese](https://shisho.dev/docs/ja/r/202608-takumi-runner-cicd-sensor-integration/)) for setup. It is a separate commercial product, and cicd-sensor works without it.
-
-Other vendors and services are equally welcome to integrate with cicd-sensor.
 
 ## About the project
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -61,9 +61,11 @@ For platform and runner environment status, see [Platform support](user-guide/ov
 
 ## Third-party services
 
-cicd-sensor is vendor-neutral: it works on its own, and any manager it talks to is one you choose to run. If you would rather not host the manager yourself, [Takumi Runner](https://flatt.tech/takumi) by GMO Flatt Security acts as a hosted cicd-sensor Manager and adds its own threat detection and trace analysis over the collected logs. See their integration guide ([English](https://shisho.dev/docs/r/202608-takumi-runner-cicd-sensor-integration/) / [Japanese](https://shisho.dev/docs/ja/r/202608-takumi-runner-cicd-sensor-integration/)), and [Hosted manager (third party)](user-guide/manager.md#hosted-manager-third-party) for where it fits.
+If you would rather not host the manager yourself, Takumi Runner by GMO Flatt Security acts as a hosted cicd-sensor Manager and adds its own threat detection and trace analysis over the collected logs. See their integration guide ([English](https://shisho.dev/docs/r/202608-takumi-runner-cicd-sensor-integration/) / [Japanese](https://shisho.dev/docs/ja/r/202608-takumi-runner-cicd-sensor-integration/)), and [Hosted manager (third party)](user-guide/manager.md#hosted-manager-third-party) for where it fits.
 
-Other vendors and services are equally welcome to integrate with cicd-sensor.
+<sub>cicd-sensor is vendor-neutral: it works on its own, and any manager it talks to is one you choose to run. Other vendors and services are equally welcome to integrate with cicd-sensor.</sub>
+
+<sub>When cicd-sensor is pointed at a third-party hosted manager, the logs and events it collects are sent to that vendor's service.</sub>
 
 ## About the project
 

--- a/docs/user-guide/manager.md
+++ b/docs/user-guide/manager.md
@@ -62,9 +62,11 @@ Plain HTTP is supported for trusted private networks where the network boundary 
 
 Hosting the manager yourself is not the only option. A third-party service can run the manager for you, and the Agent or the Action points at it through `manager-url` / `manager-token` exactly as it would for a self-hosted manager.
 
-[Takumi Runner](https://flatt.tech/takumi) by GMO Flatt Security works as a hosted cicd-sensor Manager: it terminates the Agent's config fetch and log ingest, and adds the vendor's own threat detection and trace analysis over the collected logs. See the vendor's integration guide ([English](https://shisho.dev/docs/r/202608-takumi-runner-cicd-sensor-integration/) / [Japanese](https://shisho.dev/docs/ja/r/202608-takumi-runner-cicd-sensor-integration/)) for setup. It is a separate commercial product, not operated by the cicd-sensor project.
+Takumi Runner by GMO Flatt Security works as a hosted cicd-sensor Manager: it terminates the Agent's config fetch and log ingest, and adds the vendor's own threat detection and trace analysis over the collected logs. See the vendor's integration guide ([English](https://shisho.dev/docs/r/202608-takumi-runner-cicd-sensor-integration/) / [Japanese](https://shisho.dev/docs/ja/r/202608-takumi-runner-cicd-sensor-integration/)) for setup. It is a separate commercial product, not operated by the cicd-sensor project.
 
-Other vendors and services are equally welcome to integrate with cicd-sensor; any service can operate a manager the same way.
+<sub>Other vendors and services are equally welcome to integrate with cicd-sensor; any service can operate a manager the same way.</sub>
+
+<sub>When cicd-sensor is pointed at a third-party hosted manager, the logs and events it collects are sent to that vendor's service.</sub>
 
 ## Network requirements
 


### PR DESCRIPTION
- Move the README "Third-party services" section up, right below the feature comparison table.
- Demote the vendor-neutral framing and "other vendors welcome" sentences to `<sub>` small print; the Takumi Runner paragraph stays as body text.
- Add a small-print disclosure to README, docs/index.md, and docs/user-guide/manager.md: logs and events collected by cicd-sensor are sent to the vendor's service when pointed at a third-party hosted manager.
- Drop the flatt.tech product link; keep the integration guide links.