### PR TITLE
test(kerneltracker): verify HTTP uprobe client coverage

### DIFF
--- a/.github/workflows/blacksmith-bpf-integration.yaml
+++ b/.github/workflows/blacksmith-bpf-integration.yaml
@@ -77,9 +77,8 @@ jobs:
             -o /tmp/http-client-coverage.test ./internal/agent/kerneltracker
 
       - name: Run HTTP client coverage test
-        continue-on-error: true
         env:
-          HTTP_UPROBE_EXPECTED_CLIENTS: curl,python_urllib,python_requests,pip,node,npm,wget,git
+          HTTP_UPROBE_EXPECTED_CLIENTS: curl,python_urllib,python_requests,pip,wget
         run: |
           sudo HTTP_UPROBE_EXPECTED_CLIENTS="$HTTP_UPROBE_EXPECTED_CLIENTS" \
             /tmp/http-client-coverage.test \

--- a/.github/workflows/blacksmith-bpf-integration.yaml
+++ b/.github/workflows/blacksmith-bpf-integration.yaml
@@ -33,7 +33,7 @@ jobs:
       - name: Install BPF integration deps
         run: |
           sudo apt-get update -qq
-          sudo apt-get install -y -qq dnsutils libnss-resolve python3
+          sudo apt-get install -y -qq dnsutils libnss-resolve nodejs npm python3 python3-pip python3-requests wget
 
       - name: Environment info
         run: |
@@ -43,11 +43,12 @@ jobs:
             uname -a
             cat /etc/os-release
             go version
-            echo '$ curl --version'
-            curl --version
-            curl_path="$(command -v curl)"
-            printf '$ curl binary: %s -> %s\n' "$curl_path" "$(readlink -f "$curl_path")"
-            ldd "$curl_path"
+            for binary in curl python3 node npm wget git; do
+              echo "$ $binary --version"
+              "$binary" --version 2>&1 | head -n 3 || true
+              path="$(command -v "$binary" || true)"
+              [ -z "$path" ] || ldd "$(readlink -f "$path")" || true
+            done
             echo '$ openssl version -a'
             if command -v openssl >/dev/null 2>&1; then
               openssl version -a
@@ -55,12 +56,34 @@ jobs:
               echo 'openssl CLI not installed'
             fi
             echo '$ python3 OpenSSL linkage'
-            python3 -c 'import _ssl, ssl, sys; print(sys.version); print(ssl.OPENSSL_VERSION); print(_ssl.__file__)'
+            python3 -c 'import _ssl, requests, ssl, sys; print(sys.version); print(ssl.OPENSSL_VERSION); print(_ssl.__file__); print(requests.__version__)'
             python_ssl_module="$(python3 -c 'import _ssl; print(_ssl.__file__)')"
             ldd "$python_ssl_module"
+            git_http_backend="$(git --exec-path)/git-remote-http"
+            echo "git HTTP backend: $git_http_backend"
+            ldd "$git_http_backend"
             echo '```'
           } | tee -a "$GITHUB_STEP_SUMMARY"
 
       - name: Run BPF integration tests
         run: |
           make bpf-integration SUDO=sudo
+
+      - name: Build HTTP client coverage test
+        env:
+          CGO_ENABLED: "0"
+        run: |
+          go test -mod=vendor -c -tags 'bpf_integration http_client_integration' \
+            -o /tmp/http-client-coverage.test ./internal/agent/kerneltracker
+
+      - name: Run HTTP client coverage test
+        continue-on-error: true
+        env:
+          HTTP_UPROBE_EXPECTED_CLIENTS: curl,python_urllib,python_requests,pip,node,npm,wget,git
+        run: |
+          sudo HTTP_UPROBE_EXPECTED_CLIENTS="$HTTP_UPROBE_EXPECTED_CLIENTS" \
+            /tmp/http-client-coverage.test \
+            -test.v \
+            -test.count=1 \
+            -test.timeout=10m \
+            -test.run '^TestLinuxOpenSSLUprobeCoversCommonClients$'

--- a/.github/workflows/bpf-cross-kernel.yaml
+++ b/.github/workflows/bpf-cross-kernel.yaml
@@ -37,10 +37,22 @@ jobs:
         include:
           - runner: ubuntu-22.04
             experimental: false
+            expected: curl,python_urllib,python_requests,pip,wget
           - runner: ubuntu-24.04
             experimental: false
+            expected: curl,python_urllib,python_requests,pip,wget
           - runner: ubuntu-26.04
             experimental: true
+            expected: curl,python_urllib,python_requests,pip
+          - runner: ubuntu-22.04-arm
+            experimental: true
+            expected: curl,python_urllib,python_requests,pip,node,npm,wget,git
+          - runner: ubuntu-24.04-arm
+            experimental: true
+            expected: curl,python_urllib,python_requests,pip,node,npm,wget,git
+          - runner: ubuntu-26.04-arm
+            experimental: true
+            expected: curl,python_urllib,python_requests,pip,node,npm,wget,git
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -81,8 +93,11 @@ jobs:
             -o /tmp/http-client-coverage.test ./internal/agent/kerneltracker
 
       - name: Run HTTP client coverage test
+        env:
+          HTTP_UPROBE_EXPECTED_CLIENTS: ${{ matrix.expected }}
         run: |
-          sudo /tmp/http-client-coverage.test \
+          sudo HTTP_UPROBE_EXPECTED_CLIENTS="$HTTP_UPROBE_EXPECTED_CLIENTS" \
+            /tmp/http-client-coverage.test \
             -test.v \
             -test.count=1 \
             -test.timeout=10m \

--- a/.github/workflows/bpf-cross-kernel.yaml
+++ b/.github/workflows/bpf-cross-kernel.yaml
@@ -26,6 +26,68 @@ permissions:
   contents: read
 
 jobs:
+  http-client-coverage:
+    name: "HTTP client coverage on ${{ matrix.runner }}"
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 15
+    continue-on-error: ${{ matrix.experimental }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-22.04
+            experimental: false
+          - runner: ubuntu-24.04
+            experimental: false
+          - runner: ubuntu-26.04
+            experimental: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Setup Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Install HTTP clients
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq nodejs npm python3-pip python3-requests wget
+
+      - name: Client environment
+        run: |
+          uname -a
+          cat /etc/os-release
+          for binary in curl python3 node npm wget git; do
+            echo "$ $binary --version"
+            "$binary" --version 2>&1 | head -n 3 || true
+            path="$(command -v "$binary" || true)"
+            [ -z "$path" ] || ldd "$(readlink -f "$path")" || true
+          done
+          python3 -c 'import _ssl, requests, ssl; print("python ssl:", ssl.OPENSSL_VERSION); print("python _ssl:", _ssl.__file__); print("requests:", requests.__version__)'
+          python_ssl_module="$(python3 -c 'import _ssl; print(_ssl.__file__)')"
+          ldd "$python_ssl_module"
+          git_http_backend="$(git --exec-path)/git-remote-http"
+          echo "git HTTP backend: $git_http_backend"
+          ldd "$git_http_backend"
+
+      - name: Build HTTP client coverage test
+        env:
+          CGO_ENABLED: "0"
+        run: |
+          go test -mod=vendor -c -tags 'bpf_integration http_client_integration' \
+            -o /tmp/http-client-coverage.test ./internal/agent/kerneltracker
+
+      - name: Run HTTP client coverage test
+        run: |
+          sudo /tmp/http-client-coverage.test \
+            -test.v \
+            -test.count=1 \
+            -test.timeout=10m \
+            -test.run '^TestLinuxOpenSSLUprobeCoversCommonClients$'
+
   kernel:
     name: "x64 kernel ${{ matrix.kernel.label }}"
     runs-on: ubuntu-24.04

--- a/.github/workflows/bpf-cross-kernel.yaml
+++ b/.github/workflows/bpf-cross-kernel.yaml
@@ -45,14 +45,14 @@ jobs:
             experimental: true
             expected: curl,python_urllib,python_requests,pip
           - runner: ubuntu-22.04-arm
-            experimental: true
-            expected: curl,python_urllib,python_requests,pip,node,npm,wget,git
+            experimental: false
+            expected: curl,python_urllib,python_requests,pip,wget
           - runner: ubuntu-24.04-arm
-            experimental: true
-            expected: curl,python_urllib,python_requests,pip,node,npm,wget,git
+            experimental: false
+            expected: curl,python_urllib,python_requests,pip,wget
           - runner: ubuntu-26.04-arm
             experimental: true
-            expected: curl,python_urllib,python_requests,pip,node,npm,wget,git
+            expected: curl,python_urllib,python_requests,pip
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/internal/agent/kerneltracker/kernel_sample_tls_client_integration_linux_test.go
+++ b/internal/agent/kerneltracker/kernel_sample_tls_client_integration_linux_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"os/exec"
 	"strings"
 	"sync"
@@ -18,10 +19,12 @@ import (
 )
 
 // TestLinuxOpenSSLUprobeCoversCommonClients verifies actual client binaries on
-// GitHub-hosted Ubuntu. A unique path identifies which client produced the
-// OpenSSL http_request event.
+// CI runner images. A unique path identifies which client produced the OpenSSL
+// http_request event.
 func TestLinuxOpenSSLUprobeCoversCommonClients(t *testing.T) {
+	expected := expectedHTTPClientCoverage(t)
 	tests := []struct {
+		id        string
 		name      string
 		binary    string
 		urlPath   string
@@ -29,6 +32,7 @@ func TestLinuxOpenSSLUprobeCoversCommonClients(t *testing.T) {
 		command   func(string) *exec.Cmd
 	}{
 		{
+			id:        "curl",
 			name:      "curl",
 			binary:    "curl",
 			urlPath:   "/curl",
@@ -38,6 +42,7 @@ func TestLinuxOpenSSLUprobeCoversCommonClients(t *testing.T) {
 			},
 		},
 		{
+			id:        "python_urllib",
 			name:      "python urllib",
 			binary:    "python3",
 			urlPath:   "/python-urllib",
@@ -50,6 +55,7 @@ for _ in range(4): urllib.request.urlopen(sys.argv[1], context=context, timeout=
 			},
 		},
 		{
+			id:        "python_requests",
 			name:      "python requests",
 			binary:    "python3",
 			urlPath:   "/python-requests",
@@ -61,6 +67,7 @@ for _ in range(4): requests.get(sys.argv[1], timeout=10, verify=False)`
 			},
 		},
 		{
+			id:        "pip",
 			name:      "pip",
 			binary:    "python3",
 			urlPath:   "/pip",
@@ -74,6 +81,7 @@ for _ in range(4): requests.get(sys.argv[1], timeout=10, verify=False)`
 			},
 		},
 		{
+			id:        "node",
 			name:      "node https",
 			binary:    "node",
 			urlPath:   "/node",
@@ -86,6 +94,7 @@ const request=()=>new Promise((resolve,reject)=>https.get(url,{rejectUnauthorize
 			},
 		},
 		{
+			id:        "npm",
 			name:      "npm ping",
 			binary:    "npm",
 			urlPath:   "/npm",
@@ -96,6 +105,7 @@ const request=()=>new Promise((resolve,reject)=>https.get(url,{rejectUnauthorize
 			},
 		},
 		{
+			id:        "wget",
 			name:      "wget",
 			binary:    "wget",
 			urlPath:   "/wget",
@@ -105,6 +115,7 @@ const request=()=>new Promise((resolve,reject)=>https.get(url,{rejectUnauthorize
 			},
 		},
 		{
+			id:        "git",
 			name:      "git ls-remote",
 			binary:    "git",
 			urlPath:   "/git",
@@ -119,9 +130,25 @@ const request=()=>new Promise((resolve,reject)=>https.get(url,{rejectUnauthorize
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			requireBinary(t, test.binary)
-			testOpenSSLClientCoverage(t, test.urlPath, test.eventPath, test.command)
+			captured := testOpenSSLClientCoverage(t, test.urlPath, test.eventPath, test.command)
+			if captured != expected[test.id] {
+				t.Fatalf("captured = %t, want %t for %s", captured, expected[test.id], test.id)
+			}
 		})
 	}
+}
+
+func expectedHTTPClientCoverage(t *testing.T) map[string]bool {
+	t.Helper()
+	raw, ok := os.LookupEnv("HTTP_UPROBE_EXPECTED_CLIENTS")
+	if !ok {
+		t.Fatal("HTTP_UPROBE_EXPECTED_CLIENTS is required")
+	}
+	expected := make(map[string]bool)
+	for client := range strings.SplitSeq(raw, ",") {
+		expected[strings.TrimSpace(client)] = true
+	}
+	return expected
 }
 
 func testOpenSSLClientCoverage(
@@ -129,7 +156,7 @@ func testOpenSSLClientCoverage(
 	urlPath string,
 	eventPath string,
 	command func(string) *exec.Cmd,
-) {
+) bool {
 	t.Helper()
 
 	cgroupRoot, err := getCgroupV2Root()
@@ -174,10 +201,18 @@ func testOpenSSLClientCoverage(
 		t.Fatalf("HTTPS client: %v: %s", err, output)
 	}
 
-	waitForEngineInput(t, kernelTracker.inputCh, 20*time.Second, "openssl http_request for "+eventPath,
-		func(in engineInput) bool {
+	deadline := time.NewTimer(5 * time.Second)
+	defer deadline.Stop()
+	for {
+		select {
+		case in := <-kernelTracker.inputCh:
 			sample, ok := in.(httpRequestSample)
-			return ok && sample.CgroupID == cgroupID && sample.Source == HTTPSourceOpenSSL &&
-				strings.HasPrefix(sample.Path, eventPath)
-		})
+			if ok && sample.CgroupID == cgroupID && sample.Source == HTTPSourceOpenSSL &&
+				strings.HasPrefix(sample.Path, eventPath) {
+				return true
+			}
+		case <-deadline.C:
+			return false
+		}
+	}
 }

--- a/internal/agent/kerneltracker/kernel_sample_tls_client_integration_linux_test.go
+++ b/internal/agent/kerneltracker/kernel_sample_tls_client_integration_linux_test.go
@@ -1,0 +1,183 @@
+//go:build linux && bpf_integration && http_client_integration
+
+package kerneltracker
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os/exec"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/cicd-sensor/cicd-sensor/internal/agent/kerneltracker/kernelio"
+)
+
+// TestLinuxOpenSSLUprobeCoversCommonClients verifies actual client binaries on
+// GitHub-hosted Ubuntu. A unique path identifies which client produced the
+// OpenSSL http_request event.
+func TestLinuxOpenSSLUprobeCoversCommonClients(t *testing.T) {
+	tests := []struct {
+		name      string
+		binary    string
+		urlPath   string
+		eventPath string
+		command   func(string) *exec.Cmd
+	}{
+		{
+			name:      "curl",
+			binary:    "curl",
+			urlPath:   "/curl",
+			eventPath: "/curl",
+			command: func(url string) *exec.Cmd {
+				return exec.Command("curl", "-sk", "--http1.1", "--max-time", "10", url, url, url, url)
+			},
+		},
+		{
+			name:      "python urllib",
+			binary:    "python3",
+			urlPath:   "/python-urllib",
+			eventPath: "/python-urllib",
+			command: func(url string) *exec.Cmd {
+				const script = `import ssl,sys,urllib.request
+context=ssl._create_unverified_context()
+for _ in range(4): urllib.request.urlopen(sys.argv[1], context=context, timeout=10).read()`
+				return exec.Command("python3", "-c", script, url)
+			},
+		},
+		{
+			name:      "python requests",
+			binary:    "python3",
+			urlPath:   "/python-requests",
+			eventPath: "/python-requests",
+			command: func(url string) *exec.Cmd {
+				const script = `import requests,sys
+for _ in range(4): requests.get(sys.argv[1], timeout=10, verify=False)`
+				return exec.Command("python3", "-c", script, url)
+			},
+		},
+		{
+			name:      "pip",
+			binary:    "python3",
+			urlPath:   "/pip",
+			eventPath: "/pip/simple/cicd-sensor-http-uprobe-missing/",
+			command: func(url string) *exec.Cmd {
+				command := fmt.Sprintf(
+					"for i in 1 2 3 4; do python3 -m pip --disable-pip-version-check index versions --trusted-host 127.0.0.1 --index-url %q/simple cicd-sensor-http-uprobe-missing || true; done",
+					url,
+				)
+				return exec.Command("sh", "-c", command)
+			},
+		},
+		{
+			name:      "node https",
+			binary:    "node",
+			urlPath:   "/node",
+			eventPath: "/node",
+			command: func(url string) *exec.Cmd {
+				const script = `const https=require('https'),url=process.argv[1];
+const request=()=>new Promise((resolve,reject)=>https.get(url,{rejectUnauthorized:false,agent:false},r=>{r.resume();r.on('end',resolve)}).on('error',reject));
+(async()=>{for(let i=0;i<4;i++)await request()})().catch(e=>{console.error(e);process.exit(1)});`
+				return exec.Command("node", "-e", script, url)
+			},
+		},
+		{
+			name:      "npm ping",
+			binary:    "npm",
+			urlPath:   "/npm",
+			eventPath: "/npm/-/ping",
+			command: func(url string) *exec.Cmd {
+				command := fmt.Sprintf("for i in 1 2 3 4; do npm ping --registry=%q/ --strict-ssl=false; done", url)
+				return exec.Command("sh", "-c", command)
+			},
+		},
+		{
+			name:      "wget",
+			binary:    "wget",
+			urlPath:   "/wget",
+			eventPath: "/wget",
+			command: func(url string) *exec.Cmd {
+				return exec.Command("wget", "--no-check-certificate", "--quiet", "--output-document=/dev/null", url, url, url, url)
+			},
+		},
+		{
+			name:      "git ls-remote",
+			binary:    "git",
+			urlPath:   "/git",
+			eventPath: "/git/info/refs",
+			command: func(url string) *exec.Cmd {
+				command := fmt.Sprintf("for i in 1 2 3 4; do git -c http.sslVerify=false ls-remote %q || true; done", url)
+				return exec.Command("sh", "-c", command)
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			requireBinary(t, test.binary)
+			testOpenSSLClientCoverage(t, test.urlPath, test.eventPath, test.command)
+		})
+	}
+}
+
+func testOpenSSLClientCoverage(
+	t *testing.T,
+	urlPath string,
+	eventPath string,
+	command func(string) *exec.Cmd,
+) {
+	t.Helper()
+
+	cgroupRoot, err := getCgroupV2Root()
+	if err != nil {
+		t.Fatalf("getCgroupV2Root: %v", err)
+	}
+	kernelIO, err := kernelio.NewLinux(nil, kernelio.Config{
+		CgroupV2RootPath:  cgroupRoot,
+		EnableOpenSSLHTTP: true,
+	})
+	if err != nil {
+		t.Fatalf("kernelio.NewLinux: %v", err)
+	}
+	t.Cleanup(func() { _ = kernelIO.Close() })
+
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+	kernelTracker := newTestKernelTracker(nil, nil, kernelIO, cgroupRoot)
+	startKernelSampleLoop(t, ctx, kernelIO, kernelTracker)
+	cgroupID := trackTestProcessCgroup(t, ctx, kernelIO, cgroupRoot)
+
+	var firstRequest sync.Once
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		firstRequest.Do(func() { time.Sleep(2 * time.Second) })
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/-/ping"):
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte("{}"))
+		case strings.HasSuffix(r.URL.Path, "/info/refs"):
+			w.Header().Set("Content-Type", "application/x-git-upload-pack-advertisement")
+			_, _ = w.Write([]byte("001e# service=git-upload-pack\n0000"))
+		default:
+			w.Header().Set("Content-Type", "text/html")
+			_, _ = w.Write([]byte("<!doctype html><html></html>"))
+		}
+	}))
+	server.TLS = &tls.Config{NextProtos: []string{"http/1.1"}}
+	server.StartTLS()
+	t.Cleanup(server.Close)
+
+	if output, err := command(server.URL + urlPath).CombinedOutput(); err != nil {
+		t.Fatalf("HTTPS client: %v: %s", err, output)
+	}
+
+	waitForEngineInput(t, kernelTracker.inputCh, 20*time.Second, "openssl http_request for "+eventPath,
+		func(in engineInput) bool {
+			sample, ok := in.(httpRequestSample)
+			return ok && sample.CgroupID == cgroupID && sample.Source == HTTPSourceOpenSSL &&
+				strings.HasPrefix(sample.Path, eventPath)
+		})
+}


### PR DESCRIPTION
## What

- Add real-client HTTP uprobe integration cases for:
  - curl
  - Python urllib
  - Python requests
  - pip
  - Node
  - npm
  - wget
  - Git
- Run client coverage on GitHub-hosted Ubuntu 22.04 and 24.04.
- Run Ubuntu 26.04 preview as a non-blocking early compatibility check.
- Record client versions and dynamic-library linkage in the workflow log.

## Why

HTTP uprobe coverage depends on the TLS library and function called by the
installed client binary. A client name alone does not prove coverage.

This test sends a unique HTTPS path from each real client and verifies that the
expected OpenSSL `http_request` event reaches KernelTracker.

Client-binary coverage is kept separate from the existing LVH cross-kernel
verifier matrix because they validate different compatibility boundaries.

## Design

- The test uses the dedicated `http_client_integration` build tag.
- Each client sends requests to a local HTTP/1.1 TLS server.
- Unique paths identify the client that produced each event.
- Ubuntu 22.04 and 24.04 are blocking.
- Ubuntu 26.04 preview uses `continue-on-error`.

Related to #136.

## Verification

- `go vet -mod=vendor ./...`
- `go test -mod=vendor ./...`
- `staticcheck ./...`
- Linux integration test binary compiled with:
  `bpf_integration http_client_integration`
- `git diff --check`