### PR TITLE
feat(rules): add arrayref/proc-macro1 IOC and Rust build-time dropper rules

### DIFF
--- a/rules/generic-execution.yaml
+++ b/rules/generic-execution.yaml
@@ -7,6 +7,19 @@ rule_sets:
       node_package_manager_data_dirs:
         - "/.local/share/pnpm/"
 
+      # proc-macro code runs inside rustc. Build scripts are matched inline:
+      # cargo always places them at
+      # <target>/<profile>/build/<crate>-<hash>/build-script-<name>
+      # (build-script-build for build.rs), so the rules require the /build/
+      # parent and match the build-script- prefix rather than the full name.
+      rustc_fragments:
+        - "/bin/rustc"
+
+      staged_exec_dirs:
+        - "/tmp/"
+        - "/var/tmp/"
+        - "/dev/shm/"
+
     rules:
       - rule_id: python_tmp_pyz_exec
         rule_name: "Supply-chain: Python archive payload executed from /tmp"
@@ -61,3 +74,61 @@ rule_sets:
         action: detect
         tags:
           mitre_tactic: execution
+
+      - rule_id: rust_build_staged_payload_exec
+        rule_name: "Supply-chain: staged payload executed below Rust build script or rustc"
+        description: |
+          What:
+            Detects execution of a binary from /tmp, /var/tmp, /dev/shm, or memfd when the process ancestry contains a cargo build script (build-script-*) or rustc.
+          Why:
+            cargo runs build scripts and proc-macros automatically during build, check, and test. The proc-macro1 dropper used by the August 2026 arrayref compromise downloaded a binary to /tmp and spawned it detached from build.rs; the same shape fits any build-time dropper.
+          Notes:
+            Legitimate build scripts run toolchain binaries (cc, cmake, pkg-config) and write to OUT_DIR, not to temporary directories. A toolchain unpacked under /tmp (ad-hoc downloads, Bazel with an output root or sandbox base in /tmp or /dev/shm) also matches; exclude it with a rule modifier. Review the crate that owns the build script and the downloaded artifact.
+        event_type: process_exec
+        condition: |
+          (
+            is_memfd ||
+            list.staged_exec_dirs.exists(d, process.exec_path.startsWith(d))
+          ) &&
+          process.ancestors.exists(a,
+            list.rustc_fragments.exists(p, a.exec_path.contains(p)) ||
+            (
+              a.exec_path.contains("/build/") &&
+              a.exec_path.contains("/build-script-")
+            )
+          )
+        action: detect
+        tags:
+          mitre_tactic: execution
+
+      - rule_id: rust_build_egress
+        rule_name: "Supply-chain: network egress from Rust build script or rustc lineage"
+        description: |
+          What:
+            Collects non-loopback network connections made by a cargo build script, rustc, or any process below them.
+          Why:
+            cargo performs registry and git fetches itself; build scripts and proc-macros normally have no reason to reach the network. Build-time droppers download their payload from here, and the spawned payload inherits the lineage.
+          Notes:
+            Some sys crates download prebuilt libraries in build.rs (rusty_v8, torch-sys, esp-idf-sys, onnxruntime-sys) and compile-time database macros (sqlx query!) connect to a database. Collect level so those stay reviewable; exclude known crates with a rule modifier. Combine with rust_build_staged_payload_exec and credential rules.
+        event_type: network_connect
+        condition: |
+          !(family == "ipv4" && inIpRange(remote_ip, "127.0.0.0/8")) &&
+          remote_ip != "::1" &&
+          !remote_ip.startsWith("::ffff:127.") &&
+          (
+            list.rustc_fragments.exists(p, process.exec_path.contains(p)) ||
+            (
+              process.exec_path.contains("/build/") &&
+              process.exec_path.contains("/build-script-")
+            ) ||
+            process.ancestors.exists(a,
+              list.rustc_fragments.exists(p, a.exec_path.contains(p)) ||
+              (
+                a.exec_path.contains("/build/") &&
+                a.exec_path.contains("/build-script-")
+              )
+            )
+          )
+        action: collect
+        tags:
+          mitre_tactic: command-and-control

--- a/rules/generic-execution.yaml
+++ b/rules/generic-execution.yaml
@@ -105,11 +105,11 @@ rule_sets:
         rule_name: "Supply-chain: network egress from Rust build script or rustc lineage"
         description: |
           What:
-            Collects non-loopback network connections made by a cargo build script, rustc, or any process below them.
+            Detects non-loopback network connections made by a cargo build script, rustc, or any process below them.
           Why:
             cargo performs registry and git fetches itself; build scripts and proc-macros normally have no reason to reach the network. Build-time droppers download their payload from here, and the spawned payload inherits the lineage.
           Notes:
-            Some sys crates download prebuilt libraries in build.rs (rusty_v8, torch-sys, esp-idf-sys, onnxruntime-sys) and compile-time database macros (sqlx query!) connect to a database. Collect level so those stay reviewable; exclude known crates with a rule modifier. Combine with rust_build_staged_payload_exec and credential rules.
+            Some sys crates download prebuilt libraries in build.rs (rusty_v8, torch-sys, esp-idf-sys, onnxruntime-sys) and compile-time database macros (sqlx query!) connect to a database; exclude those known crates with a rule modifier. Review the destination and the crate that owns the build script, and combine with rust_build_staged_payload_exec and credential rules.
         event_type: network_connect
         condition: |
           !(family == "ipv4" && inIpRange(remote_ip, "127.0.0.0/8")) &&
@@ -129,6 +129,6 @@ rule_sets:
               )
             )
           )
-        action: collect
+        action: detect
         tags:
           mitre_tactic: command-and-control

--- a/rules/generic_execution_test.go
+++ b/rules/generic_execution_test.go
@@ -99,3 +99,185 @@ func TestNodeInlineEvalDescendantUserDataScriptExecRule(t *testing.T) {
 		})
 	}
 }
+
+func TestRustBuildRules(t *testing.T) {
+	t.Parallel()
+
+	loaded, err := rulesource.LoadRulesFile("generic-execution.yaml")
+	if err != nil {
+		t.Fatalf("load execution rules: %v", err)
+	}
+	if len(loaded.RuleSets) != 1 {
+		t.Fatalf("expected 1 ruleset, got %d", len(loaded.RuleSets))
+	}
+	set := loaded.RuleSets[0]
+
+	byID := make(map[string]rule.Rule, len(set.Rules))
+	for _, r := range set.Rules {
+		byID[r.RuleID] = r
+	}
+
+	env, err := celengine.NewEnv()
+	if err != nil {
+		t.Fatalf("new env: %v", err)
+	}
+
+	// Lineage observed for the August 2026 proc-macro1 dropper: cargo runs the
+	// compiled build script directly, and the detached /tmp payload still
+	// reports build-script-build as its immediate ancestor at exec time.
+	buildScriptLineage := []celengine.CELAncestor{
+		{ExecPath: "/home/runner/work/app/app/target/debug/build/proc-macro1-0c1d2e3f/build-script-build", Argv: []string{"build-script-build"}},
+		{ExecPath: "/home/runner/.cargo/bin/cargo", Argv: []string{"cargo", "build"}},
+	}
+	rustcLineage := []celengine.CELAncestor{
+		{ExecPath: "/home/runner/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/bin/rustc", Argv: []string{"rustc", "--crate-name", "app"}},
+		{ExecPath: "/home/runner/.cargo/bin/cargo", Argv: []string{"cargo", "build"}},
+	}
+	cargoOnlyLineage := []celengine.CELAncestor{
+		{ExecPath: "/home/runner/.cargo/bin/cargo", Argv: []string{"cargo", "test"}},
+	}
+
+	cases := []struct {
+		name      string
+		ruleID    string
+		input     celengine.CELInputEvent
+		wantMatch bool
+	}{
+		{
+			name:      "detects the dropper payload spawned from build-script-build",
+			ruleID:    "rust_build_staged_payload_exec",
+			input:     celengine.CELInputEvent{Process: celengine.NewCELProcess("/tmp/rust-setup", []string{"/tmp/rust-setup", "23.254.165.112:443"}, buildScriptLineage)},
+			wantMatch: true,
+		},
+		{
+			name:      "matches a custom-named build script binary",
+			ruleID:    "rust_build_staged_payload_exec",
+			input:     celengine.CELInputEvent{Process: celengine.NewCELProcess("/var/tmp/stage", nil, []celengine.CELAncestor{{ExecPath: "/work/target/release/build/foo-1234/build-script-gen"}})},
+			wantMatch: true,
+		},
+		{
+			name:      "matches /dev/shm execution below a proc-macro host rustc",
+			ruleID:    "rust_build_staged_payload_exec",
+			input:     celengine.CELInputEvent{Process: celengine.NewCELProcess("/dev/shm/x", nil, rustcLineage)},
+			wantMatch: true,
+		},
+		{
+			name:      "matches memfd execution below a build script",
+			ruleID:    "rust_build_staged_payload_exec",
+			input:     celengine.CELInputEvent{Process: celengine.NewCELProcess("/memfd:payload (deleted)", nil, buildScriptLineage), IsMemfd: true},
+			wantMatch: true,
+		},
+		{
+			name:      "ignores toolchain binaries spawned by a build script",
+			ruleID:    "rust_build_staged_payload_exec",
+			input:     celengine.CELInputEvent{Process: celengine.NewCELProcess("/usr/bin/cc", []string{"cc", "-O2"}, buildScriptLineage)},
+			wantMatch: false,
+		},
+		{
+			name:      "ignores /tmp execution without build script or rustc ancestry",
+			ruleID:    "rust_build_staged_payload_exec",
+			input:     celengine.CELInputEvent{Process: celengine.NewCELProcess("/tmp/rust-setup", nil, cargoOnlyLineage)},
+			wantMatch: false,
+		},
+		{
+			name:      "ignores rustdoc doctest binaries run from /tmp",
+			ruleID:    "rust_build_staged_payload_exec",
+			input:     celengine.CELInputEvent{Process: celengine.NewCELProcess("/tmp/rustdoctestabc123/rust_out", nil, []celengine.CELAncestor{{ExecPath: "/home/runner/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/bin/rustdoc"}, {ExecPath: "/home/runner/.cargo/bin/cargo", Argv: []string{"cargo", "test", "--doc"}}})},
+			wantMatch: false,
+		},
+		{
+			name:      "ignores a build-script- path fragment outside a cargo build directory",
+			ruleID:    "rust_build_staged_payload_exec",
+			input:     celengine.CELInputEvent{Process: celengine.NewCELProcess("/tmp/tool", nil, []celengine.CELAncestor{{ExecPath: "/opt/build-script-runner/bin/run"}})},
+			wantMatch: false,
+		},
+		{
+			name:      "ignores /tmp-prefixed paths outside the staged directories",
+			ruleID:    "rust_build_staged_payload_exec",
+			input:     celengine.CELInputEvent{Process: celengine.NewCELProcess("/tmpfs/bin/tool", nil, buildScriptLineage)},
+			wantMatch: false,
+		},
+		{
+			name:      "collects the payload download performed by the build script itself",
+			ruleID:    "rust_build_egress",
+			input:     celengine.CELInputEvent{Process: celengine.NewCELProcess("/work/target/debug/build/proc-macro1-0c1d/build-script-build", nil, nil), RemoteIP: "23.254.165.112", RemotePort: 9089, Protocol: "tcp", Family: "ipv4"},
+			wantMatch: true,
+		},
+		{
+			name:      "collects the C2 beacon from the detached payload below the build script",
+			ruleID:    "rust_build_egress",
+			input:     celengine.CELInputEvent{Process: celengine.NewCELProcess("/tmp/rust-setup", nil, buildScriptLineage), RemoteIP: "23.254.165.112", RemotePort: 443, Protocol: "tcp", Family: "ipv4"},
+			wantMatch: true,
+		},
+		{
+			name:      "collects IPv6 egress below rustc",
+			ruleID:    "rust_build_egress",
+			input:     celengine.CELInputEvent{Process: celengine.NewCELProcess("/usr/bin/curl", nil, rustcLineage), RemoteIP: "2001:db8::1", RemotePort: 443, Protocol: "tcp", Family: "ipv6"},
+			wantMatch: true,
+		},
+		{
+			name:      "ignores loopback connections from a build script",
+			ruleID:    "rust_build_egress",
+			input:     celengine.CELInputEvent{Process: celengine.NewCELProcess("/work/target/debug/build/x-1/build-script-build", nil, nil), RemoteIP: "127.0.0.1", RemotePort: 8080, Protocol: "tcp", Family: "ipv4"},
+			wantMatch: false,
+		},
+		{
+			name:      "ignores IPv6 loopback connections from a build script",
+			ruleID:    "rust_build_egress",
+			input:     celengine.CELInputEvent{Process: celengine.NewCELProcess("/work/target/debug/build/x-1/build-script-build", nil, nil), RemoteIP: "::1", RemotePort: 8080, Protocol: "tcp", Family: "ipv6"},
+			wantMatch: false,
+		},
+		{
+			name:      "ignores IPv4-mapped loopback connections from a build script",
+			ruleID:    "rust_build_egress",
+			input:     celengine.CELInputEvent{Process: celengine.NewCELProcess("/work/target/debug/build/x-1/build-script-build", nil, nil), RemoteIP: "::ffff:127.0.0.1", RemotePort: 5432, Protocol: "tcp", Family: "ipv6"},
+			wantMatch: false,
+		},
+		{
+			name:      "ignores cargo registry fetches without build script lineage",
+			ruleID:    "rust_build_egress",
+			input:     celengine.CELInputEvent{Process: celengine.NewCELProcess("/home/runner/.cargo/bin/cargo", []string{"cargo", "build"}, nil), RemoteIP: "104.16.1.1", RemotePort: 443, Protocol: "tcp", Family: "ipv4"},
+			wantMatch: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.ruleID+"/"+tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			r, ok := byID[tc.ruleID]
+			if !ok {
+				t.Fatalf("rule %q not present in shipped ruleset", tc.ruleID)
+			}
+			prog, err := env.Compile(r.RuleID, r.EventType, r.Condition, set.Lists)
+			if err != nil {
+				t.Fatalf("compile %s: %v", r.RuleID, err)
+			}
+			staticActivation, err := celengine.NewListActivation(rule.NormalizePredefinedLists(set.Lists))
+			if err != nil {
+				t.Fatalf("list activation: %v", err)
+			}
+			matched, err := prog.EvalActivation(celengine.NewEventActivation(tc.input).WithParent(staticActivation))
+			if err != nil {
+				t.Fatalf("eval %s: %v", r.RuleID, err)
+			}
+			if matched != tc.wantMatch {
+				t.Fatalf("rule %s matched=%v, want %v", r.RuleID, matched, tc.wantMatch)
+			}
+		})
+	}
+
+	wantActions := map[string]rule.RuleAction{
+		"rust_build_staged_payload_exec": rule.RuleActionDetect,
+		"rust_build_egress":              rule.RuleActionCollect,
+	}
+	for id, want := range wantActions {
+		r, ok := byID[id]
+		if !ok {
+			t.Fatalf("expected rule %q to be shipped", id)
+		}
+		if r.Action != want {
+			t.Fatalf("rule %s action=%q, want %q", id, r.Action, want)
+		}
+	}
+}

--- a/rules/generic_execution_test.go
+++ b/rules/generic_execution_test.go
@@ -198,19 +198,19 @@ func TestRustBuildRules(t *testing.T) {
 			wantMatch: false,
 		},
 		{
-			name:      "collects the payload download performed by the build script itself",
+			name:      "detects the payload download performed by the build script itself",
 			ruleID:    "rust_build_egress",
 			input:     celengine.CELInputEvent{Process: celengine.NewCELProcess("/work/target/debug/build/proc-macro1-0c1d/build-script-build", nil, nil), RemoteIP: "23.254.165.112", RemotePort: 9089, Protocol: "tcp", Family: "ipv4"},
 			wantMatch: true,
 		},
 		{
-			name:      "collects the C2 beacon from the detached payload below the build script",
+			name:      "detects the C2 beacon from the detached payload below the build script",
 			ruleID:    "rust_build_egress",
 			input:     celengine.CELInputEvent{Process: celengine.NewCELProcess("/tmp/rust-setup", nil, buildScriptLineage), RemoteIP: "23.254.165.112", RemotePort: 443, Protocol: "tcp", Family: "ipv4"},
 			wantMatch: true,
 		},
 		{
-			name:      "collects IPv6 egress below rustc",
+			name:      "detects IPv6 egress below rustc",
 			ruleID:    "rust_build_egress",
 			input:     celengine.CELInputEvent{Process: celengine.NewCELProcess("/usr/bin/curl", nil, rustcLineage), RemoteIP: "2001:db8::1", RemotePort: 443, Protocol: "tcp", Family: "ipv6"},
 			wantMatch: true,
@@ -269,7 +269,7 @@ func TestRustBuildRules(t *testing.T) {
 
 	wantActions := map[string]rule.RuleAction{
 		"rust_build_staged_payload_exec": rule.RuleActionDetect,
-		"rust_build_egress":              rule.RuleActionCollect,
+		"rust_build_egress":              rule.RuleActionDetect,
 	}
 	for id, want := range wantActions {
 		r, ok := byID[id]

--- a/rules/ioc.yaml
+++ b/rules/ioc.yaml
@@ -208,3 +208,58 @@ rule_sets:
           mitre_tactic: execution
           ioc_date: "2026-08-04"
           source_url: https://www.wiz.io/blog/keyv-and-cacheable-npm-supply-chain-attack
+
+      - rule_id: arrayref_proc_macro1_c2_ip
+        rule_name: "IOC: arrayref / proc-macro1 crate compromise C2 IP"
+        description: |
+          What:
+            Terminates outbound connections to the payload host and C2 servers
+            of the August 2026 arrayref / append-only-vec / internment crates.io
+            compromise (proc-macro1 build.rs dropper).
+          Why:
+            Active-compromise IOC. The build script fetches the stage-2 binary
+            from 23.254.165.112:9089 and the binary beacons to
+            23.254.165.112:443; 23.254.167.107 / .216 are follow-on C2 hosts in
+            the same Hostwinds range (.216 is from third-party reports cited by
+            StepSecurity). The dropper dials raw IPs over rustls with
+            certificate checks disabled, so no domain or http_request event
+            precedes this connection.
+          Notes:
+            Preserve job logs and artifacts, rebuild the runner, and rotate all
+            credentials reachable from the job.
+        event_type: network_connect
+        condition: |
+          family == "ipv4" &&
+          (
+            remote_ip == "23.254.165.112" ||
+            remote_ip == "23.254.167.107" ||
+            remote_ip == "23.254.167.216"
+          )
+        action: terminate
+        tags:
+          mitre_tactic: command-and-control
+          ioc_date: "2026-08-20"
+          source_url: https://www.stepsecurity.io/blog/arrayref-rust-crate-supply-chain-attack
+
+      - rule_id: arrayref_proc_macro1_dropper_exec
+        rule_name: "IOC: arrayref / proc-macro1 dropper executed from /tmp/rust-setup"
+        description: |
+          What:
+            Terminates execution of /tmp/rust-setup, the stage-2 infostealer and
+            backdoor launched by the proc-macro1 build script.
+          Why:
+            Active-compromise IOC. The binary receives the C2 address as its
+            first argument, steals Chromium browser credentials, and installs
+            systemd user persistence.
+          Notes:
+            Review the lineage (build-script-build below cargo) and the lockfile
+            for arrayref 0.3.10, append-only-vec 0.1.9, internment 0.8.7, or any
+            proc-macro1 dependency. Preserve job logs and artifacts, rebuild the
+            runner, and rotate all credentials reachable from the job.
+        event_type: process_exec
+        condition: process.exec_path == "/tmp/rust-setup"
+        action: terminate
+        tags:
+          mitre_tactic: execution
+          ioc_date: "2026-08-20"
+          source_url: https://safedep.io/arrayref-proc-macro1-rust-build-time-malware/


### PR DESCRIPTION
## Summary
Detection rules for the 2026-08-20 crates.io compromise (arrayref 0.3.10 / append-only-vec 0.1.9 / internment 0.8.7 → proc-macro1 build.rs dropper), plus generic rules for the same build-time dropper shape.

IOC (`rules/ioc.yaml`):
- `arrayref_proc_macro1_c2_ip` — network_connect to 23.254.165.112 / 23.254.167.107 / 23.254.167.216 → terminate
- `arrayref_proc_macro1_dropper_exec` — exec of `/tmp/rust-setup` → terminate

Generic (`rules/generic-execution.yaml`):
- `rust_build_staged_payload_exec` — exec from /tmp, /var/tmp, /dev/shm or memfd below a cargo build script (`…/build/<crate>-<hash>/build-script-*`) or rustc → detect
- `rust_build_egress` — non-loopback network_connect from build script / rustc lineage → detect (build.rs prebuilt downloads such as rusty_v8 / torch-sys and sqlx-style compile-time DB macros are known hits; exclude with a rule modifier)

The dropper dials a raw IP over rustls with certificate checks disabled, so no `domain` / `http_request` event precedes it; `network_connect` is the catching layer. `mem::forget` detach keeps the cgroup, so lineage attribution survives.

## Known false positives
- Toolchains unpacked under /tmp or /dev/shm and invoked by build.rs / the linker (ad-hoc downloads, Bazel with output root or sandbox base there) match `rust_build_staged_payload_exec`; exclude with a rule modifier.
- 23.254.167.216 comes from third-party reports cited by StepSecurity.

## Test plan
- `make rules-validate`, `make rules-test` (`TestRustBuildRules`, 17 cases), `make rules-bundle-validate`

Refs: https://blog.rust-lang.org/2026/08/20/supply-chain-attack-on-arrayref/ , https://www.stepsecurity.io/blog/arrayref-rust-crate-supply-chain-attack , https://safedep.io/arrayref-proc-macro1-rust-build-time-malware/ , https://www.wiz.io/blog/rust-supply-chain-attack-on-arrayref-significant-overlap-with-dprk-campaigns

https://claude.ai/code/session_01A6Hj1VoJXxUC4Z75TwAQGx
