### PR TITLE
test: simplify Go HTTP version coverage matrix

### DIFF
--- a/.github/workflows/blacksmith-bpf-integration.yaml
+++ b/.github/workflows/blacksmith-bpf-integration.yaml
@@ -78,25 +78,6 @@ jobs:
           CGO_ENABLED=1 go build -buildvcs=false -trimpath -buildmode=pie \
             -ldflags='-s -w -linkmode=external' \
             -o /tmp/go-http-cgo-client ./internal/agent/kerneltracker/testdata/go_http_client
-          versioned_clients=()
-          # Pin the minimum, pclntab layout boundaries, previous supported
-          # release, and latest stable Go release verified by this PR.
-          for version in 1.18.10 1.20.14 1.25.14 1.26.7 1.27.0; do
-            goroot="$(env -u GOROOT GOTOOLCHAIN="go${version}" go env GOROOT)"
-            output="/tmp/go-http-${version}"
-            env -u GOROOT GO111MODULE=off GOTOOLCHAIN=local CGO_ENABLED=0 "$goroot/bin/go" build \
-              -trimpath -ldflags='-s -w' \
-              -o "$output" ./internal/agent/kerneltracker/testdata/go_http_client
-            "$goroot/bin/go" version -m "$output" | grep -F "go${version}"
-            versioned_clients+=("go${version}-internal=${output}")
-            output="/tmp/go-http-cgo-${version}"
-            env -u GOROOT GO111MODULE=off GOTOOLCHAIN=local CGO_ENABLED=1 CC=cc "$goroot/bin/go" build \
-              -trimpath -buildmode=pie -ldflags='-s -w -linkmode=external' \
-              -o "$output" ./internal/agent/kerneltracker/testdata/go_http_client
-            "$goroot/bin/go" version -m "$output" | grep -F "go${version}"
-            versioned_clients+=("go${version}-external=${output}")
-          done
-          printf 'GO_HTTP_VERSIONED_TEST_CLIENTS=%s\n' "$(IFS=,; echo "${versioned_clients[*]}")" >> "$GITHUB_ENV"
 
       - name: Run HTTP client coverage test
         env:
@@ -105,9 +86,8 @@ jobs:
           sudo HTTP_UPROBE_EXPECTED_CLIENTS="$HTTP_UPROBE_EXPECTED_CLIENTS" \
             GO_HTTP_TEST_CLIENT=/tmp/go-http-client \
             GO_HTTP_CGO_TEST_CLIENT=/tmp/go-http-cgo-client \
-            GO_HTTP_VERSIONED_TEST_CLIENTS="$GO_HTTP_VERSIONED_TEST_CLIENTS" \
             /tmp/http-client-coverage.test \
             -test.v \
             -test.count=1 \
             -test.timeout=10m \
-            -test.run '^TestLinux(OpenSSLUprobeCoversCommonClients|Nghttp2UprobeCoversHTTP2Clients|GoNetHTTPUprobe(CapturesHTTPS|CapturesExternallyLinkedHTTPS|CoversGH|CoversSupportedGoVersions))$'
+            -test.run '^TestLinux(OpenSSLUprobeCoversCommonClients|Nghttp2UprobeCoversHTTP2Clients|GoNetHTTPUprobe(CapturesHTTPS|CapturesExternallyLinkedHTTPS|CoversGH))$'

--- a/.github/workflows/bpf-cross-kernel.yaml
+++ b/.github/workflows/bpf-cross-kernel.yaml
@@ -94,10 +94,47 @@ jobs:
           CGO_ENABLED=1 go build -buildvcs=false -trimpath -buildmode=pie \
             -ldflags='-s -w -linkmode=external' \
             -o /tmp/go-http-cgo-client ./internal/agent/kerneltracker/testdata/go_http_client
+
+      - name: Run HTTP client coverage test
+        env:
+          HTTP_UPROBE_EXPECTED_CLIENTS: ${{ matrix.expected }}
+        run: |
+          sudo HTTP_UPROBE_EXPECTED_CLIENTS="$HTTP_UPROBE_EXPECTED_CLIENTS" \
+            GO_HTTP_TEST_CLIENT=/tmp/go-http-client \
+            GO_HTTP_CGO_TEST_CLIENT=/tmp/go-http-cgo-client \
+            /tmp/http-client-coverage.test \
+            -test.v \
+            -test.count=1 \
+            -test.timeout=10m \
+            -test.run '^TestLinux(OpenSSLUprobeCoversCommonClients|Nghttp2UprobeCoversHTTP2Clients|GoNetHTTPUprobe(CapturesHTTPS|CapturesExternallyLinkedHTTPS|CoversGH))$'
+
+  go-http-version-coverage:
+    name: "Go HTTP versions on ${{ matrix.runner }}"
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        runner:
+          - ubuntu-24.04
+          - ubuntu-24.04-arm
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Setup Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Build Go version coverage
+        run: |
+          CGO_ENABLED=0 go test -mod=vendor -c -tags 'bpf_integration http_client_integration' \
+            -o /tmp/go-http-version-coverage.test ./internal/agent/kerneltracker
           versioned_clients=()
-          # Pin the minimum, pclntab layout boundaries, previous supported
-          # release, and latest stable Go release verified by this PR.
-          for version in 1.18.10 1.20.14 1.25.14 1.26.7 1.27.0; do
+          # Pin the supported minimum, pclntab layout boundaries, and latest release.
+          for version in 1.18.10 1.20.14 1.26.7 1.27.0; do
             goroot="$(env -u GOROOT GOTOOLCHAIN="go${version}" go env GOROOT)"
             output="/tmp/go-http-${version}"
             env -u GOROOT GO111MODULE=off GOTOOLCHAIN=local CGO_ENABLED=0 "$goroot/bin/go" build \
@@ -114,19 +151,14 @@ jobs:
           done
           printf 'GO_HTTP_VERSIONED_TEST_CLIENTS=%s\n' "$(IFS=,; echo "${versioned_clients[*]}")" >> "$GITHUB_ENV"
 
-      - name: Run HTTP client coverage test
-        env:
-          HTTP_UPROBE_EXPECTED_CLIENTS: ${{ matrix.expected }}
+      - name: Run Go version coverage
         run: |
-          sudo HTTP_UPROBE_EXPECTED_CLIENTS="$HTTP_UPROBE_EXPECTED_CLIENTS" \
-            GO_HTTP_TEST_CLIENT=/tmp/go-http-client \
-            GO_HTTP_CGO_TEST_CLIENT=/tmp/go-http-cgo-client \
-            GO_HTTP_VERSIONED_TEST_CLIENTS="$GO_HTTP_VERSIONED_TEST_CLIENTS" \
-            /tmp/http-client-coverage.test \
+          sudo GO_HTTP_VERSIONED_TEST_CLIENTS="$GO_HTTP_VERSIONED_TEST_CLIENTS" \
+            /tmp/go-http-version-coverage.test \
             -test.v \
             -test.count=1 \
             -test.timeout=10m \
-            -test.run '^TestLinux(OpenSSLUprobeCoversCommonClients|Nghttp2UprobeCoversHTTP2Clients|GoNetHTTPUprobe(CapturesHTTPS|CapturesExternallyLinkedHTTPS|CoversGH|CoversSupportedGoVersions))$'
+            -test.run '^TestLinuxGoNetHTTPUprobeCoversSupportedGoVersions$'
 
   kernel:
     name: "x64 kernel ${{ matrix.kernel.label }}"

--- a/docs/developer-guide/ebpf/go-http-uprobes.md
+++ b/docs/developer-guide/ebpf/go-http-uprobes.md
@@ -165,8 +165,9 @@ Unit tests build stripped non-PIE, PIE, and cgo externally linked PIE clients,
 resolve `Transport.roundTrip` through the profiler dependency, validate the ELF
 file-offset conversion, and verify the fixed Request/URL offsets. BPF
 integration tests exercise both `http.Client.Do` and direct
-`Transport.RoundTrip` over HTTP/1.1 and HTTP/2. They use stripped internally and
-externally linked fixtures built with Go 1.18.10, 1.20.14, 1.25.14, 1.26.7, and
-1.27.0, plus the real `gh` binary. The CI matrix runs these tests on amd64 and
-arm64. Fixture requests are repeated within one process because asynchronous
-attachment does not guarantee capture of a newly mapped file's first request.
+`Transport.RoundTrip` over HTTP/1.1 and HTTP/2. A dedicated Ubuntu 24.04 matrix
+uses stripped internally and externally linked fixtures built with Go 1.18.10,
+1.20.14, 1.26.7, and 1.27.0 on amd64 and arm64. Real-client coverage includes
+the `gh` binary. Fixture requests are repeated within one process because
+asynchronous attachment does not guarantee capture of a newly mapped file's
+first request.

--- a/internal/agent/kerneltracker/kernel_sample_go_http_integration_linux_test.go
+++ b/internal/agent/kerneltracker/kernel_sample_go_http_integration_linux_test.go
@@ -101,19 +101,17 @@ func TestLinuxGoNetHTTPUprobeCoversSupportedGoVersions(t *testing.T) {
 		if !found || version == "" || clientPath == "" {
 			t.Fatalf("invalid GO_HTTP_VERSIONED_TEST_CLIENTS entry %q", specification)
 		}
-		for _, clientMode := range []string{"client", "transport"} {
-			t.Run(version+"/"+clientMode, func(t *testing.T) {
-				path := "/go-version-" + version + "-" + clientMode
-				host := "go-" + version + "-" + clientMode + ".example"
-				runGoHTTPClientBurst(t, clientPath, clientMode, server.URL+path, host)
-				waitForEngineInput(t, kernelTracker.inputCh, 20*time.Second, "Go net/http request from "+version+" via "+clientMode,
-					func(in engineInput) bool {
-						sample, ok := in.(httpRequestSample)
-						return ok && sample.CgroupID == cgroupID && sample.Source == HTTPSourceGoNetHTTP &&
-							sample.Method == "GET" && sample.Path == path && sample.Host == host
-					})
-			})
-		}
+		t.Run(version, func(t *testing.T) {
+			path := "/go-version-" + version
+			host := "go-" + version + ".example"
+			runGoHTTPClientBurst(t, clientPath, "client", server.URL+path, host)
+			waitForEngineInput(t, kernelTracker.inputCh, 20*time.Second, "Go net/http request from "+version,
+				func(in engineInput) bool {
+					sample, ok := in.(httpRequestSample)
+					return ok && sample.CgroupID == cgroupID && sample.Source == HTTPSourceGoNetHTTP &&
+						sample.Method == "GET" && sample.Path == path && sample.Host == host
+				})
+		})
 	}
 }
 


### PR DESCRIPTION
## What

- Move multi-version Go HTTP uprobe coverage into a dedicated Ubuntu 24.04 amd64/arm64 job.
- Cover Go 1.18.10, 1.20.14, 1.26.7, and 1.27.0 with stripped internally and externally linked fixtures.
- Remove duplicate `client` and `transport` execution from the version matrix while retaining API-path coverage in the regular integration suite.
- Remove repeated multi-version fixture builds from the Blacksmith and per-distribution client matrices.

## Why

Go compatibility depends primarily on Go binary layout, link mode, and architecture rather than every distribution and kernel combination. A dedicated matrix preserves the meaningful compatibility boundaries while reducing repeated builds and BPF integration executions.