### PR TITLE
fix(kerneltracker): discover low-address HTTP uprobe targets

### DIFF
--- a/.github/workflows/blacksmith-bpf-integration.yaml
+++ b/.github/workflows/blacksmith-bpf-integration.yaml
@@ -78,7 +78,7 @@ jobs:
 
       - name: Run HTTP client coverage test
         env:
-          HTTP_UPROBE_EXPECTED_CLIENTS: curl,python_urllib,python_requests,pip,wget
+          HTTP_UPROBE_EXPECTED_CLIENTS: curl,python_urllib,python_requests,pip,node,npm,wget
         run: |
           sudo HTTP_UPROBE_EXPECTED_CLIENTS="$HTTP_UPROBE_EXPECTED_CLIENTS" \
             /tmp/http-client-coverage.test \

--- a/.github/workflows/bpf-cross-kernel.yaml
+++ b/.github/workflows/bpf-cross-kernel.yaml
@@ -37,22 +37,22 @@ jobs:
         include:
           - runner: ubuntu-22.04
             experimental: false
-            expected: curl,python_urllib,python_requests,pip,wget
+            expected: curl,python_urllib,python_requests,pip,node,npm,wget
           - runner: ubuntu-24.04
             experimental: false
-            expected: curl,python_urllib,python_requests,pip,wget
+            expected: curl,python_urllib,python_requests,pip,node,npm,wget
           - runner: ubuntu-26.04
             experimental: true
-            expected: curl,python_urllib,python_requests,pip
+            expected: curl,python_urllib,python_requests,pip,node,npm
           - runner: ubuntu-22.04-arm
             experimental: false
-            expected: curl,python_urllib,python_requests,pip,wget
+            expected: curl,python_urllib,python_requests,pip,node,npm,wget
           - runner: ubuntu-24.04-arm
             experimental: false
-            expected: curl,python_urllib,python_requests,pip,wget
+            expected: curl,python_urllib,python_requests,pip,node,npm,wget
           - runner: ubuntu-26.04-arm
             experimental: true
-            expected: curl,python_urllib,python_requests,pip
+            expected: curl,python_urllib,python_requests,pip,node,npm
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/docs/developer-guide/ebpf/http-uprobes.md
+++ b/docs/developer-guide/ebpf/http-uprobes.md
@@ -307,8 +307,8 @@ of an OpenSSL `http_request` event for that runner image.
 | Python `urllib.request` over HTTPS HTTP/1.1 | Verified | GitHub-hosted Ubuntu 22.04, 24.04, and 26.04 preview on x64 and arm64; observes `SSL_write_ex`. |
 | Python requests over HTTPS HTTP/1.x | Verified | GitHub-hosted Ubuntu 22.04, 24.04, and 26.04 preview on x64 and arm64; observes `SSL_write_ex`. |
 | pip over HTTPS | Verified | GitHub-hosted Ubuntu 22.04, 24.04, and 26.04 preview on x64 and arm64; observes `SSL_write_ex`. |
-| Node over HTTPS HTTP/1.x | Not covered (verified) | GitHub-hosted Ubuntu 22.04, 24.04, and 26.04 preview on x64 and arm64 do not expose a selected attachable function path. |
-| npm over HTTPS | Not covered (verified) | Uses the same uncovered Node TLS path on the verified runner images. |
+| Node over HTTPS HTTP/1.x | Verified | GitHub-hosted Ubuntu 22.04, 24.04, and 26.04 preview on x64 and arm64; observes `SSL_write`. |
+| npm over HTTPS | Verified | GitHub-hosted Ubuntu 22.04, 24.04, and 26.04 preview on x64 and arm64 through Node's `SSL_write` path. |
 | wget over HTTPS HTTP/1.x | Verified on 22.04 and 24.04 | GitHub-hosted x64 and arm64 observe `SSL_write`; Ubuntu 26.04 preview uses GnuTLS and is not covered. |
 | Git over HTTPS | Not covered (verified) | GitHub-hosted Ubuntu 22.04, 24.04, and 26.04 preview on x64 and arm64 use a GnuTLS-backed Git HTTP helper. |
 | curl or Node over HTTP/2 | Planned | Requires nghttp2 support. |

--- a/internal/agent/kerneltracker/kernelio/http_uprobe_discovery.go
+++ b/internal/agent/kerneltracker/kernelio/http_uprobe_discovery.go
@@ -498,7 +498,22 @@ func parseExecMapping(line string) (rng string, mapped mappedFileIdentity, ok bo
 	if strings.HasPrefix(fields[5], "[") { // [vdso] etc.
 		return "", "", false
 	}
-	return fields[0], mappedFileIdentity(fields[3] + ":" + fields[4]), true
+	startText, endText, found := strings.Cut(fields[0], "-")
+	if !found {
+		return "", "", false
+	}
+	start, err := strconv.ParseUint(startText, 16, 64)
+	if err != nil {
+		return "", "", false
+	}
+	end, err := strconv.ParseUint(endText, 16, 64)
+	if err != nil || end <= start {
+		return "", "", false
+	}
+	// map_files names ranges without leading zeroes, while maps can pad low
+	// addresses (for example, a non-PIE executable mapped at 00400000).
+	rng = fmt.Sprintf("%x-%x", start, end)
+	return rng, mappedFileIdentity(fields[3] + ":" + fields[4]), true
 }
 
 // fifoSet is a fixed-size set with FIFO eviction. It is a cache: eviction only

--- a/internal/agent/kerneltracker/kernelio/http_uprobe_discovery.go
+++ b/internal/agent/kerneltracker/kernelio/http_uprobe_discovery.go
@@ -510,8 +510,9 @@ func parseExecMapping(line string) (rng string, mapped mappedFileIdentity, ok bo
 	if err != nil || end <= start {
 		return "", "", false
 	}
-	// map_files names ranges without leading zeroes, while maps can pad low
-	// addresses (for example, a non-PIE executable mapped at 00400000).
+	// /proc/<pid>/map_files exposes each mapped ELF under its unpadded VMA range.
+	// Therefore maps "00400000-066a1000" becomes map_files "400000-66a1000".
+	// Parse numerically so the lookup opens the mapped ELF entry.
 	rng = fmt.Sprintf("%x-%x", start, end)
 	return rng, mappedFileIdentity(fields[3] + ":" + fields[4]), true
 }

--- a/internal/agent/kerneltracker/kernelio/http_uprobe_discovery_test.go
+++ b/internal/agent/kerneltracker/kernelio/http_uprobe_discovery_test.go
@@ -55,6 +55,13 @@ func TestParseExecMapping(t *testing.T) {
 			wantMapping: "fd:01:1443212",
 		},
 		{
+			name:        "low executable address is normalized for map_files",
+			line:        "00400000-066a1000 r-xp 00000000 08:01 1443212 /usr/bin/node",
+			wantOK:      true,
+			wantRange:   "400000-66a1000",
+			wantMapping: "08:01:1443212",
+		},
+		{
 			name:   "non-executable mapping is skipped",
 			line:   "55a1b2c21000-55a1b2c25000 r--p 00021000 fd:01 1443212 /usr/lib/x86_64-linux-gnu/libssl.so.3",
 			wantOK: false,
@@ -72,6 +79,11 @@ func TestParseExecMapping(t *testing.T) {
 		{
 			name:   "no pathname field is skipped",
 			line:   "7ffff7fce000-7ffff7fd0000 r-xp 00000000 00:00 12345",
+			wantOK: false,
+		},
+		{
+			name:   "invalid address range is skipped",
+			line:   "not-hex r-xp 00000000 08:01 1443212 /usr/bin/node",
 			wantOK: false,
 		},
 	}


### PR DESCRIPTION
## What

- Canonicalize executable mapping ranges before opening `/proc/<pid>/map_files/<range>`.
- Add a regression test for zero-padded low addresses used by non-PIE executables.
- Require the existing real-client E2E to capture Node and npm across the GitHub-hosted and Blacksmith matrices.
- Record Node and npm HTTP/1.x coverage in the HTTP uprobe developer guide.

## Why

Official Node binaries map their executable at a low address. `/proc/<pid>/maps` can render that range with leading zeroes (for example, `00400000-066a1000`), while the corresponding `map_files` entry is named `400000-66a1000`. Discovery previously reused the raw `maps` text, so opening `map_files` raced into a deterministic `ENOENT` and never reached symbol attachment.

Parsing and reformatting both endpoints fixes the file lookup. Node and npm then use the existing `SSL_write` attachment and HTTP/1 parser; this PR adds no BPF program, event field, source value, or worker state.

Git over HTTPS remains separate: the tested Git helper uses GnuTLS for HTTP/1.x and commonly negotiates HTTP/2 through nghttp2, so this PR does not claim Git coverage.

Closes no stage by itself; contributes to cicd-sensor/cicd-sensor#136 client coverage verification.

## Validation

- `make check`
- `go test -mod=vendor -race ./internal/agent/kerneltracker/kernelio`
- `go vet -mod=vendor ./...`
- `staticcheck ./...`
- mdBook build
- Linux arm64 6.8 privileged E2E with official Node v22: Node HTTPS and npm ping both emitted the expected OpenSSL `http_request` paths