### PR TITLE
feat(agent): add HTTP request capture rollout flag

### DIFF
--- a/cmd/cicd-sensor/agent.go
+++ b/cmd/cicd-sensor/agent.go
@@ -35,6 +35,7 @@ type agentStartOptions struct {
 	GitHubK8sRunnerSocketPath string
 	ShutdownGrace             time.Duration
 	JobTTL                    time.Duration
+	EnableHTTPRequest         bool
 }
 
 func runAgentSubcommand(args []string) {
@@ -61,6 +62,7 @@ func runAgentStart(args []string) {
 	var githubK8sRunnerSocketPath string
 	var shutdownGrace time.Duration
 	var jobTTL time.Duration
+	var enableHTTPRequest bool
 	socketPath = defaultSocketPath
 	githubK8sRunnerSocketPath = os.Getenv("CICD_SENSOR_GITHUB_K8S_RUNNER_SOCKET")
 	fs.Usage = func() {
@@ -82,6 +84,8 @@ func runAgentStart(args []string) {
 		fmt.Fprintln(fs.Output(), "  --shutdown-grace DURATION")
 		fmt.Fprintln(fs.Output(), "        Best-effort drain window used after SIGTERM. (default 8s)")
 		fmt.Fprintf(fs.Output(), "  --job-ttl DURATION\n        Job age threshold after which the job is expired and forcibly finalized.\n        Expiry is checked about once per minute, so finalization may happen up to\n        about one minute after the TTL is reached. (default %s)\n", formatDuration(job.DefaultTTL))
+		fmt.Fprintln(fs.Output(), "  --enable-http-request=BOOL")
+		fmt.Fprintln(fs.Output(), "        Enable HTTP request capture. (default false)")
 	}
 	fs.StringVar(&socketPath, "socket", socketPath, "Agent control socket path.")
 	fs.StringVar(&githubK8sRunnerSocketPath, "github-k8s-runner-socket", githubK8sRunnerSocketPath, "GitHub Kubernetes runner socket path.")
@@ -91,6 +95,7 @@ func runAgentStart(args []string) {
 	fs.StringVar(&managerTokenFilePath, "manager-token-file", "", "Path to a file containing the host scope manager bearer token. Overrides CICD_SENSOR_MANAGER_TOKEN.")
 	fs.DurationVar(&shutdownGrace, "shutdown-grace", 8*time.Second, "Best-effort drain window used after SIGTERM. Must end before the supervisor's kill timeout (for example systemd TimeoutStopSec), or the drain is cut off mid-flight.")
 	fs.DurationVar(&jobTTL, "job-ttl", job.DefaultTTL, "Job age threshold after which the job is expired and forcibly finalized; expiry is checked about once per minute.")
+	fs.BoolVar(&enableHTTPRequest, "enable-http-request", false, "Enable HTTP request capture.")
 	if err := fs.Parse(args[1:]); err != nil {
 		os.Exit(2)
 	}
@@ -113,6 +118,7 @@ func runAgentStart(args []string) {
 		GitHubK8sRunnerSocketPath: githubK8sRunnerSocketPath,
 		ShutdownGrace:             shutdownGrace,
 		JobTTL:                    jobTTL,
+		EnableHTTPRequest:         enableHTTPRequest,
 	}
 	if err := validateAgentStartRequiredOptions(opts); err != nil {
 		fmt.Fprintln(os.Stderr, err)
@@ -166,6 +172,7 @@ func runAgentStart(args []string) {
 	a := agent.NewAgent(logger, opts.SocketPath, jobcontext.Provider(opts.Provider), opts.Runner, hostManager, hostManagerClient)
 	a.SetShutdownGrace(opts.ShutdownGrace)
 	a.SetJobTTL(opts.JobTTL)
+	a.SetHTTPRequestEnabled(opts.EnableHTTPRequest)
 	a.SetGitHubK8sRunnerSocketPath(opts.GitHubK8sRunnerSocketPath)
 	if err := a.Run(ctx); err != nil {
 		if errors.Is(err, listener.ErrAlreadyRunning) {

--- a/docs/developer-guide/ebpf-runtime.md
+++ b/docs/developer-guide/ebpf-runtime.md
@@ -69,21 +69,22 @@ The eBPF Runtime handles both rule-facing events and internal tracking samples.
 | file | `security_file_open`, `security_inode_unlink`, `security_inode_rename`, `security_inode_link` | `file_open`, `file_remove`, `file_move`, `file_link` |
 | mount | `security_sb_mount`, `security_move_mount` | `mount` for path exposure attempts |
 | domain | `udp_sendmsg`, `udpv6_sendmsg`, `tcp_sendmsg` | `domain` |
-| http | `tcp_sendmsg`; rollout-disabled `uprobe_mmap` discovery plus OpenSSL and nghttp2 uprobes | `http_request` |
+| http | rollout-disabled cleartext `tcp_sendmsg`; `uprobe_mmap` discovery plus OpenSSL, nghttp2, and Go uprobes | `http_request` |
 | unix socket | `unix_stream_connect`, `unix_dgram_connect` | `unix_socket_connect` |
 
 `cgroup/connect4/6` is not attached per tracked cgroup. The agent attaches once to the cgroup v2 root detected at startup, and the program uses `tracked_cgroups` lookup to handle only target jobs.
 
 `unix_stream_connect` / `unix_dgram_connect` observe AF_UNIX connects at the proto_ops entry points, so connects denied earlier by an LSM (AppArmor, SELinux, BPF LSM) are not observable.
 
-The `http_request` hook detects cleartext HTTP by content, not by port: a
+When `--enable-http-request=true`, the `http_request` hook detects cleartext
+HTTP by content, not by port: a
 send whose first bytes match a request-method token is parsed **in eBPF**
 (request line + `Host` only, query stripped at `?`), and only the parsed
 `method` / `path` / `host` fields leave the kernel — the raw send prefix
 stays in a per-CPU scratch map and never enters the ring buffer. TLS writes
 start with a record byte and never match a method token; KTLS plaintext sends
 are intercepted by the TLS ULP before `tcp_sendmsg` and do not reach the
-hook. The rollout-disabled OpenSSL path reads HTTP/1.x before encryption, while
+hook. The OpenSSL path reads HTTP/1.x before encryption, while
 the nghttp2 path reads HTTP/2 pseudo-headers before HPACK encoding. See
 [HTTP Uprobe Runtime](ebpf/http-uprobes.md) for the discovery rationale, attach
 and event lifecycle, selected functions, verified clients, and known gaps.

--- a/docs/developer-guide/ebpf/http-uprobes.md
+++ b/docs/developer-guide/ebpf/http-uprobes.md
@@ -5,9 +5,10 @@ how it discovers and attaches uprobes, how requests become events, and how
 attachments are reclaimed. Cleartext HTTP capture at `tcp_sendmsg` uses the same
 `http_request` event but does not use this discovery lifecycle.
 
-OpenSSL HTTP/1.x, nghttp2 HTTP/2, and Go `net/http` HTTPS capture are implemented.
-They remain disabled by default while first-request timing and environment
-compatibility are evaluated.
+Cleartext HTTP, OpenSSL HTTP/1.x, nghttp2 HTTP/2, and Go `net/http` HTTPS
+capture are implemented. All `http_request` sources remain disabled by default
+while first-request timing and environment compatibility are evaluated. Enable
+them together with `--enable-http-request=true`.
 
 ## Purpose and scope
 
@@ -310,8 +311,9 @@ x64 and arm64 unless noted otherwise.
 
 ## Operational status and known limits
 
-- HTTP uprobes are rollout-disabled in shipped builds. The internal switch is a
-  temporary rollout control, not a permanent user-facing opt-in.
+- `http_request` capture is disabled by default during rollout. The
+  `--enable-http-request` switch controls both the cleartext tap and the HTTP
+  uprobe runtime, and remains the disable path after default enablement.
 - Mapping notification precedes the selected function call, but ELF
   classification and attachment are asynchronous. The function can run before
   its uprobe is attached, so the initial request can be missed. This remains a

--- a/docs/user-guide/rule-event-types.md
+++ b/docs/user-guide/rule-event-types.md
@@ -492,13 +492,15 @@ Example event value:
 
 Evaluates the request line of an outgoing HTTP request: method, path, and host together.
 Only the request line and the `Host` header are captured — no other headers and no body.
+Capture is disabled by default during rollout. Enable the cleartext and
+uprobe-based sources together with `--enable-http-request=true`.
 
 | field | Type | Example value | Meaning |
 | --- | --- | --- | --- |
 | `method` | string | `get`, `post` | Request method. Lowercase; write the condition in either case. |
 | `path` | string | `/repos/cli/cli/releases` | Request path with the query string removed. Lowercase. |
 | `host` | string | `api.github.com`, `example.com:8080` | Request host (`Host` header). Lowercase; may include a port. |
-| `source` | string | `cleartext_http`, `openssl`, `nghttp2` | Capture channel; userspace-library taps are not yet enabled in shipped builds. |
+| `source` | string | `cleartext_http`, `openssl`, `nghttp2`, `go_net_http` | Capture channel. |
 | `process` | object | `process.exec_path == "/usr/bin/curl"` | Process that sent the request |
 
 `source` reports where the request line was read:
@@ -508,19 +510,19 @@ Only the request line and the `Host` header are captured — no other headers an
 - `openssl` — HTTPS **HTTP/1.x** read before encryption at OpenSSL's
   `SSL_write` / `SSL_write_ex`. Client coverage depends on which function the
   installed binary calls; see the developer guide's verified workload matrix.
-  This tap is **not yet enabled** in shipped builds; default enablement waits
-  for the remaining rollout gates (there is no separate opt-in).
 - `nghttp2` — HTTP/2 pseudo-headers read at `nghttp2_submit_request` or
   `nghttp2_submit_request2`, before HPACK encoding. This tap shares the same
   rollout state as `openssl`.
+- `go_net_http` — Go `net/http` request values read before protocol encoding.
+  Stripped Go binaries are resolved through their pclntab metadata.
 
 Known gaps (absence of an `http_request` event does **not** mean absence of
 egress — combine with `domain` and `network_connect` rules):
 
 - HTTP/2 clients that do not call a selected nghttp2 request function are not
   captured. HTTP/3/QUIC is also outside this event.
-- Go `crypto/tls`, Java JSSE, rustls, and other non-OpenSSL stacks are not
-  captured. A fully symbol-stripped static binary is not captured either.
+- Java JSSE, rustls, and other stacks without a selected capture point are not
+  captured.
 - Capture is best-effort against uncooperative code: a process can evade a
   uprobe, and the very first request of a brand-new process can beat the attach.
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -28,6 +28,7 @@ type Agent struct {
 	githubK8sRunnerSocketPath string
 	shutdownGrace             time.Duration
 	jobTTL                    time.Duration
+	enableHTTPRequest         bool
 	reaperCancel              context.CancelFunc
 	cancelEngine              context.CancelFunc
 	engineDone                <-chan error
@@ -71,6 +72,11 @@ func (a *Agent) SetJobTTL(ttl time.Duration) {
 	}
 }
 
+// SetHTTPRequestEnabled controls cleartext and userspace-library HTTP capture.
+func (a *Agent) SetHTTPRequestEnabled(enabled bool) {
+	a.enableHTTPRequest = enabled
+}
+
 // SetGitHubK8sRunnerSocketPath enables the GitHub Kubernetes runner socket.
 func (a *Agent) SetGitHubK8sRunnerSocketPath(path string) {
 	a.githubK8sRunnerSocketPath = path
@@ -102,7 +108,9 @@ func (a *Agent) Run(ctx context.Context) error {
 	jobRegistry := jobregistry.New(a.logger)
 	jobRegistry.SetJobTTL(a.jobTTL)
 
-	kernelTracker, err := kerneltracker.New(a.logger, jobRegistry)
+	kernelTracker, err := kerneltracker.NewWithConfig(a.logger, jobRegistry, kerneltracker.Config{
+		EnableHTTPRequest: a.enableHTTPRequest,
+	})
 	if err != nil {
 		return fmt.Errorf("new kernel tracker: %w", err)
 	}

--- a/internal/agent/kerneltracker/engine.go
+++ b/internal/agent/kerneltracker/engine.go
@@ -27,8 +27,18 @@ type KernelTracker struct {
 	jobTracking *jobTrackingState
 }
 
+// Config contains optional kernel runtime features owned by KernelTracker.
+type Config struct {
+	EnableHTTPRequest bool
+}
+
 // New builds the production KernelTracker and its KernelIO adapter.
 func New(logger *slog.Logger, jobEndNotifier JobEndNotifier) (*KernelTracker, error) {
+	return NewWithConfig(logger, jobEndNotifier, Config{})
+}
+
+// NewWithConfig builds the production KernelTracker with optional features.
+func NewWithConfig(logger *slog.Logger, jobEndNotifier JobEndNotifier, trackerConfig Config) (*KernelTracker, error) {
 	cgroupRoot, err := getCgroupV2Root()
 	if errors.Is(err, kernelio.ErrNotSupported) {
 		cgroupRoot = ""
@@ -38,7 +48,10 @@ func New(logger *slog.Logger, jobEndNotifier JobEndNotifier) (*KernelTracker, er
 
 	config := kernelio.Config{}
 	if cgroupRoot != "" {
-		config = kernelio.Config{CgroupV2RootPath: cgroupRoot}
+		config = kernelio.Config{
+			CgroupV2RootPath:  cgroupRoot,
+			EnableHTTPRequest: trackerConfig.EnableHTTPRequest,
+		}
 	}
 	kernelIO, err := kernelio.New(logger, config)
 	if err != nil {

--- a/internal/agent/kerneltracker/kernel_sample_go_http_integration_linux_test.go
+++ b/internal/agent/kerneltracker/kernel_sample_go_http_integration_linux_test.go
@@ -161,7 +161,7 @@ func startGoHTTPIntegrationRuntime(t *testing.T) (*KernelTracker, uint64) {
 	}
 	kernelIO, err := kernelio.NewLinux(nil, kernelio.Config{
 		CgroupV2RootPath:  cgroupRoot,
-		EnableHTTPUprobes: true,
+		EnableHTTPRequest: true,
 	})
 	if err != nil {
 		t.Fatalf("kernelio.NewLinux: %v", err)

--- a/internal/agent/kerneltracker/kernel_sample_http_integration_linux_test.go
+++ b/internal/agent/kerneltracker/kernel_sample_http_integration_linux_test.go
@@ -62,6 +62,21 @@ func TestLinuxKernelSampleHTTPRequestEmitsEvent(t *testing.T) {
 		})
 }
 
+func TestLinuxKernelSampleHTTPRequestDisabled(t *testing.T) {
+	f := newHTTPCaptureFixtureWithEnabled(t, false)
+	request := "GET /disabled HTTP/1.1\r\nHost: disabled.example\r\n\r\n"
+	if _, err := f.conn.Write([]byte(request)); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	if _, found := findEngineInput(f.inputCh, 250*time.Millisecond, func(in engineInput) bool {
+		sample, ok := in.(httpRequestSample)
+		return ok && sample.CgroupID == f.cgroupID && sample.Path == "/disabled"
+	}); found {
+		t.Fatal("http_request sample emitted while capture is disabled")
+	}
+}
+
 // TestLinuxKernelSampleHTTPRequestIgnoresNonHTTP asserts the content
 // pre-check: a TLS-record-like first byte on the same tracked socket path
 // must not produce an http_request sample. A subsequent valid request acts
@@ -119,8 +134,18 @@ func (f *httpCaptureFixture) dial(t *testing.T) net.Conn {
 }
 
 func newHTTPCaptureFixture(t *testing.T) *httpCaptureFixture {
+	return newHTTPCaptureFixtureWithEnabled(t, true)
+}
+
+func newHTTPCaptureFixtureWithEnabled(t *testing.T, enabled bool) *httpCaptureFixture {
 	t.Helper()
-	kernelIO, cgroupRoot := newLinuxKernelIO(t)
+	var kernelIO *kernelio.LinuxKernelIO
+	var cgroupRoot string
+	if enabled {
+		kernelIO, cgroupRoot = newLinuxHTTPRequestKernelIO(t)
+	} else {
+		kernelIO, cgroupRoot = newLinuxKernelIO(t)
+	}
 	t.Cleanup(func() { kernelIO.Close() })
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -429,7 +454,7 @@ func workerIDFromHost(host string) (int, bool) {
 // sample — the redaction invariant stated in http_helpers.bpf.h, checked end to
 // end.
 func TestLinuxKernelSampleHTTPRequestRawSampleCarriesNoRequestBytes(t *testing.T) {
-	kernelIO, cgroupRoot := newLinuxKernelIO(t)
+	kernelIO, cgroupRoot := newLinuxHTTPRequestKernelIO(t)
 	t.Cleanup(func() { kernelIO.Close() })
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/internal/agent/kerneltracker/kernel_sample_integration_helpers_linux_test.go
+++ b/internal/agent/kerneltracker/kernel_sample_integration_helpers_linux_test.go
@@ -66,13 +66,22 @@ func startTrackedKernelIO(t *testing.T) (uint64, *KernelTracker, func()) {
 }
 
 func newLinuxKernelIO(t *testing.T) (*kernelio.LinuxKernelIO, string) {
+	return newLinuxKernelIOWithHTTPRequest(t, false)
+}
+
+func newLinuxHTTPRequestKernelIO(t *testing.T) (*kernelio.LinuxKernelIO, string) {
+	return newLinuxKernelIOWithHTTPRequest(t, true)
+}
+
+func newLinuxKernelIOWithHTTPRequest(t *testing.T, enableHTTPRequest bool) (*kernelio.LinuxKernelIO, string) {
 	t.Helper()
 	cgroupRoot, err := getCgroupV2Root()
 	if err != nil {
 		t.Fatalf("getCgroupV2Root: %v", err)
 	}
 	kernelIO, err := kernelio.NewLinux(nil, kernelio.Config{
-		CgroupV2RootPath: cgroupRoot,
+		CgroupV2RootPath:  cgroupRoot,
+		EnableHTTPRequest: enableHTTPRequest,
 	})
 	if err != nil {
 		t.Fatalf("kernelio.NewLinux: %v", err)

--- a/internal/agent/kerneltracker/kernel_sample_tls_client_integration_linux_test.go
+++ b/internal/agent/kerneltracker/kernel_sample_tls_client_integration_linux_test.go
@@ -212,7 +212,7 @@ func testNghttp2ClientCoverage(
 	}
 	kernelIO, err := kernelio.NewLinux(nil, kernelio.Config{
 		CgroupV2RootPath:  cgroupRoot,
-		EnableHTTPUprobes: true,
+		EnableHTTPRequest: true,
 	})
 	if err != nil {
 		t.Fatalf("kernelio.NewLinux: %v", err)
@@ -286,7 +286,7 @@ func testOpenSSLClientCoverage(
 	}
 	kernelIO, err := kernelio.NewLinux(nil, kernelio.Config{
 		CgroupV2RootPath:  cgroupRoot,
-		EnableHTTPUprobes: true,
+		EnableHTTPRequest: true,
 	})
 	if err != nil {
 		t.Fatalf("kernelio.NewLinux: %v", err)

--- a/internal/agent/kerneltracker/kernel_sample_tls_integration_linux_test.go
+++ b/internal/agent/kerneltracker/kernel_sample_tls_integration_linux_test.go
@@ -161,6 +161,33 @@ with urllib.request.urlopen(sys.argv[1], context=context, timeout=10) as respons
 	}
 }
 
+func TestLinuxOpenSSLUprobeDisabled(t *testing.T) {
+	curl := requireBinary(t, "curl")
+	kernelIO, cgroupRoot := newLinuxKernelIO(t)
+	t.Cleanup(func() { _ = kernelIO.Close() })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	kernelTracker := newTestKernelTracker(nil, nil, noopKernelIO{}, cgroupRoot)
+	startKernelSampleLoop(t, ctx, kernelIO, kernelTracker)
+	cgroupID := trackTestProcessCgroup(t, ctx, kernelIO, cgroupRoot)
+
+	const path = "/disabled-openssl"
+	url := h1TLSServer(t) + path
+	for range 3 {
+		if output, err := exec.Command(curl, "-sk", "--http1.1", "--max-time", "3", url).CombinedOutput(); err != nil {
+			t.Fatalf("curl: %v: %s", err, output)
+		}
+	}
+
+	if _, found := findEngineInput(kernelTracker.inputCh, 500*time.Millisecond, func(in engineInput) bool {
+		sample, ok := in.(httpRequestSample)
+		return ok && sample.CgroupID == cgroupID && sample.Path == path
+	}); found {
+		t.Fatal("OpenSSL http_request sample emitted while capture is disabled")
+	}
+}
+
 // testOpenSSLUprobeCapturesHTTPS verifies mapping-triggered attach and capture
 // for real OpenSSL clients.
 func testOpenSSLUprobeCapturesHTTPS(t *testing.T, client, path string, clientArgs func(string) []string) {
@@ -172,7 +199,7 @@ func testOpenSSLUprobeCapturesHTTPS(t *testing.T, client, path string, clientArg
 	}
 	kernelIO, err := kernelio.NewLinux(nil, kernelio.Config{
 		CgroupV2RootPath:  cgroupRoot,
-		EnableHTTPUprobes: true,
+		EnableHTTPRequest: true,
 	})
 	if err != nil {
 		t.Fatalf("kernelio.NewLinux: %v", err)

--- a/internal/agent/kerneltracker/kernelio/http_uprobe_worker_integration_test.go
+++ b/internal/agent/kerneltracker/kernelio/http_uprobe_worker_integration_test.go
@@ -60,7 +60,7 @@ func processMapsLibssl(pid int32) bool {
 func newReclaimTestWorker(t *testing.T) *httpUprobeWorker {
 	t.Helper()
 	config := testLinuxConfig(t)
-	config.EnableHTTPUprobes = true
+	config.EnableHTTPRequest = true
 	kernelIO, err := NewLinux(nil, config)
 	if err != nil {
 		t.Fatalf("NewLinux: %v", err)

--- a/internal/agent/kerneltracker/kernelio/kernel_io.go
+++ b/internal/agent/kerneltracker/kernelio/kernel_io.go
@@ -10,13 +10,9 @@ var ErrNotSupported = errors.New("not supported")
 // Config contains the cgroup v2 root detected by KernelTracker.
 type Config struct {
 	CgroupV2RootPath string
-	// EnableHTTPUprobes starts the HTTP uprobe attach-discovery worker
-	// (mapping-triggered classification, attach, and maps-liveness reclaim). It does
-	// not gate BPF load: LoadAndAssign loads and verifies the programs at startup.
-	// Disabled instances shrink the HTTP-only BPF caches to placeholder entries.
-	// Keep this rollout switch off until the HTTP uprobe environment gates pass;
-	// it is not intended as a long-lived user-facing setting.
-	EnableHTTPUprobes bool
+	// EnableHTTPRequest enables cleartext capture and the HTTP uprobe runtime.
+	// It does not gate BPF load: LoadAndAssign verifies all programs at startup.
+	EnableHTTPRequest bool
 }
 
 // KernelIO is the BPF program/map/ringbuf I/O boundary. It stays as an

--- a/internal/agent/kerneltracker/kernelio/kernel_io_linux.go
+++ b/internal/agent/kerneltracker/kernelio/kernel_io_linux.go
@@ -33,6 +33,11 @@ type LinuxKernelIO struct {
 	httpUprobeWorker *httpUprobeWorker
 }
 
+type tracingProgram struct {
+	name    string
+	program *ebpf.Program
+}
+
 // NewLinux loads the BPF objects, attaches programs, and opens the sample ring buffer.
 func NewLinux(logger *slog.Logger, config Config) (kernelIO *LinuxKernelIO, err error) {
 	if logger == nil {
@@ -70,13 +75,13 @@ func NewLinux(logger *slog.Logger, config Config) (kernelIO *LinuxKernelIO, err 
 		_ = rollback.Close()
 	}()
 
-	// Only the HTTP entry program is attached to tcp_sendmsg. Install its parse
-	// target before attaching so the entry never tail-calls into an empty slot.
+	// HTTP parsing uses tail-call pipelines. Populate every target before an
+	// entry program can be attached. Do this regardless of the rollout setting:
+	// EnableHTTPRequest controls external hooks and worker startup, while the
+	// loaded BPF object always contains complete parse pipelines.
 	if err := kernelIO.objs.HttpStages.Put(uint32(0), kernelIO.objs.HandleTcpSendmsgHttpParse); err != nil {
 		return nil, fmt.Errorf("install http parse target: %w", err)
 	}
-	// Uprobe tail targets use a separate kprobe-type jump table. Install every
-	// target before discovery or tests can attach an entry program.
 	for index, program := range []*ebpf.Program{
 		kernelIO.objs.HandleSslWriteParse,
 		kernelIO.objs.HandleNghttp2Required,
@@ -88,31 +93,10 @@ func NewLinux(logger *slog.Logger, config Config) (kernelIO *LinuxKernelIO, err 
 			return nil, fmt.Errorf("install HTTP uprobe stage %d: %w", index, err)
 		}
 	}
-	if config.EnableHTTPRequest {
-		kernelIO.httpUprobeWorker = newHTTPUprobeWorker(
-			[]symbolUprobeTarget{
-				{symbol: "SSL_write", program: kernelIO.objs.HandleSslWrite},
-				{symbol: "SSL_write_ex", program: kernelIO.objs.HandleSslWrite},
-				{symbol: "nghttp2_submit_request", program: kernelIO.objs.HandleNghttp2SubmitRequest},
-				{symbol: "nghttp2_submit_request2", program: kernelIO.objs.HandleNghttp2SubmitRequest},
-			},
-			kernelIO.logger,
-			config.CgroupV2RootPath,
-			kernelIO.objs.HttpUprobeDiscoveryCache,
-			goUprobeTarget{
-				function: goNetHTTPRoundTripFunction,
-				program:  kernelIO.objs.HandleGoNetHttpRoundTrip,
-			},
-		)
-	}
 
 	// fentry/security_file_open is used instead of BPF LSM so deployments do
 	// not need lsm=..., Rename/symlink observation stays in inode hooks
 	// because security_path_* cannot use bpf_d_path in container filesystems.
-	type tracingProgram struct {
-		name    string
-		program *ebpf.Program
-	}
 	tracingPrograms := []tracingProgram{
 		{name: "sched_process_fork", program: kernelIO.objs.HandleSchedProcessFork},
 		{name: "sched_process_exec", program: kernelIO.objs.HandleSchedProcessExec},
@@ -135,22 +119,33 @@ func NewLinux(logger *slog.Logger, config Config) (kernelIO *LinuxKernelIO, err 
 		{name: "unix_dgram_connect", program: kernelIO.objs.HandleUnixDgramConnect},
 	}
 	if config.EnableHTTPRequest {
-		tracingPrograms = append(tracingPrograms, tracingProgram{
-			name:    "tcp_sendmsg_http",
-			program: kernelIO.objs.HandleTcpSendmsgHttp,
-		})
+		// One rollout switch enables both HTTP paths: cleartext parsing at
+		// tcp_sendmsg and mmap-triggered discovery for OpenSSL, nghttp2, and Go
+		// uprobes. The worker owns the links created by the discovery path.
+		tracingPrograms = append(tracingPrograms,
+			tracingProgram{name: "tcp_sendmsg_http", program: kernelIO.objs.HandleTcpSendmsgHttp},
+			tracingProgram{name: "uprobe_mmap", program: kernelIO.objs.HandleUprobeMmap},
+		)
+		kernelIO.httpUprobeWorker = newHTTPUprobeWorker(
+			[]symbolUprobeTarget{
+				{symbol: "SSL_write", program: kernelIO.objs.HandleSslWrite},
+				{symbol: "SSL_write_ex", program: kernelIO.objs.HandleSslWrite},
+				{symbol: "nghttp2_submit_request", program: kernelIO.objs.HandleNghttp2SubmitRequest},
+				{symbol: "nghttp2_submit_request2", program: kernelIO.objs.HandleNghttp2SubmitRequest},
+			},
+			kernelIO.logger,
+			config.CgroupV2RootPath,
+			kernelIO.objs.HttpUprobeDiscoveryCache,
+			goUprobeTarget{
+				function: goNetHTTPRoundTripFunction,
+				program:  kernelIO.objs.HandleGoNetHttpRoundTrip,
+			},
+		)
 	}
 	for _, attach := range tracingPrograms {
 		attached, err := link.AttachTracing(link.TracingOptions{Program: attach.program})
 		if err != nil {
 			return nil, fmt.Errorf("attach %s tracing program: %w", attach.name, err)
-		}
-		kernelIO.links = append(kernelIO.links, attached)
-	}
-	if config.EnableHTTPRequest {
-		attached, err := link.AttachTracing(link.TracingOptions{Program: kernelIO.objs.HandleUprobeMmap})
-		if err != nil {
-			return nil, fmt.Errorf("attach uprobe_mmap tracing program: %w", err)
 		}
 		kernelIO.links = append(kernelIO.links, attached)
 	}

--- a/internal/agent/kerneltracker/kernelio/kernel_io_linux.go
+++ b/internal/agent/kerneltracker/kernelio/kernel_io_linux.go
@@ -88,7 +88,7 @@ func NewLinux(logger *slog.Logger, config Config) (kernelIO *LinuxKernelIO, err 
 			return nil, fmt.Errorf("install HTTP uprobe stage %d: %w", index, err)
 		}
 	}
-	if config.EnableHTTPUprobes {
+	if config.EnableHTTPRequest {
 		kernelIO.httpUprobeWorker = newHTTPUprobeWorker(
 			[]symbolUprobeTarget{
 				{symbol: "SSL_write", program: kernelIO.objs.HandleSslWrite},
@@ -109,10 +109,11 @@ func NewLinux(logger *slog.Logger, config Config) (kernelIO *LinuxKernelIO, err 
 	// fentry/security_file_open is used instead of BPF LSM so deployments do
 	// not need lsm=..., Rename/symlink observation stays in inode hooks
 	// because security_path_* cannot use bpf_d_path in container filesystems.
-	for _, attach := range []struct {
+	type tracingProgram struct {
 		name    string
 		program *ebpf.Program
-	}{
+	}
+	tracingPrograms := []tracingProgram{
 		{name: "sched_process_fork", program: kernelIO.objs.HandleSchedProcessFork},
 		{name: "sched_process_exec", program: kernelIO.objs.HandleSchedProcessExec},
 		{name: "cgroup_mkdir", program: kernelIO.objs.HandleCgroupMkdir},
@@ -129,18 +130,24 @@ func NewLinux(logger *slog.Logger, config Config) (kernelIO *LinuxKernelIO, err 
 		{name: "udp_sendmsg", program: kernelIO.objs.HandleUdpSendmsg},
 		{name: "udpv6_sendmsg", program: kernelIO.objs.HandleUdpv6Sendmsg},
 		{name: "tcp_sendmsg", program: kernelIO.objs.HandleTcpSendmsg},
-		{name: "tcp_sendmsg_http", program: kernelIO.objs.HandleTcpSendmsgHttp},
 		{name: "unix_stream_sendmsg", program: kernelIO.objs.HandleUnixStreamSendmsg},
 		{name: "unix_stream_connect", program: kernelIO.objs.HandleUnixStreamConnect},
 		{name: "unix_dgram_connect", program: kernelIO.objs.HandleUnixDgramConnect},
-	} {
+	}
+	if config.EnableHTTPRequest {
+		tracingPrograms = append(tracingPrograms, tracingProgram{
+			name:    "tcp_sendmsg_http",
+			program: kernelIO.objs.HandleTcpSendmsgHttp,
+		})
+	}
+	for _, attach := range tracingPrograms {
 		attached, err := link.AttachTracing(link.TracingOptions{Program: attach.program})
 		if err != nil {
 			return nil, fmt.Errorf("attach %s tracing program: %w", attach.name, err)
 		}
 		kernelIO.links = append(kernelIO.links, attached)
 	}
-	if config.EnableHTTPUprobes {
+	if config.EnableHTTPRequest {
 		attached, err := link.AttachTracing(link.TracingOptions{Program: kernelIO.objs.HandleUprobeMmap})
 		if err != nil {
 			return nil, fmt.Errorf("attach uprobe_mmap tracing program: %w", err)


### PR DESCRIPTION
## Summary

- Add `--enable-http-request` as the single rollout switch for all `http_request` capture sources.
- Keep cleartext `tcp_sendmsg_http`, HTTP uprobe discovery, and OpenSSL, nghttp2, and Go capture disabled by default.
- Continue loading and verifying the BPF programs while capture is disabled, but do not attach the HTTP entry hooks or start the HTTP uprobe worker.
- Document the shared rollout control and the currently supported `http_request` sources.

## Why

HTTP request capture needs a rollout control while environment compatibility and first-request coverage continue to be evaluated. A single switch avoids partial configurations where cleartext capture is active while uprobe-based HTTPS capture is disabled, or vice versa.

The switch is expected to become enabled by default after rollout validation, while remaining available as an explicit disable path.

## Test plan

- `go vet ./...`
- `staticcheck ./...`
- `go test -race ./cmd/cicd-sensor ./internal/agent/...`
- `make test`
- `make rules-validate rules-bundle-validate`
- Linux 6.8 arm64 BPF integration: cleartext capture enabled and disabled
- Linux 6.8 arm64 BPF integration: OpenSSL capture enabled with curl and Python, and disabled
- Linux 6.8 arm64 BPF integration: Go `net/http` over HTTP/1.1 and HTTP/2
- Linux 6.8 arm64 BPF integration: nghttp2 coverage with curl, Node, and Git
- Linux amd64 `bpf_integration` test compilation