### PR TITLE
docs: add community-verified AKS node images to Kubernetes Preview

### DIFF
--- a/docs/user-guide/kubernetes/index.md
+++ b/docs/user-guide/kubernetes/index.md
@@ -63,8 +63,17 @@ test -S /var/run/nri/nri.sock
 ```
 
 GKE Standard with COS, containerd 2.x, and systemd cgroups has been verified.
+
+Community verified AKS node images (GitHub ARC Preview):
+
+| AKS node image | Runtime | Notes |
+| --- | --- | --- |
+| Ubuntu 24.04 | containerd 2.x, systemd | NRI present; default, kubernetes, and dind exercised |
+| Ubuntu 22.04 | containerd 1.7 | NRI off by default; default and dind OK; kubernetes-mode needs NRI enabled |
+| Azure Linux 3.0 | containerd 2.x, systemd | NRI present; default, kubernetes, and dind exercised |
+
 Managed Kubernetes environments that do not allow privileged node agents or required host mounts are not supported.
-This includes GKE Autopilot and managed container services outside Kubernetes, such as Amazon ECS.
+This includes GKE Autopilot, AKS Virtual Nodes / ACI, and managed container services outside Kubernetes, such as Amazon ECS.
 
 ## cicd-sensor components
 


### PR DESCRIPTION
## Summary

Document community-verified AKS node images next to the existing GKE Standard line in the Kubernetes Preview node requirements, so operators on Azure can see which images were actually exercised instead of guessing from GKE-only wording.

`docs/user-guide/kubernetes/index.md` now:

- Keeps the existing GKE Standard / COS / containerd 2.x / systemd verified line.
- Adds a community-verified AKS table for the three images tested with GitHub ARC Preview: Ubuntu 24.04 (containerd 2.x, NRI present; default, kubernetes, and dind), Ubuntu 22.04 (containerd 1.7, NRI off by default; default and dind OK; kubernetes-mode needs NRI enabled first), and Azure Linux 3.0 (containerd 2.x, NRI present; default, kubernetes, and dind).
- Mentions AKS Virtual Nodes / ACI in the not-supported list alongside GKE Autopilot and Amazon ECS.

This covers only those three AKS images on the cluster that was tested, not every AKS SKU. `github-arc.md` did not need a change.

Fixes #187

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / cleanup
- [x] Docs
- [ ] CI / tooling
- [ ] Other:

## Test plan

Community verification on AKS Kubernetes v1.35.7 with cicd-sensor v0.0.46 (Manager + node agent DaemonSet) and ARC gha-runner-scale-set 0.14.2. Node preflight, Manager + agent smoke, and real ARC Preview jobs were run on the three images below. Every PASS row included agent `github_k8s_start_accepted`.

- [x] Ubuntu 24.04 / containerd 2.x — NRI present; ARC Preview default, kubernetes, and dind PASS
- [x] Ubuntu 22.04 / containerd 1.7 — NRI off by default; default and dind PASS; kubernetes-mode blocked until NRI is enabled
- [x] Azure Linux 3.0 / containerd 2.x — NRI present; default, kubernetes, and dind PASS
- [x] Docs keep the GKE Standard / COS / containerd 2.x / systemd line and add AKS Virtual Nodes / ACI to the not-supported list
- [x] Wording is scoped to these community-verified images (Virtual Nodes / ACI were not enabled on the lab cluster)

## Checklist

- [x] `go test ./...` passes locally (Go sources were not touched; expected to remain clean)
- [x] `gofmt -l` and `go vet ./...` are clean (Go sources were not touched)
- [x] Docs and rule samples are updated if behavior changed (docs-only; Kubernetes Preview node matrix)
- [x] No secrets, credentials, or unrelated changes included

CI skips `docs/**` PRs via `paths-ignore`, so the lint/test workflow will not run on this change. Docs deploy is triggered on merge to `main`.