### PR TITLE
fix(docker): build arm64 images with arm64 binaries

### DIFF
--- a/Dockerfile.agent
+++ b/Dockerfile.agent
@@ -12,8 +12,8 @@ COPY vendor ./vendor
 COPY cmd ./cmd
 COPY internal ./internal
 
-ARG TARGETOS=linux
-ARG TARGETARCH=amd64
+ARG TARGETOS
+ARG TARGETARCH
 ARG VERSION=dev
 
 ENV CGO_ENABLED=0

--- a/Dockerfile.manager
+++ b/Dockerfile.manager
@@ -11,8 +11,8 @@ COPY vendor ./vendor
 COPY cmd ./cmd
 COPY internal ./internal
 
-ARG TARGETOS=linux
-ARG TARGETARCH=amd64
+ARG TARGETOS
+ARG TARGETARCH
 ARG VERSION=dev
 
 ENV CGO_ENABLED=0

--- a/Dockerfile.manager.lambda
+++ b/Dockerfile.manager.lambda
@@ -13,8 +13,8 @@ COPY vendor ./vendor
 COPY cmd ./cmd
 COPY internal ./internal
 
-ARG TARGETOS=linux
-ARG TARGETARCH=amd64
+ARG TARGETOS
+ARG TARGETARCH
 ARG VERSION=dev
 
 ENV CGO_ENABLED=0


### PR DESCRIPTION
Closes #170

`ARG TARGETARCH=amd64` overrides the per-platform value buildx injects,
so both sub-manifests were built with GOARCH=amd64 and shared the same
binary layer. Remove the defaults from all three Dockerfiles.

Verified locally: a multi-platform build of Dockerfile.manager now yields
distinct binary layers, with arm64 = `ELF ... ARM aarch64`.